### PR TITLE
fix: typedoc out path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,8 +50,8 @@ yarn-error.log*
 lib/
 
 # docs build
-apps/web/docs/composables/typedoc-sidebar.json
-apps/web/docs/composables/**/*.md
+apps/web/docs/reference/composables/typedoc-sidebar.json
+apps/web/docs/reference/**/*.md
 
 .vscode
 *.code-workspace

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -6,7 +6,7 @@
   "exclude": ["node_modules", "mocks", "__tests__", "cypress.config.ts"],
   "typedocOptions": {
       "entryPoints": ["composables/index.ts"],
-      "out": "docs/composables",
+      "out": "docs/reference/composables",
       "excludeExternals": true,
       "plugin": ["typedoc-plugin-markdown", "typedoc-vitepress-theme"],
       "githubPages": false


### PR DESCRIPTION
## Why:

Aligns the path with the paths in the SDK documentation. This is necessary for consistent routing on the docs site.

## Checklist before requesting a review
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.