### PR TITLE
feat: made buttons in order history visible on mobile

### DIFF
--- a/packages/theme/pages/MyAccount/OrderHistory.vue
+++ b/packages/theme/pages/MyAccount/OrderHistory.vue
@@ -164,14 +164,14 @@
             </SfTableData>
             <SfTableData class="orders__view orders__element--right">
               <SfButton
-                class="sf-button--text desktop-only"
+                class="sf-button--text"
                 @click="setCurrentOrder(order)"
               >
                 {{ $t('OrderHistory.View details') }}
               </SfButton>
               <SfButton
                 :disabled="!orderGetters.isReturnable(order)"
-                class="sf-button--text desktop-only"
+                class="sf-button--text"
                 @click="setCurrentOrder(order), (returnOrder = true)"
               >
                 {{ $t('OrderHistory.Return items') }}

--- a/packages/theme/pages/MyAccount/OrderReturns.vue
+++ b/packages/theme/pages/MyAccount/OrderReturns.vue
@@ -116,7 +116,7 @@
             </SfTableData>
             <SfTableData class="orders__view orders__element--right">
               <SfButton
-                class="sf-button--text desktop-only"
+                class="sf-button--text"
                 @click="currentReturn = orderReturn"
               >
                 {{ $t('OrderHistory.View details') }}


### PR DESCRIPTION
## Why:
Buttons in order history and returns history were not all visible on mobile
Closes: 
[Task 63076](https://dev.azure.com/plentymarkets/plentymarkets/_workitems/edit/63076): View Details and Return items buttons are invisible on mobile
## Describe your changes
Made order history and return history visible on mobile as well
## Checklist before requesting a review
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
