### PR TITLE
fix: ssr for multilingual homepage

### DIFF
--- a/apps/web/composables/useInitialSetup/useInitialSetup.ts
+++ b/apps/web/composables/useInitialSetup/useInitialSetup.ts
@@ -43,14 +43,11 @@ const setInitialDataSSR: SetInitialData = async () => {
   const { setCategoryTree } = useCategoryTree();
   const { setCart, loading: cartLoading } = useCart();
   const { setWishlistItemIds } = useWishlist();
-  const { fetchCategoryTemplate } = useCategoryTemplate();
-  const runtimeConfig = useRuntimeConfig();
 
   cartLoading.value = true;
 
   try {
     const { data } = await useAsyncData(() => useSdk().plentysystems.getInit());
-    await fetchCategoryTemplate(runtimeConfig.public.homepageCategoryId);
     if (data.value?.data) {
       setUser(data.value.data.session as SessionResult);
       setCart(data.value.data.session?.basket as Cart);

--- a/apps/web/pages/index.vue
+++ b/apps/web/pages/index.vue
@@ -37,8 +37,12 @@
 
 <script lang="ts" setup>
 const { isEditing } = useEditor();
+const { fetchCategoryTemplate } = useCategoryTemplate();
 const { data: homepage, fetchPageTemplate } = useHomepage();
 const { showNewsletter } = useNewsletter();
 
+const runtimeConfig = useRuntimeConfig();
+
+await fetchCategoryTemplate(runtimeConfig.public.homepageCategoryId);
 fetchPageTemplate();
 </script>

--- a/docs/changelog/changelog_en.md
+++ b/docs/changelog/changelog_en.md
@@ -65,6 +65,7 @@ Each client supports two PWA instances. With this change, you can designate the 
 - The language selector is no longer displayed if only one language is configured.
 - Fixed an issue with category product prices not being updated on page change.
 - Added SSR rendering for homepage.
+- Fixed SSR rendering for homepage when switching language.
 - CSS for the Swiper library is now only loaded on pages that use the `HeroCarousel` component.
 - The `HeroCarousel` no longer overlaps the navigation menu on mobile devices.
 - Improved CLS for hero skeleton.


### PR DESCRIPTION
## Why:

When fetching the homepage template from the system, switching the language didn't update the template.

## Describe your changes

- Moves template call from SSR init to homepage.

## Checklist before requesting a review

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
