### PR TITLE
fix(docs-composables): side navigation links

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,7 @@
     "docs:dev": "yarn publish-typedoc && vitepress dev docs",
     "docs:build": "yarn publish-typedoc && vitepress build docs",
     "docs:preview": "vitepress preview docs",
-    "publish-typedoc": "yarn typedoc",
+    "publish-typedoc": "yarn typedoc && mkdir -p docs/reference && mv reference/composables/ docs/reference",
     "lint": "eslint --ext .vue,.js,.ts .",
     "lint:fix": "eslint --ext .vue,.js,.ts . --fix",
     "preview": "nuxt preview",

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -7,7 +7,7 @@
   "exclude": ["node_modules", "mocks", "__tests__", "cypress.config.ts"],
   "typedocOptions": {
     "entryPoints": ["composables/index.ts"],
-    "out": "docs/reference/composables",
+    "out": "reference/composables",
     "excludeExternals": true,
     "plugin": ["typedoc-plugin-markdown", "typedoc-vitepress-theme"],
     "githubPages": false,

--- a/docs/changelog/changelog_de.md
+++ b/docs/changelog/changelog_de.md
@@ -33,6 +33,7 @@
 - Ein Fehler beim REST-Aufruf zur Abfrage der Systemkonfiguration wurde behoben.
 - Die Schaltflächen bei den Adressen in der Kasse wurden in der mobilen Ansicht angepasst.
 - Problem behoben, bei dem die Navigationsleiste zwischen 640px und 767px verschwunden ist.
+- In der automatisch generierten Dokumentation von Composables enthält die Seitennavigation jetzt die richtigen Verlinkungen.
 
 ## v1.5.0 (2024-07-19) <a href="https://github.com/plentymarkets/plentyshop-pwa/compare/v1.4.1...v1.5.0" target="_blank" rel="noopener"><b>Übersicht aller Änderungen</b></a>
 

--- a/docs/changelog/changelog_en.md
+++ b/docs/changelog/changelog_en.md
@@ -35,6 +35,7 @@
 - Fixed pagination issues with reactivity.
 - Fixed wrongful display of base prices issue.
 - Fixed setting the vsf-locale cookie on ssr.
+- The side navigation of the automatically generated composables documentation now contains the correct links.
 
 ### 👷 Changed
 


### PR DESCRIPTION
## Why:

Closes: [AB#121797](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/121797)

## Describe your changes

- Fixes the automatically generated links in the side navigation.
- The link structure is now identical to the one used for the shop API documentation.

## Checklist before requesting a review

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
