### PR TITLE
fix: enforce quantity limits in QuantitySelector component

### DIFF
--- a/apps/web/components/ui/QuantitySelector/QuantitySelector.vue
+++ b/apps/web/components/ui/QuantitySelector/QuantitySelector.vue
@@ -90,6 +90,12 @@ const inputClasses = computed(
 onMounted(() => (inputId.value = useId()));
 
 watch(count, (quantity) => {
+  if (quantity < minValue) {
+    set(minValue);
+  } else if (quantity > maxValue) {
+    set(maxValue);
+  }
+
   emit('changeQuantity', quantity);
 });
 

--- a/docs/changelog/changelog_en.md
+++ b/docs/changelog/changelog_en.md
@@ -28,6 +28,7 @@
 - Updated the category menu markup by removing a button element nested within an anchor tag.
 - Fixed nuxt runtime error.
 - Turnstile validation error in the contact form if turnstile is not configured.
+- It's no longer possible to enter values outside the quantity limits in the quantity selector. The quantity will be set to 1 or the maximum value instead.
 
 ### Chore
 


### PR DESCRIPTION
## Why:

Closes: #ID

## Describe your changes

- If the user tries to set the quantity of a product to 0 or to remove the quantity value, the quantity becomes 1.
- If the user tries to set the quantity of a product above its maximum value, the quantity becomes the maximum value.

## Checklist before requesting a review

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
