### PR TITLE
perf: lazy load i18n

### DIFF
--- a/apps/web/configuration/i18n.config.ts
+++ b/apps/web/configuration/i18n.config.ts
@@ -33,4 +33,5 @@ export const nuxtI18nOptions: NuxtI18nOptions = {
   strategy: 'prefix_and_default',
   vueI18n: '~/configuration/vueI18n.config.ts',
   detectBrowserLanguage: false,
+  lazy: true,
 };

--- a/docs/changelog/changelog_en.md
+++ b/docs/changelog/changelog_en.md
@@ -34,6 +34,7 @@ For changelogs of newer versions, refer to the [Releases](https://github.com/ple
 
 - The contact form requires a turnstile validation otherwise the form will not show up.
 - `vsf-locale` cookie got removed, we now send a header `locale` with every sdk request.
+- Translations are now lazy loaded. This decreases JavaScript chunk size, which in turn improves page load performance.
 
 ### 🩹 Fixed
 


### PR DESCRIPTION
## Why:

Lazy loading i18n removes the translations from the main JS chunk, reducing its file size, which should improve performance. Lazy loading is considered [good practice](https://i18n.nuxtjs.org/docs/guide/lazy-load-translations) in applications with many translations.

## Describe your changes

- Activates lazy loading for i18n.

## Checklist before requesting a review

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
