### PR TITLE
fix: e2e workflow triggers

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -3,10 +3,6 @@ name: e2e-tests
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-  push:
-    branches:
-      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why:

Avoid running the e2e workflow when it's not necessary. This saves time and resources.

## Describe your changes

- No need to run the tests after merging into main when pull requests are mandatory.
- By removing the pull request trigger types, the workflow doesn't get run again when converting from draft to pull request.

## Checklist before requesting a review
- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.