### PR TITLE
docs: remove readme from typedoc output

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -9,6 +9,7 @@
       "out": "docs/reference/composables",
       "excludeExternals": true,
       "plugin": ["typedoc-plugin-markdown", "typedoc-vitepress-theme"],
-      "githubPages": false
+      "githubPages": false,
+      "readme": "none"
   }
 }


### PR DESCRIPTION
## Why:

Remove the repository's README from the output generated by TypeScript. Instead, the API overview will become the main entry point.

## Describe your changes

## Checklist before requesting a review
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
