### PR TITLE
docs: remove explicit return type

### DIFF
--- a/apps/web/composables/usePayPal/usePayPal.ts
+++ b/apps/web/composables/usePayPal/usePayPal.ts
@@ -43,7 +43,6 @@ export const usePayPal = () => {
 
   /**
    * @description Function to get the PayPal config.
-   * @return Promise<boolean>
    * @example
    * ``` ts
    * loadConfig();


### PR DESCRIPTION
## Why:

TypeDoc generates a description for the return type here. The output doesn't get formatted properly, leading to errors when generating the documentation site.

## Describe your changes

- Fixes TypeDoc Markdown output

## Checklist before requesting a review

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
