### PR TITLE
fix: cookiebar line break and category breadcrumb on mobile

### DIFF
--- a/apps/web/components/Cookiebar/Cookiebar.vue
+++ b/apps/web/components/Cookiebar/Cookiebar.vue
@@ -78,7 +78,7 @@
                   v-if="propKey !== 'name' && propKey !== 'accepted' && propKey !== 'cookieNames'"
                   class="flex p-2 mb-1 bg-white"
                 >
-                  <div class="w-1/4">
+                  <div class="w-1/4 break-words mr-2">
                     {{ t(`CookieBar.keys.${propKey}`) }}
                   </div>
                   <div class="w-3/4 break-words">

--- a/apps/web/components/MegaMenu/MegaMenu.vue
+++ b/apps/web/components/MegaMenu/MegaMenu.vue
@@ -128,7 +128,7 @@
       >
         <nav>
           <div class="flex items-center justify-between p-4 border-b border-b-neutral-200 border-b-solid">
-            <p class="typography-text-base font-medium">Browse products</p>
+            <p class="typography-text-base font-medium">{{ t('browseProducts') }}</p>
             <UiButton variant="tertiary" square :aria-label="t('closeMenu')" class="ml-2" @click="close()">
               <SfIconClose class="text-neutral-500" />
             </UiButton>

--- a/apps/web/components/ui/Breadcrumbs/Breadcrumbs.vue
+++ b/apps/web/components/ui/Breadcrumbs/Breadcrumbs.vue
@@ -1,7 +1,7 @@
 <template>
   <nav data-testid="breadcrumbs" class="inline-flex items-center text-sm font-normal">
     <ol class="flex w-auto leading-none group md:flex-wrap">
-      <li class="flex items-center sm:hidden text-neutral-500 z-10">
+      <li class="flex items-center sm:hidden text-neutral-500 z-9">
         <NuxtLazyHydrate :on-interaction="['click', 'touchstart']">
           <SfDropdown v-model="dropdownOpened" strategy="absolute" placement="bottom-start" @update:model-value="close">
             <template #trigger>

--- a/apps/web/i18n/lang/de.json
+++ b/apps/web/i18n/lang/de.json
@@ -346,6 +346,7 @@
   "closeDrawer": "Drawer schließen",
   "closeListSettings": "Listeneinstellungen schließen",
   "closeMenu": "Menü schließen",
+  "browseProducts": "Produkte durchstöbern",
   "coming-soon": "Demnächst",
   "contact": {
     "clearAll": "Alles löschen",

--- a/apps/web/i18n/lang/en.json
+++ b/apps/web/i18n/lang/en.json
@@ -346,6 +346,7 @@
   "closeDrawer": "Close Drawer",
   "closeListSettings": "Close list settings",
   "closeMenu": "Close Menu",
+  "browseProducts": "Browse Products",
   "coming-soon": "Coming Soon",
   "contact": {
     "clearAll": "Clear all",

--- a/docs/changelog/changelog_en.md
+++ b/docs/changelog/changelog_en.md
@@ -37,6 +37,7 @@ For changelogs of newer versions, refer to the [Releases](https://github.com/ple
 
 ### 🩹 Fixed
 
+- Fixed cookierbar text overlap.
 - Fixed an issue in the guest checkout flow that allowed address saving without providing an email.
 - Fixed an issue where the currency was not displayed correctly.
 - Fixed missing form labels for DHL preferred delivery services.

--- a/docs/changelog/changelog_en.md
+++ b/docs/changelog/changelog_en.md
@@ -37,7 +37,7 @@ For changelogs of newer versions, refer to the [Releases](https://github.com/ple
 
 ### 🩹 Fixed
 
-- Fixed cookierbar text overlap.
+- Fixed cookierbar text overlap and browse products translation.
 - Fixed an issue in the guest checkout flow that allowed address saving without providing an email.
 - Fixed an issue where the currency was not displayed correctly.
 - Fixed missing form labels for DHL preferred delivery services.


### PR DESCRIPTION
[AB#157965](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/157965)
and
[AB#158961](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/158961)