### PR TITLE
refactor: nuxt config

### DIFF
--- a/apps/web/i18n.config.ts
+++ b/apps/web/i18n.config.ts
@@ -1,4 +1,6 @@
-export default defineI18nConfig(() => ({
+import type { NuxtI18nOptions } from '@nuxtjs/i18n';
+
+export default {
   fallbackLocale: 'en',
   detectBrowserLanguage: false,
   numberFormats: {
@@ -17,4 +19,20 @@ export default defineI18nConfig(() => ({
       },
     },
   },
-}));
+};
+
+export const nuxtI18nOptions: NuxtI18nOptions = {
+  locales: [
+    {
+      code: 'en',
+      file: 'en.json',
+    },
+    {
+      code: 'de',
+      file: 'de.json',
+    },
+  ],
+  langDir: 'lang',
+  defaultLocale: 'en',
+  strategy: 'prefix_and_default',
+};

--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -1,6 +1,7 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 import { validateApiUrl } from './utils/pathHelper';
 import cookieConfig from './cookie.config';
+import { nuxtI18nOptions } from './i18n.config';
 
 export default defineNuxtConfig({
   telemetry: false,
@@ -35,96 +36,6 @@ export default defineNuxtConfig({
     dirs: ['composables', 'composables/**', 'utils/**'],
   },
   css: ['~/assets/style.scss'],
-  image: {
-    screens: {
-      '4xl': 1920,
-      '3xl': 1536,
-      '2xl': 1366,
-      xl: 1280,
-      lg: 1024,
-      md: 768,
-      sm: 640,
-      xs: 376,
-      '2xs': 360,
-    },
-  },
-  modules: [
-    [
-      '@nuxtjs/google-fonts',
-      {
-        families: {
-          'Red Hat Display': { wght: [400, 500, 700] },
-          'Red Hat Text': { wght: [300, 400, 500, 700] },
-        },
-      },
-    ],
-    '@nuxtjs/turnstile',
-    '@nuxtjs/sitemap',
-    [
-      '@nuxtjs/tailwindcss',
-      {
-        configPath: '~/tailwind.config.ts',
-      },
-    ],
-    [
-      '@nuxtjs/i18n',
-      {
-        locales: [
-          {
-            code: 'en',
-            file: 'en.json',
-          },
-          {
-            code: 'de',
-            file: 'de.json',
-          },
-        ],
-        langDir: 'lang',
-        defaultLocale: 'en',
-        strategy: 'prefix_and_default',
-      },
-    ],
-    [
-      '@vee-validate/nuxt',
-      {
-        autoImports: true,
-        componentNames: {
-          Form: 'VeeForm',
-          Field: 'VeeField',
-          FieldArray: 'VeeFieldArray',
-          ErrorMessage: 'VeeErrorMessage',
-        },
-      },
-    ],
-    [
-      'nuxt-viewport',
-      {
-        breakpoints: {
-          sm: 640,
-          md: 640,
-          lg: 1024,
-        },
-        defaultBreakpoints: {
-          mobile: 'sm',
-          tablet: 'md',
-          desktop: 'lg',
-        },
-        fallbackBreakpoint: 'lg',
-        cookie: {
-          expires: 365,
-          name: 'plenty-viewport',
-          path: '/',
-          sameSite: 'Strict',
-          secure: true,
-        },
-      },
-    ],
-    '@nuxt/image',
-    '@vite-pwa/nuxt',
-    '@nuxt/test-utils/module',
-    'nuxt-lazy-hydrate',
-    'nuxt-svgo',
-  ],
   // eslint-disable-next-line unicorn/expiring-todo-comments
   // TODO: build is consistently failing because of this. check whether we need pre-render check.
   nitro: {
@@ -133,9 +44,6 @@ export default defineNuxtConfig({
     },
     compressPublicAssets: true,
   },
-  turnstile: {
-    siteKey: process.env?.CLOUDFLARE_TURNSTILE_SITE_KEY,
-  },
   routeRules: {
     '/_ipx/**': { headers: { 'cache-control': `public, max-age=31536000, immutable` } },
     '/icons/**': { headers: { 'cache-control': `public, max-age=31536000, immutable` } },
@@ -143,35 +51,6 @@ export default defineNuxtConfig({
   },
   site: {
     url: '',
-  },
-  sitemap: {
-    xslColumns: [
-      // URL column must always be set, no value needed
-      { label: 'URL', width: '75%' },
-      { label: 'Last Modified', select: 'sitemap:lastmod', width: '25%' },
-    ],
-    autoLastmod: true,
-    sitemaps: {
-      'sitemap/content': {
-        exclude: [
-          '/en/**', // default language
-          '/search',
-          '/offline',
-          '/my-account/**',
-          '/readonly-checkout',
-          '/set-new-password',
-          '/reset-password-success',
-          '/cart',
-          '/checkout',
-          '/thank-you',
-          '/wishlist',
-          '/login',
-          '/signup',
-          '/reset-password',
-        ],
-        includeAppSources: true,
-      },
-    },
   },
   hooks: {
     'pages:extend'(pages) {
@@ -195,6 +74,108 @@ export default defineNuxtConfig({
       useWebp: process.env?.USE_WEBP === '1' ?? false,
       validateReturnReasons: process.env.VALIDATE_RETURN_REASONS === '1' ?? false,
       enableQuickCheckoutTimer: process.env.ENABLE_QUICK_CHECKOUT_TIMER === '1' ?? false,
+    },
+  },
+  modules: [
+    '@nuxt/image',
+    '@nuxt/test-utils/module',
+    '@nuxtjs/google-fonts',
+    '@nuxtjs/i18n',
+    '@nuxtjs/sitemap',
+    '@nuxtjs/tailwindcss',
+    '@nuxtjs/turnstile',
+    'nuxt-lazy-hydrate',
+    'nuxt-svgo',
+    'nuxt-viewport',
+    '@vee-validate/nuxt',
+    '@vite-pwa/nuxt',
+  ],
+  image: {
+    screens: {
+      '4xl': 1920,
+      '3xl': 1536,
+      '2xl': 1366,
+      xl: 1280,
+      lg: 1024,
+      md: 768,
+      sm: 640,
+      xs: 376,
+      '2xs': 360,
+    },
+  },
+  googleFonts: {
+    families: {
+      'Red Hat Display': { wght: [400, 500, 700] },
+      'Red Hat Text': { wght: [300, 400, 500, 700] },
+    },
+  },
+  i18n: nuxtI18nOptions,
+  sitemap: {
+    xslColumns: [
+      // URL column must always be set, no value needed
+      { label: 'URL', width: '75%' },
+      { label: 'Last Modified', select: 'sitemap:lastmod', width: '25%' },
+    ],
+    autoLastmod: true,
+    sitemaps: {
+      'sitemap/content': {
+        exclude: [
+          `/${nuxtI18nOptions.defaultLocale}/**`,
+          '/search',
+          '/offline',
+          '/my-account/**',
+          '/readonly-checkout',
+          '/set-new-password',
+          '/reset-password-success',
+          '/cart',
+          '/checkout',
+          '/thank-you',
+          '/wishlist',
+          '/login',
+          '/signup',
+          '/reset-password',
+        ],
+        includeAppSources: true,
+      },
+    },
+  },
+  tailwindcss: {
+    configPath: '~/tailwind.config.ts',
+  },
+  turnstile: {
+    siteKey: process.env?.CLOUDFLARE_TURNSTILE_SITE_KEY,
+  },
+  svgo: {
+    global: false,
+    componentPrefix: 'plenty',
+  },
+  viewport: {
+    breakpoints: {
+      sm: 640,
+      md: 640,
+      lg: 1024,
+    },
+    defaultBreakpoints: {
+      mobile: 'sm',
+      tablet: 'md',
+      desktop: 'lg',
+    },
+    fallbackBreakpoint: 'lg',
+    cookie: {
+      expires: 365,
+      name: 'plenty-viewport',
+      path: '/',
+      sameSite: 'Strict',
+      secure: true,
+    },
+  },
+  veeValidate: {
+    autoImports: true,
+    componentNames: {
+      Form: 'VeeForm',
+      Field: 'VeeField',
+      FieldArray: 'VeeFieldArray',
+      ErrorMessage: 'VeeErrorMessage',
     },
   },
   pwa: {
@@ -248,9 +229,5 @@ export default defineNuxtConfig({
       ],
     },
     registerWebManifestInRouteRules: true,
-  },
-  svgo: {
-    global: false,
-    componentPrefix: 'plenty',
   },
 });


### PR DESCRIPTION
## Why:

Clean-up

## Describe your changes

- Extracts Nuxt i18n config to i18n config file, so that all i18n configs are in one place
- Standardizes module configurations in general to always use the config key
- Update sitemap to respond to default locale changes from i18n config

## Checklist before requesting a review

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
