### PR TITLE
fix: PagesView.vue(99,21): error TS2367: This comparison appears to b…

### DIFF
--- a/apps/web/components/PagesView/PagesView.vue
+++ b/apps/web/components/PagesView/PagesView.vue
@@ -66,9 +66,7 @@
 import PagesItem from '~/components/PagesView/PagesItem.vue';
 import { SfIconClose, SfIconHelp, SfTooltip, SfIconAdd } from '@storefront-ui/vue';
 import type { MenuItemType } from '~/components/PagesView/types';
-const { $i18n } = useNuxtApp();
-const currentLocale = ref($i18n.locale.value);
-
+const { locale } = useI18n();
 const { pages } = await usePages();
 const contentPagesOpen = ref(false);
 const productPagesOpen = ref(false);
@@ -101,7 +99,10 @@ const openHelpPage = () => {
     de: 'https://knowledge.plentymarkets.com/de-de/manual/main/webshop/shop-editor.html',
   };
 
-  const targetUrl = currentLocale.value === 'de' ? urls.de : urls.en;
-  window.open(targetUrl, '_blank');
+  const targetUrl = locale.value in urls ? urls[locale.value] : null;
+
+  if (targetUrl) {
+    window.open(targetUrl, '_blank');
+  }
 };
 </script>

--- a/docs/changelog/changelog_en.md
+++ b/docs/changelog/changelog_en.md
@@ -23,7 +23,8 @@
 - Fix toolbar arrow
 - Fix Page Selector closes on second button click
 - Fix my orders page shipping date's missing locale.
-- Fix left side menu german navigation
+- Fix left side menu german navigation.
+- Fix production build error. [#1151](https://github.com/plentymarkets/plentyshop-pwa/pull/1151)
 
 # v1.12.0 (2025-03-19)<a href="https://github.com/plentymarkets/plentyshop-pwa/compare/v1.11.1...v1.12.0" target="_blank" rel="noopener"><b>Overview of all changes</b></a>
 


### PR DESCRIPTION
…e unintentional because the types '"en"' and '"de"' have no overlap.

## Why:

Closes: #ID
[AB#154282](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/154282)
## Describe your changes

## Checklist before requesting a review

- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
