### PR TITLE
fix: editor components display logic

### DIFF
--- a/apps/web/components/PageBlock/PageBlock.vue
+++ b/apps/web/components/PageBlock/PageBlock.vue
@@ -1,7 +1,5 @@
 <template>
-  <UiBlockPlaceholder
-    v-if="visiblePlaceholder.index === index && visiblePlaceholder.position === 'top' && drawerOpen"
-  />
+  <UiBlockPlaceholder v-if="displayTopPlaceholder(index)" />
   <div
     :class="[
       'relative group',
@@ -61,9 +59,7 @@
       <SfIconAdd class="cursor-pointer" />
     </button>
   </div>
-  <UiBlockPlaceholder
-    v-if="visiblePlaceholder.index === index && visiblePlaceholder.position === 'bottom' && drawerOpen"
-  />
+  <UiBlockPlaceholder v-if="displayBottomPlaceholder(index)" />
 </template>
 
 <script lang="ts" setup>
@@ -89,7 +85,28 @@ interface Props {
 
 defineProps<Props>();
 
-const { blockSize } = useSiteConfiguration();
+const { blockSize, drawerOpen, drawerView } = useSiteConfiguration();
 const { visiblePlaceholder } = useBlockManager();
-const { drawerOpen } = useSiteConfiguration();
+
+const displayTopPlaceholder = (index: number): boolean => {
+  const visiblePlaceholderState = visiblePlaceholder.value;
+
+  return (
+    visiblePlaceholderState.position === 'top' &&
+    visiblePlaceholderState.index === index &&
+    drawerOpen.value &&
+    drawerView.value === 'blocks'
+  );
+};
+
+const displayBottomPlaceholder = (index: number): boolean => {
+  const visiblePlaceholderState = visiblePlaceholder.value;
+
+  return (
+    visiblePlaceholderState.position === 'bottom' &&
+    visiblePlaceholderState.index === index &&
+    drawerOpen.value &&
+    drawerView.value === 'blocks'
+  );
+};
 </script>

--- a/apps/web/components/ui/Toolbar/Toolbar.vue
+++ b/apps/web/components/ui/Toolbar/Toolbar.vue
@@ -69,7 +69,7 @@ const { isEditing, isEditingEnabled, disableActions } = useEditor();
 
 const { loading } = useHomepage();
 const {
-  drawerOpen,
+  drawerView,
   openDrawerWithView,
   closeDrawer,
   settingsIsDirty,
@@ -95,7 +95,7 @@ const save = () => {
 };
 
 const toggleSettingsDrawer = () => {
-  drawerOpen.value ? closeDrawer() : openDrawerWithView('settings');
+  drawerView.value === 'settings' ? closeDrawer() : openDrawerWithView('settings');
 };
 
 const toggleEdit = () => {

--- a/apps/web/composables/useSiteConfiguration/useSiteConfiguration.ts
+++ b/apps/web/composables/useSiteConfiguration/useSiteConfiguration.ts
@@ -27,7 +27,7 @@ export const useSiteConfiguration: UseSiteConfigurationReturn = () => {
     currentFont: useRuntimeConfig().public.font,
     primaryColor: useRuntimeConfig().public.primaryColor,
     secondaryColor: useRuntimeConfig().public.secondaryColor,
-    drawerView: 'settings',
+    drawerView: null,
     blockSize: useRuntimeConfig().public.blockSize,
     selectedFont: { caption: useRuntimeConfig().public.font, value: useRuntimeConfig().public.font },
     initialData: {
@@ -102,6 +102,7 @@ export const useSiteConfiguration: UseSiteConfigurationReturn = () => {
 
   const closeDrawer = () => {
     state.value.drawerOpen = false;
+    state.value.drawerView = null;
   };
 
   const updateBlockSize: UpdateBlockSize = (size: string) => {

--- a/docs/changelog/changelog_en.md
+++ b/docs/changelog/changelog_en.md
@@ -10,6 +10,7 @@
 - Added the option to opt-out cookies in the cookie bar when the cookie is not in the "Necessary" group.
 - Added the logic to remove cookies after revoking consent.
 - Added a new placeholder block component to showcase to the user where his block will go
+- You can now add blocks on homepage from the blocks side nav
 
 ### 👷 Changed
 
@@ -17,6 +18,8 @@
 
 - Fixed an issue where page elements changed during navigation.
 - Fixed accessibility erros in edit mode.
+- Fixed an issue where the site settings view was only displayed on the second click.
+- Fixed an issue where the new block placeholder got displayed when editing the site settings.
 
 ## v1.9.1 (2025-01-29) <a href="https://github.com/plentymarkets/plentyshop-pwa/compare/v1.9.0...v1.9.1" target="_blank" rel="noopener"><b>Overview of all changes</b></a>
 
@@ -36,7 +39,6 @@
 - Added preview functionality for block sizes.
 - If there are unsaved changes in the editor and the user tries to close or reload the page, the browser will now display a warning and ask for confirmation.
 - Adding saving functionality for site settings.
-- You can now add blocks on homepage from the blocks side nav!
 
 ### 👷 Changed
 


### PR DESCRIPTION
## Why:

Closes: [AB#147467](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/147467)

## Describe your changes

- Updates logic for the new block placeholder to take the drawer view into account
- Updates logic for when to display the site settings view

## Checklist before requesting a review

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
