### PR TITLE
fix: support legacy config for meta title

### DIFF
--- a/apps/web/configuration/app.config.ts
+++ b/apps/web/configuration/app.config.ts
@@ -1,5 +1,5 @@
 export const metaDefaults = {
-  title: process.env.NUXT_PUBLIC_META_TITLE || 'PlentyONE Shop',
+  title: process.env.NUXT_PUBLIC_META_TITLE || process.env.METATITLE || 'PlentyONE Shop',
   description: process.env.NUXT_PUBLIC_META_DESCRIPTION || process.env.METADESC || 'Demo shop for PlentyONE Shop',
   keywords: process.env.NUXT_PUBLIC_META_KEYWORDS || process.env.METAKEYWORDS || 'PlentyONE, plentyshop, pwa',
   robots: process.env.NUXT_PUBLIC_ROBOTS || 'all',


### PR DESCRIPTION
## Why:

The title always defaults to PlentyONE Shop.

## Describe your changes

- Adds support for the legacy config key.

## Checklist before requesting a review

- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
