### PR TITLE
fix: backwards compatible for old logo env variable

### DIFF
--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -68,7 +68,9 @@ export default defineNuxtConfig({
       showConfigurationDrawer: process.env.SHOW_CONFIGURATION_DRAWER === '1',
       defaultItemsPerPage: Number(process.env.DEFAULT_FEEDBACK_ITEMS_PER_PAGE ?? 10),
       headerLogo:
-        process.env.NUXT_PUBLIC_HEADER_LOGO || 'https://cdn02.plentymarkets.com/mevofvd5omld/frontend/Logo/logo.svg',
+        process.env.NUXT_PUBLIC_HEADER_LOGO ||
+        process.env.LOGO ||
+        'https://cdn02.plentymarkets.com/mevofvd5omld/frontend/Logo/logo.svg',
       homepageCategoryId: Number(process.env.HOMEPAGE) ?? null,
       shippingTextCategoryId: Number(process.env.SHIPPINGTEXT) ?? null,
       storename: process.env.STORENAME || 'PlentyONE GmbH',


### PR DESCRIPTION
## Why:

Old settings should be supported during transition period.

## Describe your changes

- Re-adds previous logo environment variable as fallback.

## Checklist before requesting a review

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
