### PR TITLE
fix: fix filters on category page

### DIFF
--- a/apps/web/composables/useCategoryFilter/useCategoryFilter.ts
+++ b/apps/web/composables/useCategoryFilter/useCategoryFilter.ts
@@ -43,7 +43,7 @@ const mergeFilters = (oldFilters: Filters, filters: Filters): Filters => {
  * ```
  */
 export const useCategoryFilter = (to?: RouteLocationNormalizedGeneric): UseCategoryFiltersResponse => {
-  const route = to ?? useNuxtApp().$router.currentRoute.value;
+  const route = to ? ref(to) : useNuxtApp().$router.currentRoute;
 
   /**
    * @description Function for getting facets from url.
@@ -101,9 +101,9 @@ export const useCategoryFilter = (to?: RouteLocationNormalizedGeneric): UseCateg
    * ```
    */
   const getFiltersDataFromUrl = (): GetFacetsFromURLResponse => {
-    return Object.keys(route.query)
+    return Object.keys(route.value.query)
       .filter((f) => nonFilters.has(f))
-      .reduce(reduceFilters(route.query), {});
+      .reduce(reduceFilters(route.value.query), {});
   };
 
   /***
@@ -229,7 +229,7 @@ export const useCategoryFilter = (to?: RouteLocationNormalizedGeneric): UseCateg
    * ```
    */
   const updateSorting = (sort: string): void => {
-    navigateTo({ query: { ...route.query, sort } });
+    navigateTo({ query: { ...route.value.query, sort } });
   };
 
   /**

--- a/docs/changelog/changelog_de.md
+++ b/docs/changelog/changelog_de.md
@@ -11,6 +11,7 @@
 - Vereinheitlichung einiger Begriffe auf Deutsch und Englisch
 
 ### 🩹 Behoben
+
 - Ein Fehler wurde behoben, bei dem lediglich eine Sortierung bzw. ein Filter ausgewählt werden konnte
 
 # v1.13.2 (2025-04-14) <a href="https://github.com/plentymarkets/plentyshop-pwa/compare/v1.13.1...v1.13.2" target="_blank" rel="noopener"><b>Übersicht aller Änderungen</b></a>

--- a/docs/changelog/changelog_de.md
+++ b/docs/changelog/changelog_de.md
@@ -10,6 +10,9 @@
 
 - Vereinheitlichung einiger Begriffe auf Deutsch und Englisch
 
+### 🩹 Behoben
+- Ein Fehler wurde behoben, bei dem lediglich eine Sortierung bzw. ein Filter ausgewählt werden konnte
+
 # v1.13.2 (2025-04-14) <a href="https://github.com/plentymarkets/plentyshop-pwa/compare/v1.13.1...v1.13.2" target="_blank" rel="noopener"><b>Übersicht aller Änderungen</b></a>
 
 ### 👷 Geändert

--- a/docs/changelog/changelog_en.md
+++ b/docs/changelog/changelog_en.md
@@ -25,7 +25,7 @@
 
 ### 🩹 Fixed
 
-- Fixed broken selection when having filtering and sorting
+- Fix broken selection when having filtering and sorting
 - (dev) Fix Page Selector state.
 - (dev) Fix Page Selector closes when clicking outside the box.
 - (dev) Fix Page Selector closes on second button click.

--- a/docs/changelog/changelog_en.md
+++ b/docs/changelog/changelog_en.md
@@ -25,6 +25,7 @@
 
 ### 🩹 Fixed
 
+- Fixed broken selection when having filtering and sorting
 - (dev) Fix Page Selector state.
 - (dev) Fix Page Selector closes when clicking outside the box.
 - (dev) Fix Page Selector closes on second button click.


### PR DESCRIPTION
## Why:

You aren't able to select the sorting when a filter has been previously already applied.

Closes: #ID

## Describe your changes

Uses the reactive object of the current route to ensure it changes when navigating to a new route (to avoid updating the query based on an outdate route state).

## Checklist before requesting a review

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
