### PR TITLE
ci: disable docs based eslint rules

### DIFF
--- a/apps/web/.eslintrc.cjs
+++ b/apps/web/.eslintrc.cjs
@@ -7,19 +7,16 @@ module.exports = {
   },
   rules: {
     complexity: 0,
-    'vue/max-len': ['warn', {
-      code: 120,
-      ignoreStrings: true,
-      ignoreUrls: true,
-      ignoreTemplateLiterals: true,
-      ignoreHTMLAttributeValues: true
-    }],
     'max-lines-per-function': 'off',
-    'unicorn/no-keyword-prefix': ['error', { disallowedPrefixes: ['new', 'for'] }],
+    'max-statements': 'off',
+    'no-undef': 'off',
+    'etc/no-deprecated': 'off',
+    'etc/no-internal': 'off',
     'no-secrets/no-secrets': 'off',
+    'unicorn/filename-case': 'off',
+    'unicorn/no-keyword-prefix': ['error', { disallowedPrefixes: ['new', 'for'] }],
     'unicorn/prefer-array-some': 'off',
     'sonarjs/no-duplicate-string': 'off',
-    'max-statements': 'off',
     '@typescript-eslint/no-empty-function': ['error', { allow: ['arrowFunctions'] }],
     '@typescript-eslint/ban-ts-comment': 'off',
     'vue/component-tags-order': [
@@ -28,9 +25,14 @@ module.exports = {
         order: ['template', 'script', 'style'],
       },
     ],
+    'vue/max-len': ['warn', {
+      code: 120,
+      ignoreStrings: true,
+      ignoreUrls: true,
+      ignoreTemplateLiterals: true,
+      ignoreHTMLAttributeValues: true
+    }],
     'vue/multi-word-component-names': 'off',
-    'unicorn/filename-case': 'off',
-    'no-undef': 'off',
     'vue/no-setup-props-destructure': 'off',
     'vue/singleline-html-element-content-newline': 'off',
     'vue/max-attributes-per-line': 'off',


### PR DESCRIPTION
## Why:

These two rules take the longest to execute, but don't seem to provide us with any tangible benefit.

## Describe your changes

- Disable etc/no-deprecated
- Disable etc/no-internal
- Sort rules by name and extension

## Checklist before requesting a review

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
