### PR TITLE
fix: typography in headlines

### DIFF
--- a/apps/web/configuration/tailwind.config.ts
+++ b/apps/web/configuration/tailwind.config.ts
@@ -16,6 +16,24 @@ export default {
         'display-2': {
           fontFamily: 'inherit',
         },
+        'headline-1': {
+          fontFamily: 'inherit',
+        },
+        'headline-2': {
+          fontFamily: 'inherit',
+        },
+        'headline-3': {
+          fontFamily: 'inherit',
+        },
+        'headline-4': {
+          fontFamily: 'inherit',
+        },
+        'headline-5': {
+          fontFamily: 'inherit',
+        },
+        'headline-6': {
+          fontFamily: 'inherit',
+        },
       }),
       fontFamily: {
         body: [`${fontFamilyText}`, ...defaultTheme.fontFamily.sans],

--- a/docs/changelog/changelog_en.md
+++ b/docs/changelog/changelog_en.md
@@ -17,6 +17,7 @@
 - Automatically generate a language file for every active language, not just the default language.
 - Soft login was still shown after successfully authenticating on the order confirmation page.
 - Fixed an issue where manufacturer data was introducing 'name' into structured data instead of 'externalName'.
+- Headlines now use the configured font.
 
 ### 👷 Changed
 


### PR DESCRIPTION
## Why:

Headlines use a generic fallback (Inter Sans Serif)

## Describe your changes

- Updates Tailwind configuration

## Checklist before requesting a review

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
