### PR TITLE
refactor: remove yarnrc from git index

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,0 @@
-nodeLinker: node-modules
-
-yarnPath: .yarn/releases/yarn-3.6.3.cjs

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ This project queries data from plentysystems by using other NPM packages as midd
 
 1. In the root directory, create a new file called `.yarnrc.yml`.
 2. Copy the contents of `.yarnrc.yml.example` to `.yarnrc.yml`.
-3. In `yarnrc.yml`, replace `<TOKEN>` with the Personal Access Token you created earlier.
+3. In `.yarnrc.yml`, replace `<TOKEN>` with the Personal Access Token you created earlier.
 
-Git doesn't track `yarnrc.yml`, so you don't have to worry about exposing your token.
+Git doesn't track `.yarnrc.yml`, so you don't have to worry about exposing your token.
 
 ### Starting the app
 


### PR DESCRIPTION
## Why:

The file is no longer needed for workflows. Removing it from the index and having it in the .gitignore improves security for access tokens.