### PR TITLE
fix: missing aria label for reset filters

### DIFF
--- a/apps/web/components/CategoryFilters/Filter.vue
+++ b/apps/web/components/CategoryFilters/Filter.vue
@@ -60,7 +60,7 @@
           </template>
           {{ $t('apply') }}
         </UiButton>
-        <UiButton type="reset" @click="resetPriceFilter" class="h-10" variant="secondary">
+        <UiButton type="reset" @click="resetPriceFilter" class="h-10" variant="secondary" :aria-label="$t('clear')">
           <SfIconClose />
         </UiButton>
       </div>

--- a/docs/changelog/changelog_en.md
+++ b/docs/changelog/changelog_en.md
@@ -8,6 +8,7 @@
 
 ### 🩹 Fixed
 
+- Fixed accesibility error caused by missing label on clear filters.
 - Fixed same text in alt and title warning in category page.
 - Replaced favicon with PlentyONE favicon.
 - Added margin for graduated prices.


### PR DESCRIPTION
[AB#142181](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/142181)