### PR TITLE
chore: add dev mode flag

### DIFF
--- a/apps/web/components/SettingsToolbar/SettingsToolbar.vue
+++ b/apps/web/components/SettingsToolbar/SettingsToolbar.vue
@@ -5,6 +5,7 @@
   >
     <div class="relative flex flex-col px-1 py-1">
       <button
+        v-if="runtimeConfig.public.isDev"
         type="button"
         class="editor-button relative py-2 flex justify-center"
         :class="{ 'bg-editor-button text-white rounded-md': drawerView === 'PagesView' }"
@@ -60,4 +61,5 @@ import paintBrushWhite from 'assets/icons/paths/paint-brush-white.svg';
 import pagesWhite from 'assets/icons/paths/pages-white.svg';
 import pagesBlack from 'assets/icons/paths/pages-black.svg';
 const { drawerView, openDrawerWithView } = useSiteConfiguration();
+const runtimeConfig = useRuntimeConfig();
 </script>

--- a/apps/web/components/ui/Toolbar/Toolbar.vue
+++ b/apps/web/components/ui/Toolbar/Toolbar.vue
@@ -7,7 +7,7 @@
       <UiBrandLogo />
       <div class="absolute left-1/2 transform -translate-x-1/2 flex space-x-2">
         <UiLanguageEditor />
-        <UiPageSelector />
+        <UiPageSelector v-if="runtimeConfig.public.isDev" />
       </div>
       <div class="ml-auto flex space-x-2">
         <button

--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -43,6 +43,7 @@ export default defineNuxtConfig({
     public: {
       domain: validateApiUrl(process.env.API_URL) ?? process.env.API_ENDPOINT,
       apiEndpoint: process.env.API_ENDPOINT,
+      isDev: process.env.NODE_ENV === 'development',
       cookieGroups: cookieConfig,
       turnstileSiteKey: process.env?.TURNSTILESITEKEY ?? '',
       useAvif: process.env?.IMAGEAVIF === 'true',


### PR DESCRIPTION
## Why:

Allows us to keep integrating our progress without exposing it to users. This means the app stays releasable throughout the development process.

## Describe your changes

- Adds a runtime configuration that reads the Node environment. `isDev` is `true` when starting the app with `npm run dev`. It's `false` when starting the app with `npm start`.
- Applies the flag to the page selector.
- Applies the flag to the page management.

## Checklist before requesting a review

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
