### PR TITLE
ci: fix release token

### DIFF
--- a/.github/workflows/release-new-app.yml
+++ b/.github/workflows/release-new-app.yml
@@ -3,11 +3,6 @@ name: New release app
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      tag-version:
-        description: 'The tag version, branch name or SHA to checkout'
-        required: true
 
 jobs:
   create-archive:
@@ -16,7 +11,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }} || ${{ inputs.tag-version }}
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Compress repo to Tar
         uses: a7ul/tar-action@v1.1.0
@@ -33,6 +28,5 @@ jobs:
         uses: JantHsueh/upload-file-action@1.0
         with:
           url: "https://pwapublish.plentysystems.com/storeDefaultApplication"
-          forms: '{ "token": "${{ secrets.URL_ENDPOINT_TOKEN }}" }'
+          forms: '{ "token": "${{ secrets.SUPPLIER_TOKEN }}" }'
           fileForms: '{ "file": "pwa.tar.gz" }'
-

--- a/docs/changelog/changelog_de.md
+++ b/docs/changelog/changelog_de.md
@@ -25,6 +25,7 @@
 - Registration ohne Cloudflare Turnstile-Konfiguration ist jetzt möglich.
 - Bei Verwendung der Anmeldung über den Header erfolgte keine Weiterleitung, während man sich auf der Gast-Anmeldeseite befand
 - Die Umgebungsvariable zum Laden der Systemeinstellungen wird jetzt in der aktualisierten `.env`-Datei korrekt übernommen.
+- Im Workflow zum Veröffentlichen der App wird jetzt ein Lieferanten-Token verwendet.
 
 ### Geändert
 

--- a/docs/changelog/changelog_en.md
+++ b/docs/changelog/changelog_en.md
@@ -44,6 +44,7 @@
 - Fixed language selector on mobile
 - Fixed the scroll for reviews on mobile
 - The environment variable for fetching the system configuration from remote now gets correctly written to the updated `.env` file
+- The token in the release workflow now uses a supplier secret.
 
 ### 👷 Changed
 


### PR DESCRIPTION
## Why:

Closes: [AB#117339](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/117339)

## Describe your changes

- Uses supplier token for authentication when uploading to store.

## Checklist before requesting a review

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
