### PR TITLE
refactor: eslint no explicit any

### DIFF
--- a/apps/web/__tests__/support/pageObjects/CheckoutPageObject.ts
+++ b/apps/web/__tests__/support/pageObjects/CheckoutPageObject.ts
@@ -244,6 +244,7 @@ export class CheckoutPageObject extends PageObject {
     return this;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   fillForm(fixture: any) {
     this.firstNameInput.type(fixture.firstName);
     this.lastNameInput.type(fixture.lastName);

--- a/apps/web/__tests__/test/unit/i18n.spec.ts
+++ b/apps/web/__tests__/test/unit/i18n.spec.ts
@@ -57,6 +57,7 @@ const hasAllKeys = (obj1: object, obj2: object)  => {
     expect(obj1Skeleton).toEqual(obj2Skeleton);
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const setValuesToEmptyString = (obj: Record<string, any>) => {
     Object.keys(obj).forEach((key) => {
         if (isObject(obj[key]) && obj[key] !== null) {
@@ -70,7 +71,7 @@ const setValuesToEmptyString = (obj: Record<string, any>) => {
     return obj;
   }
 
-const isObject = (item: any) => {
+const isObject = (item: unknown) => {
     return (item && typeof item === 'object' && !Array.isArray(item));
 }
 

--- a/apps/web/components/AddressContainer/AddressContainer.vue
+++ b/apps/web/components/AddressContainer/AddressContainer.vue
@@ -78,7 +78,9 @@ const isShipping = type === AddressType.Shipping;
 const { checkoutAddress, hasCheckoutAddress } = useCheckoutAddress(type);
 const { isLoading: formIsLoading, addressToEdit, add: showNewForm, open: editing } = useAddressForm(type);
 const { shippingAsBilling } = useShippingAsBilling();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const addressFormShipping = ref(null as any);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const addressFormBilling = ref(null as any);
 
 const sameAsShippingAddress = computed(() =>

--- a/apps/web/components/AddressFormBilling/AddressFormBilling.vue
+++ b/apps/web/components/AddressFormBilling/AddressFormBilling.vue
@@ -161,6 +161,7 @@ const [vatNumber, vatNumberAttributes] = defineField('vatNumber');
 
 if (!addAddress) {
   hasCompany.value = Boolean(userAddressGetters.getCompanyName(address as Address));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   setValues(address as any);
   if (!hasCompany.value) {
     companyName.value = '';

--- a/apps/web/components/AddressFormShipping/AddressFormShipping.vue
+++ b/apps/web/components/AddressFormShipping/AddressFormShipping.vue
@@ -179,6 +179,7 @@ const [vatNumber, vatNumberAttributes] = defineField('vatNumber');
 
 if (!addAddress) {
   hasShippingCompany.value = Boolean(userAddressGetters.getCompanyName(address as Address));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   setValues(address as any);
   if (!hasShippingCompany.value) {
     companyName.value = '';

--- a/apps/web/components/ZoomableImage/ZoomableImage.vue
+++ b/apps/web/components/ZoomableImage/ZoomableImage.vue
@@ -85,7 +85,7 @@ const computedHeight = computed(() => {
   return imageUrl.includes(defaults.IMAGE_LINK_SUFIX) ? imageHeight : '';
 });
 
-const nuxtImgProps = computed<Record<string, any>>(() => ({
+const nuxtImgProps = computed<Record<string, unknown>>(() => ({
   id: `gallery-img-${index}`,
   alt: imageAlt,
   title: imageTitle,

--- a/apps/web/components/ui/Breadcrumbs/Breadcrumbs.vue
+++ b/apps/web/components/ui/Breadcrumbs/Breadcrumbs.vue
@@ -77,7 +77,7 @@ const toggle = () => {
 const NuxtLink = resolveComponent('NuxtLink');
 const route = useRoute();
 const items = route.path.split('/');
-const itemListElement = [] as Array<any>;
+const itemListElement = [] as Array<unknown>;
 let name = '';
 items.forEach((item, index) => {
   name += item;

--- a/apps/web/components/ui/CartProductCard/CartProductCard.vue
+++ b/apps/web/components/ui/CartProductCard/CartProductCard.vue
@@ -143,6 +143,7 @@ const localePath = useLocalePath();
 const imageLoaded = ref(false);
 const img = ref();
 const deleteLoading = ref(false);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const quantitySelectorReference = ref(null as any);
 const itemQuantitySelector = ref(cartGetters.getItemQty(cartItem));
 const maximumOrderQuantity = ref();

--- a/apps/web/components/ui/HeroCarousel/HeroCarousel.vue
+++ b/apps/web/components/ui/HeroCarousel/HeroCarousel.vue
@@ -69,10 +69,13 @@ const enableModules = computed(() => bannerItems.length > 1);
 const generalTextColor = ref('inherit');
 const activeIndex = ref(0);
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const onSwiperInit = (swiper: any) => {
   generalTextColor.value = bannerItems[0]?.text?.color ?? 'inherit';
   activeIndex.value = swiper.realIndex;
 };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const onSlideChange = (swiper: any) => {
   activeIndex.value = swiper.realIndex;
 };

--- a/apps/web/composables/useApplePay/useApplePay.ts
+++ b/apps/web/composables/useApplePay/useApplePay.ts
@@ -39,6 +39,7 @@ export const useApplePay = () => {
       state.value.scriptLoaded = true;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     state.value.script = (script as any).Applepay() as ApplepayType;
     state.value.config = await state.value.script.config();
 

--- a/apps/web/composables/useCookieBar/useCookieBar.ts
+++ b/apps/web/composables/useCookieBar/useCookieBar.ts
@@ -6,8 +6,11 @@ const checkIfScriptIsExternal = (scriptName: string): boolean => {
   return scriptName.startsWith('http');
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function convertToSaveableJson(jsonList: any): string {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return jsonList.map((group: any) => ({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [group.name]: group.cookies.map((cookie: any) => ({
       [cookie.name]: cookie.accepted,
     })),
@@ -92,6 +95,7 @@ export const useCookieBar = (
                   } else {
                     (0, eval)(script);
                   }
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 } catch (error: any) {
                   // @TODO error handling
                   return new Error(error);

--- a/apps/web/composables/useGooglePay/useGooglePay.ts
+++ b/apps/web/composables/useGooglePay/useGooglePay.ts
@@ -43,6 +43,7 @@ export const useGooglePay = () => {
       state.value.scriptLoaded = true;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     state.value.script = (script as any).Googlepay() as GooglePayPayPal;
     state.value.googleConfig = await state.value.script.config();
     state.value.paymentsClient = getPaymentsClient();

--- a/apps/web/composables/useJsonEditor/useJsonEditor.ts
+++ b/apps/web/composables/useJsonEditor/useJsonEditor.ts
@@ -26,6 +26,7 @@ export const useJsonEditor = (initialJson: string) => {
       JSON.parse(jsonText.value);
       errorMessage.value = '';
       isEditingEnabled.value = true;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
       errorMessage.value = 'Invalid JSON: ' + error.message;
       isEditingEnabled.value = false;
@@ -43,6 +44,7 @@ export const useJsonEditor = (initialJson: string) => {
       validateJson();
       updateLineCount();
       checkInputChange();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
       errorMessage.value = 'Invalid JSON: ' + error.message;
       isEditingEnabled.value = false;

--- a/apps/web/composables/useNotification/types.ts
+++ b/apps/web/composables/useNotification/types.ts
@@ -1,6 +1,6 @@
 export interface Notification {
   message: string | string[];
-  action?: { text: string; onClick: (...arguments_: any) => void };
+  action?: { text: string; onClick: (...arguments_: Array<unknown>) => void };
   type: 'neutral' | 'positive' | 'secondary' | 'warning' | 'negative';
   persist?: boolean;
   id?: symbol;

--- a/apps/web/composables/useStructuredData/useStructuredData.ts
+++ b/apps/web/composables/useStructuredData/useStructuredData.ts
@@ -140,6 +140,7 @@ export const useStructuredData: useStructuredDataReturn = () => {
         '@type': 'QuantitativeValue',
         value: productGetters.getWeightG(product),
       },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
 
     const manufacturer = productSeoSettingsGetters.getSeoManufacturer(product);

--- a/apps/web/composables/useStructuredData/useStructuredData.ts
+++ b/apps/web/composables/useStructuredData/useStructuredData.ts
@@ -140,7 +140,7 @@ export const useStructuredData: useStructuredDataReturn = () => {
         '@type': 'QuantitativeValue',
         value: productGetters.getWeightG(product),
       },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
 
     const manufacturer = productSeoSettingsGetters.getSeoManufacturer(product);

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -37,7 +37,6 @@ export default withNuxt(
       'arrow-parens': ['error', 'always'],
       'no-console': ['error'],
       'no-constant-binary-expression': 'off',
-      '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-unused-expressions': ['error', { allowTernary: true }],
       'vue/no-console': ['error'],
       'vue/no-multiple-template-root': ['off'],

--- a/apps/web/pages/[...slug].vue
+++ b/apps/web/pages/[...slug].vue
@@ -58,7 +58,7 @@ const breadcrumbs = computed(() => {
 
 watch(
   () => locale.value,
-  (changedLocale: any) => {
+  (changedLocale: string) => {
     router.push({
       path: buildCategoryLanguagePath(`${productsCatalog.value.languageUrls[changedLocale]}`),
       query: route.query,

--- a/apps/web/sdk.client.ts
+++ b/apps/web/sdk.client.ts
@@ -38,6 +38,7 @@ const createHttpClient = () => {
 };
 
 const handleHttpError = (error: unknown) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const axiosError = error as any;
   const data = axiosError?.response?.data?.data || axiosError?.response?.data;
   const events = axiosError?.response?.data?.events;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "extends": "./.nuxt/tsconfig.json",
   "compilerOptions": {
+    "module": "ESNext",
     "types": ["vitest/globals", "@vite-pwa/nuxt", "@types/applepayjs", "@types/googlepay"],
     "verbatimModuleSyntax": false,
+    "noImplicitAny": true,
   },
   "exclude": ["node_modules", "mocks", "__tests__", "cypress.config.ts"],
   "typedocOptions": {

--- a/apps/web/utils/jsonHelper.ts
+++ b/apps/web/utils/jsonHelper.ts
@@ -1,4 +1,4 @@
-export const deepEqual = (object1: any, object2: any): boolean => {
+export const deepEqual = (object1: unknown, object2: unknown): boolean => {
   if (object1 === object2) return true;
 
   if (typeof object1 !== typeof object2 || object1 === null || object2 === null) {

--- a/apps/web/vitest.config.setup.ts
+++ b/apps/web/vitest.config.setup.ts
@@ -8,6 +8,7 @@ import { setupServer } from 'msw/node';
 import { HttpResponse, http } from 'msw';
 import { FacetMock } from './__tests__/__mocks__/facet.mock';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const FindTestIdPlugin = (wrapper: any) => {
   function findByTestId(testId: string) {
     return wrapper.find(`[data-testid='${testId}']`);
@@ -18,6 +19,7 @@ const FindTestIdPlugin = (wrapper: any) => {
   };
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const GetTestIdPlugin = (wrapper: any) => {
   function getByTestId(testId: string) {
     return wrapper.get(`[data-testid='${testId}']`);


### PR DESCRIPTION
## Why:

Follow-up to #876 

## Describe your changes

- Enables the `no-explicity-any` rule.
- Enables `noImplicitAny` in the TypeScript compiler options.
- Addresses some explicit any types.
- Disables the `no-explicit-any` rule on a line-by-line basis for the remaining occurrences.

## Checklist before requesting a review

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
