### PR TITLE
ci: add vue accessibility plugin for eslint

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -1,5 +1,6 @@
 import withNuxt from './.nuxt/eslint.config.mjs';
 import { architecture, ecma } from "@vue-storefront/eslint-config";
+import pluginVueA11y from "eslint-plugin-vuejs-accessibility";
 
 export default withNuxt(
   {
@@ -18,6 +19,7 @@ export default withNuxt(
   ecma({
     withImport: false,
   }),
+  ...pluginVueA11y.configs["flat/recommended"],
   {
     /**
      * Rules from other plugins
@@ -42,6 +44,13 @@ export default withNuxt(
       'vue/no-multiple-template-root': ['off'],
       'vue/no-v-html': ['off'],
       'vue/html-self-closing': ['error', { html: { void: 'always' } }],
+      'vuejs-accessibility/click-events-have-key-events': 'off',
+      'vuejs-accessibility/form-control-has-label': 'off',
+      'vuejs-accessibility/label-has-for': 'off',
+      'vuejs-accessibility/mouse-events-have-key-events': 'off',
+      'vuejs-accessibility/no-autofocus': 'off',
+      'vuejs-accessibility/no-redundant-roles': 'off',
+      'vuejs-accessibility/no-static-element-interactions': 'off',
     }
   },
 );

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -57,6 +57,7 @@
     "cypress-wait-until": "^2.0.1",
     "eslint": "^9.16.0",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-vuejs-accessibility": "^2.4.1",
     "happy-dom": "^15.11.7",
     "msw": "^2.6.7",
     "nuxt": "^3.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,6 +115,7 @@
         "cypress-wait-until": "^2.0.1",
         "eslint": "^9.16.0",
         "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-vuejs-accessibility": "^2.4.1",
         "happy-dom": "^15.11.7",
         "msw": "^2.6.7",
         "nuxt": "^3.16.0",
@@ -20692,6 +20693,41 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/eslint-plugin-vuejs-accessibility": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vuejs-accessibility/-/eslint-plugin-vuejs-accessibility-2.4.1.tgz",
+      "integrity": "sha512-ZRZhPdslplZXSF71MtSG+zXYRAT5KiHR4JVuo/DERQf9noAkDvi5W418VOE1qllmJd7wTenndxi1q8XeDMxdHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.0",
+        "emoji-regex": "^10.0.0",
+        "vue-eslint-parser": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-vuejs-accessibility/node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eslint-plugin-vuejs-accessibility/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint-processor-vue-blocks": {
       "version": "1.0.0",


### PR DESCRIPTION
## Why:

Check accessibility guidelines on pull requests.

## Describe your changes

- Adds `eslint-plugin-vuejs-accessibility` plugin.
- Disables all rules for later implementation.

[Rules overview](https://vue-a11y.github.io/eslint-plugin-vuejs-accessibility/rule-overview/)

## Checklist before requesting a review

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
