### PR TITLE
docs: use npx to generate typedoc reference

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,7 @@
     "docs:dev": "npm run publish-typedoc && vitepress dev docs",
     "docs:build": "npm run publish-typedoc && vitepress build docs",
     "docs:preview": "vitepress preview docs",
-    "publish-typedoc": "npm run typedoc && mkdir -p docs/reference && mv reference/composables/ docs/reference",
+    "publish-typedoc": "npx typedoc && mkdir -p docs/reference && mv reference/composables/ docs/reference",
     "lint": "nuxi prepare && eslint . --max-warnings 0",
     "lint:fix": "nuxi prepare && eslint . --fix --max-warnings 0",
     "preview": "nuxt preview",


### PR DESCRIPTION
## Why:

Closes: [AB#150372](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/150372)

## Describe your changes

- Uses `npx` instead of `npm run` to generate TypeDoc reference

## Checklist before requesting a review

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
