### PR TITLE
fix: text alignment in media card

### DIFF
--- a/apps/web/components/ui/MediaCard/MediaCard.vue
+++ b/apps/web/components/ui/MediaCard/MediaCard.vue
@@ -4,11 +4,7 @@
       <img :src="image" :alt="alt" width="728" height="485" class="w-full h-auto object-cover" />
     </div>
 
-    <div
-      v-if="text && text.trim() !== ''"
-      :class="['w-full no-preflight', textWidthClass, textAlignmentClass]"
-      v-html="text"
-    ></div>
+    <div v-if="text && text.trim() !== ''" :class="['w-full no-preflight', textWidthClass]" v-html="text"></div>
   </div>
 </template>
 
@@ -40,6 +36,6 @@ const showComponent = computed(() => {
 const textWidthClass = computed(() => {
   return !props.image || props.image.trim() === '' ? 'w-full' : 'md:w-1/2';
 });
+
 const positionClass = computed(() => (props.alignment === 'right' ? 'md:flex-row-reverse' : 'md:flex-row'));
-const textAlignmentClass = computed(() => (!props.image || props.image.trim() === '' ? 'text-center' : ''));
 </script>

--- a/docs/changelog/changelog_en.md
+++ b/docs/changelog/changelog_en.md
@@ -13,6 +13,7 @@
 - Changed brand mentions to PlentyONE and changed logo.
 - Fix for max visible pages on mobile pagination.
 - Fix for editor language picker when it showed inverted data template.
+- When the media card only displays text, the text block is now left aligned instead of centered.
 
 ## v1.8.0 (2024-12-13) <a href="https://github.com/plentymarkets/plentyshop-pwa/compare/v1.7.0...v1.8.0" target="_blank" rel="noopener"><b>Overview of all changes</b></a>
 


### PR DESCRIPTION
## Why:

Closes: [AB#141620](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/141620)

## Describe your changes

- Changes text alignment of the media card's text block to always be left-aligned, no matter whether the user provides an image or not.

## Checklist before requesting a review

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
