### PR TITLE
fix: description not displayed on page reload

### DIFF
--- a/apps/web/components/BundleOrderItems/BundleOrderItems.vue
+++ b/apps/web/components/BundleOrderItems/BundleOrderItems.vue
@@ -24,7 +24,7 @@
           {{ productBundleGetters.getBundleItemQuantity(item) }}x
           <span class="px-1 h-">{{ productBundleGetters.getBundleItemName(item) }}</span>
         </p>
-        <p class="h-auto line-clamp-3" v-html="productBundleGetters.getBundleItemDescription(item)"></p>
+        <div class="h-auto line-clamp-3" v-html="productBundleGetters.getBundleItemDescription(item)"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
[AB#101852](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/101852)

ssr vhtml on p tag on working only on div