### PR TITLE
fix: short description empty

### DIFF
--- a/docs/changelog/changelog_en.md
+++ b/docs/changelog/changelog_en.md
@@ -27,6 +27,7 @@
 - Registration without cloudflare turnstile configuration is now possible.
 - Fixed item image size in recommended product slider.
 - The wishlist button is now toggling between filled/empty heart icon
+- Changed shortDescription to return empty string
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lhci:mobile": "lhci autorun"
   },
   "dependencies": {
-    "@plentymarkets/shop-api": "^0.38.0",
+    "@plentymarkets/shop-api": "^0.38.1",
     "@vee-validate/nuxt": "^4.12.8",
     "@vee-validate/yup": "^4.12.8",
     "country-flag-icons": "^1.5.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4335,7 +4335,7 @@ __metadata:
     "@lhci/cli": ^0.13.0
     "@nuxtjs/turnstile": ^0.8.0
     "@paypal/paypal-js": 7.1.1
-    "@plentymarkets/shop-api": ^0.38.0
+    "@plentymarkets/shop-api": ^0.38.1
     "@trivago/prettier-plugin-sort-imports": ^4.3.0
     "@types/uuid": ^9.0.8
     "@vee-validate/nuxt": ^4.12.8
@@ -4363,14 +4363,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@plentymarkets/shop-api@npm:^0.38.0":
-  version: 0.38.0
-  resolution: "@plentymarkets/shop-api@npm:0.38.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40plentymarkets%2Fshop-api%2F0.38.0%2Ff27e5c93a108464546e3a995f7e8805746391a46"
+"@plentymarkets/shop-api@npm:^0.38.1":
+  version: 0.38.1
+  resolution: "@plentymarkets/shop-api@npm:0.38.1::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40plentymarkets%2Fshop-api%2F0.38.1%2Ff89db7e318637fdfb4e719a613029cd7fd3f4d20"
   dependencies:
     "@vue-storefront/middleware": ^3.10.0
     axios: ^1.6.3
     consola: ^3.0.0
-  checksum: 1cf9e0c06fc104e3d2f06d8e4deeb6c62816f71ccba4aac302048dcf69d6a13f00437529d3d1487a81a15c614756ef9ec62dd4030193d0d45031d01a82d383b6
+  checksum: 34cc137bb876b6e0abc400c4efb14d524fcedeb7bd402401156a6c7c93dc7b277084d97a9bb8a8e0c7fc780924519afa3c2e90b7453bc91f2d2025e44eca4caa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Fixed short description to empty string
- Changed version of shop-api from 0.38.0 to 0.38.1