### PR TITLE
refactor: eslint no unused expressions

### DIFF
--- a/apps/web/__tests__/support/pageObjects/CategoryObject.ts
+++ b/apps/web/__tests__/support/pageObjects/CategoryObject.ts
@@ -1,10 +1,14 @@
 import { PageObject } from "./PageObject";
 
 export class CategoryPageObject extends PageObject {
-  get filterClickShouldReloadCategory() {
+  get categoryFilter() {
+    return cy.getByTestId('category-filter-0');
+  }
+
+  filterClickShouldReloadCategory = () => {
     cy.intercept('/plentysystems/getFacet').as('getFacet');
-    cy.getByTestId('category-filter-0').first().click();
+    
+    this.categoryFilter.first().click();
     cy.wait('@getFacet').its('response.statusCode').should('eq', 200)
-    return this;
   }
 }

--- a/apps/web/__tests__/test/smoke/categoryPage.cy.ts
+++ b/apps/web/__tests__/test/smoke/categoryPage.cy.ts
@@ -14,7 +14,7 @@ describe('Smoke: Category Page', () => {
     // This way we are independet from the language and the url.
     cy.visitAndHydrate('/living-room');
 
-    category.filterClickShouldReloadCategory;
+    category.filterClickShouldReloadCategory();
   })
 
   it('[smoke] Category should load DE SSR on first visit where there are no browser cookies', () => {

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -46,7 +46,7 @@ export default withNuxt(
       '@typescript-eslint/no-invalid-void-type': 'off',
       '@typescript-eslint/no-namespace': 'off',
       '@typescript-eslint/no-require-imports': 'off',
-      '@typescript-eslint/no-unused-expressions': 'off',
+      '@typescript-eslint/no-unused-expressions': ['error', { allowTernary: true }],
       '@typescript-eslint/no-unused-vars': 'off',
       'vue/no-export-in-script-setup': 'off',
       'vue/no-multiple-template-root': 'off',


### PR DESCRIPTION
## Why:

Follow-up to #876 

## Describe your changes

- Updates configuration for `@typescript-eslint/no-unused-expressions` to allow ternary expressions
- Updates the category page object in the e2e test suite to use getters in a consistent way

## Checklist before requesting a review

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
