### PR TITLE
fix: only show express button if the item is salable

### DIFF
--- a/apps/web/components/ui/PurchaseCard/PurchaseCard.vue
+++ b/apps/web/components/ui/PurchaseCard/PurchaseCard.vue
@@ -119,7 +119,7 @@
       <Suspense>
         <template #default>
           <PayPalExpressButton
-            v-if="getCombination()"
+            v-if="getCombination() && productGetters.isSalable(product)"
             class="mt-4"
             type="SingleItem"
             @on-click="paypalHandleAddToCart"

--- a/docs/changelog/changelog_en.md
+++ b/docs/changelog/changelog_en.md
@@ -45,6 +45,7 @@
 - The side navigation of the automatically generated composables documentation now contains the correct links.
 - Fixed editing author name on reviews and replies with added e2e
 - Fixed the issue with the plentyID-cookie in the PWA live preview
+- Fixed that the PayPal Express button on the product page is only displayed if the item is available for purchase.
 
 ### 👷 Changed
 


### PR DESCRIPTION
## Why:

Closes: [AB#124176](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/124176)

## Describe your changes

## Checklist before requesting a review

- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
