### PR TITLE
refactor: eslint arrow parens

### DIFF
--- a/apps/web/__tests__/support/commands.ts
+++ b/apps/web/__tests__/support/commands.ts
@@ -35,14 +35,14 @@ Cypress.Commands.add('waitUntilElementInDOM', (actionToWaitOn: () => Cypress.Cha
   cy.waitUntil(() =>
     actionToWaitOn()
       .should('have.length.gte', 0)
-      .then(element => !!element.length),
+      .then((element) => !!element.length),
   ),
 );
 
 Cypress.Commands.add('clearServiceWorkers', () => {
   // Fix for stuck visit even though page is loaded in cypress
   if (window.navigator && navigator.serviceWorker) {
-    const registrationPromise = window.navigator.serviceWorker.getRegistrations().then(registrations =>
+    const registrationPromise = window.navigator.serviceWorker.getRegistrations().then((registrations) =>
       registrations.forEach((registration) => {
         registration.unregister();
       }),

--- a/apps/web/__tests__/support/failOnError.ts
+++ b/apps/web/__tests__/support/failOnError.ts
@@ -11,7 +11,7 @@ Cypress.on("window:before:load", (win) => {
 });
 
 Cypress.on('uncaught:exception', (err) => {
-  if (ignoreErrors.some(ignore => err.message.includes(ignore) || err.stack?.includes(ignore))) {
+  if (ignoreErrors.some((ignore) => err.message.includes(ignore) || err.stack?.includes(ignore))) {
     return false;
   }
 

--- a/apps/web/composables/useAddress/__tests__/useAddress.spec.ts
+++ b/apps/web/composables/useAddress/__tests__/useAddress.spec.ts
@@ -119,7 +119,7 @@ describe('useAddress unit', () => {
 
         await deleteAddress(addressIdToDelete);
 
-        expect(data.value.find(address => address.id === addressIdToDelete)).toBe(undefined);
+        expect(data.value.find((address) => address.id === addressIdToDelete)).toBe(undefined);
     });
 
     it('should call setCheckoutAddress if setDisplayAddress is called with setAsCheckoutAddress true', async () => {

--- a/apps/web/composables/useNotification/__tests__/useNotification.spec.ts
+++ b/apps/web/composables/useNotification/__tests__/useNotification.spec.ts
@@ -84,10 +84,10 @@ describe('useNotification', () => {
 
         expect(data.value.length).toBe(1);
 
-        await new Promise(resolve => setTimeout(resolve, 4000));
+        await new Promise((resolve) => setTimeout(resolve, 4000));
         expect(data.value.length).toBe(1);
 
-        await new Promise(resolve => setTimeout(resolve, 1100));
+        await new Promise((resolve) => setTimeout(resolve, 1100));
         expect(data.value.length).toBe(0);
     });
 
@@ -102,7 +102,7 @@ describe('useNotification', () => {
 
         expect(data.value.length).toBe(1);
 
-        await new Promise(resolve => setTimeout(resolve, 10));
+        await new Promise((resolve) => setTimeout(resolve, 10));
 
         expect(data.value.length).toBe(1);
     });
@@ -119,7 +119,7 @@ describe('useNotification', () => {
 
         expect(data.value.length).toBe(1);
 
-        await new Promise(resolve => setTimeout(resolve, 10));
+        await new Promise((resolve) => setTimeout(resolve, 10));
 
         expect(data.value.length).toBe(1);
     });

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -34,7 +34,7 @@ export default withNuxt(
      * unicorn/prefer-add-event-listener
      */
     rules: {
-      'arrow-parens': 'off',
+      'arrow-parens': ['error', 'always'],
       'no-console': ['error'],
       'no-constant-binary-expression': 'off',
       '@typescript-eslint/no-explicit-any': 'off',


### PR DESCRIPTION
## Why:

Follow-up to #876 

## Describe your changes

- Enables the `arrow-parens` rule. According to the rules documentation, `always` should be the default option, but it ended up behaving in unexpected ways without specifying.
- Adds all missing arrow parentheses.

## Checklist before requesting a review

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
