### PR TITLE
feat: made button for cookie bar move to the footer on small screens

### DIFF
--- a/packages/composables/src/useCookieBar/index.ts
+++ b/packages/composables/src/useCookieBar/index.ts
@@ -1,4 +1,5 @@
 import { ref, onMounted } from '@nuxtjs/composition-api';
+import { sharedRef } from '@vue-storefront/core';
 import type {
   cookieGetter,
   appContext,
@@ -15,7 +16,7 @@ export const useCookieBar = (
   initCheckboxIndex: number,
   initialCookieJsonFromConfig: CookieGroupFromNuxtConfig
 ): cookieGetter => {
-  const bannerIsHidden = ref(false);
+  const bannerIsHidden = sharedRef('bannerIsHidden', false);
   const defaultCheckboxIndex = initCheckboxIndex;
   const cookieJsonFromConfig = initialCookieJsonFromConfig;
   const appCookies = appContext;

--- a/packages/composables/src/useCookieBar/index.ts
+++ b/packages/composables/src/useCookieBar/index.ts
@@ -16,7 +16,7 @@ export const useCookieBar = (
   initCheckboxIndex: number,
   initialCookieJsonFromConfig: CookieGroupFromNuxtConfig
 ): cookieGetter => {
-  const bannerIsHidden = sharedRef('bannerIsHidden', false);
+  const bannerIsHidden = sharedRef('useCookieBar-bannerIsHidden', false);
   const defaultCheckboxIndex = initCheckboxIndex;
   const cookieJsonFromConfig = initialCookieJsonFromConfig;
   const appCookies = appContext;

--- a/packages/theme/components/AppFooter.vue
+++ b/packages/theme/components/AppFooter.vue
@@ -34,7 +34,6 @@
             :label="$t('CookieBar.Privacy Settings')"
             @click="bannerIsHidden = false"
           />
-          A={{ bannerIsHidden }}
         </SfListItem>
       </SfList>
     </SfFooterColumn>

--- a/packages/theme/components/AppFooter.vue
+++ b/packages/theme/components/AppFooter.vue
@@ -29,6 +29,13 @@
             :link="localePath(legalPaths[item])"
           />
         </SfListItem>
+        <SfListItem class="xl:invisible">
+          <SfMenuItem
+            :label="$t('CookieBar.Privacy Settings')"
+            @click="bannerIsHidden = false"
+          />
+          A={{ bannerIsHidden }}
+        </SfListItem>
       </SfList>
     </SfFooterColumn>
   </SfFooter>
@@ -37,8 +44,8 @@
 <script>
 import { SfFooter, SfList, SfMenuItem } from '@storefront-ui/vue';
 import { addBasePath } from '@vue-storefront/core';
-import { computed, useRouter } from '@nuxtjs/composition-api';
-import { categoryTreeGetters, useCategory } from '@vue-storefront/plentymarkets';
+import { computed, useRouter, useContext } from '@nuxtjs/composition-api';
+import { categoryTreeGetters, useCategory, useCookieBar } from '@vue-storefront/plentymarkets';
 
 export default {
   components: {
@@ -50,12 +57,20 @@ export default {
     const router = useRouter();
     const { categories, loading } = useCategory('categories');
     const categoryTree = computed(() => loading && categories.value.map((cat) => categoryTreeGetters.getTree(cat)));
+    const { $config, app } = useContext();
+    const { bannerIsHidden } = useCookieBar(
+      app.$cookies,
+      'consent-cookie',
+      0,
+      $config.cookieGroups
+    );
 
     return {
       router,
       addBasePath,
       categoryTreeGetters,
-      categoryTree
+      categoryTree,
+      bannerIsHidden
     };
   },
   data() {

--- a/packages/theme/components/CookieBar.vue
+++ b/packages/theme/components/CookieBar.vue
@@ -194,7 +194,7 @@
     <button
       v-else
       v-e2e="'cookie-show-banner-button'"
-      class="color-sf-c-primary sf-button z-10 fixed bottom-sf-2xl xl:bottom-sf-xs xl:left-auto xl:right-sf-xs"
+      class="color-sf-c-primary sf-button z-10 fixed bottom-sf-2xl xl:bottom-sf-xs xl:left-auto xl:right-sf-xs invisible xl:visible"
       aria-label="Cookie control"
       @click="bannerIsHidden = false"
     >


### PR DESCRIPTION
## Why:
Moved the cookie bar button to the footer on small screens
Closes: 
[Task 62985](https://dev.azure.com/plentymarkets/plentymarkets/_workitems/edit/62985): Remove minimized Cookie-Bar Button and instead place link under legal section
## Describe your changes

## Checklist before requesting a review
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
