### PR TITLE
fix(build): add api url to environment map

### DIFF
--- a/apps/web/build/configurator/AppConfigurator.ts
+++ b/apps/web/build/configurator/AppConfigurator.ts
@@ -16,6 +16,7 @@ dotenv.config({
 export class AppConfigurator {
   private environmentMap = {
     FETCH_REMOTE_CONFIG: process.env.FETCH_REMOTE_CONFIG,
+    API_URL: process.env.API_URL,
     API_ENDPOINT: process.env.API_ENDPOINT,
     API_SECURITY_TOKEN: process.env.API_SECURITY_TOKEN,
     CONFIG_ID: process.env.CONFIG_ID,

--- a/apps/web/build/configurator/__tests__/AppConfigurator.spec.ts
+++ b/apps/web/build/configurator/__tests__/AppConfigurator.spec.ts
@@ -66,6 +66,7 @@ $color-2-secondary-900: 2 1 55;
         beforeEach(() => {
             vi.resetModules();
             process.env.FETCH_REMOTE_CONFIG = 'true';
+            process.env.API_URL = 'https://api.example.com'
             process.env.API_ENDPOINT = 'https://api.example.com';
             process.env.API_SECURITY_TOKEN = 'securetoken';
             process.env.CONFIG_ID = '1';
@@ -73,6 +74,7 @@ $color-2-secondary-900: 2 1 55;
         
         afterEach(() => {
             delete process.env.FETCH_REMOTE_CONFIG;
+            delete process.env.API_URL;
             delete process.env.API_ENDPOINT;
             delete process.env.API_SECURITY_TOKEN;
             delete process.env.CONFIG_ID;
@@ -109,6 +111,7 @@ $color-2-secondary-900: 2 1 55;
             
             const EXPECTED = 
 `FETCH_REMOTE_CONFIG=true
+API_URL=https://api.example.com
 API_ENDPOINT=https://api.example.com
 API_SECURITY_TOKEN=securetoken
 CONFIG_ID=1

--- a/docs/changelog/changelog_en.md
+++ b/docs/changelog/changelog_en.md
@@ -32,6 +32,7 @@
 - Headlines now use the configured font.
 - Fixed layout shift on category page.
 - The build script failed on Windows because of incompatibilities between file name pattern and operating system. The file name pattern now works on Windows.
+- The build script now adds the `API_URL` to the environment if it exists.
 
 ### 👷 Changed
 


### PR DESCRIPTION
## Why:

When fetching the configuration from the server, the build script didn't write the `API_URL` to the environment, causing REST calls to run against the wrong endpoint.

## Describe your changes

- Adds `API_URL` to environment map

## Checklist before requesting a review

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
