### PR TITLE
fix: handle disabled en de

### DIFF
--- a/apps/web/build/configurator/AppConfigurator.ts
+++ b/apps/web/build/configurator/AppConfigurator.ts
@@ -103,7 +103,7 @@ export class AppConfigurator {
 
     return environmentContent;
   };
-  
+
   private writeLanguageFiles(defaultLanguageFile: string, languages: Languages, languageFilesPath: string) {
     const fileData = '{}';
     this.writer.writeMissing(fileData, defaultLanguageFile);
@@ -116,12 +116,12 @@ export class AppConfigurator {
   }
 
   private cleanUpInactiveLanguages(languages: Languages, languageFilesPath: string) {
-    if (!languages.activated.includes('en')) {
+    if (!languages.activated.includes('en') && languages.default !== 'en') {
       const enFile = path.resolve(languageFilesPath, 'en.json');
       rmSync(enFile);
     }
 
-    if (!languages.activated.includes('de')) {
+    if (!languages.activated.includes('de') && languages.default !== 'de') {
       const deFile = path.resolve(languageFilesPath, 'de.json');
       rmSync(deFile);
     }
@@ -132,9 +132,9 @@ export class AppConfigurator {
 
     const languageFilesPath = path.resolve(__dirname, '../../lang');
     const defaultLanguageFile = path.resolve(languageFilesPath, `${languages.default}.json`);
-    
+
     this.writeLanguageFiles(defaultLanguageFile, languages, languageFilesPath);
-    
+
     this.cleanUpInactiveLanguages(languages, languageFilesPath);
   };
 }

--- a/docs/changelog/changelog_en.md
+++ b/docs/changelog/changelog_en.md
@@ -34,6 +34,7 @@
 - Fixed product accordions arrow display.
 - Fixed an issue where calling useRoute within middleware could lead to misleading results.
 - Fixed an issue where you only edit the initial block you selected.
+- When the multilingualism configuration of the remote shop doesn't include English or German, the corresponding language file is now removed at build time. As a result, the language isn't displayed in the language selector.
 
 ## v1.8.0 (2024-12-13) <a href="https://github.com/plentymarkets/plentyshop-pwa/compare/v1.7.0...v1.8.0" target="_blank" rel="noopener"><b>Overview of all changes</b></a>
 


### PR DESCRIPTION
## Why:

Closes: [AB#145057](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/145057)

## Describe your changes

- Removes `en.json` and `de.json` when fetching the remote configuration if the corresponding languages are disabled.

## Checklist before requesting a review

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
