### PR TITLE
fix: select lv 6 category as new page parent

### DIFF
--- a/apps/web/components/ui/PageModal/PageModal.vue
+++ b/apps/web/components/ui/PageModal/PageModal.vue
@@ -62,6 +62,18 @@
         />
       </div>
 
+      <div
+        v-if="!isValidParentPage()"
+        class="bg-red-700 w-full rounded-md text-white text-sm px-4 py-2 grid grid-cols-[auto,1fr] gap-2"
+      >
+        <span class="flex items-center">
+          <SfIconWarning />
+        </span>
+        <span>
+          {{ invalidParentMessage }}
+        </span>
+      </div>
+
       <div class="actions grid gap-4 grid-cols-2">
         <button
           type="button"
@@ -75,6 +87,8 @@
           type="submit"
           data-testid="block-spacing-btn"
           class="border border-editor-button bg-editor-button w-full py-2 rounded-md flex align-center justify-center text-white"
+          :class="{ 'opacity-50 cursor-not-allowed': !isValidParentPage() }"
+          :disabled="!isValidParentPage()"
         >
           Add page
         </button>
@@ -84,7 +98,7 @@
 </template>
 
 <script setup lang="ts">
-import { SfIconClose, SfInput } from '@storefront-ui/vue';
+import { SfIconClose, SfIconWarning, SfInput } from '@storefront-ui/vue';
 import Multiselect from 'vue-multiselect';
 import { ErrorMessage } from 'vee-validate';
 
@@ -99,8 +113,12 @@ const {
   pageNameAttributes,
   errors,
   getLabel,
+  isValidParentPage,
   closeModal,
   onSubmit,
   handleSearch,
 } = useAddPageModal();
+
+const invalidParentMessage =
+  "You've selected a level 6 category as parent page. Select a category of level 5 or lower.";
 </script>

--- a/apps/web/composables/useAddPage/useAddPage.ts
+++ b/apps/web/composables/useAddPage/useAddPage.ts
@@ -2,7 +2,7 @@ import { useForm } from 'vee-validate';
 import { toTypedSchema } from '@vee-validate/yup';
 import { object, string } from 'yup';
 import type { CategoryEntry, CategoryTreeItem } from '@plentymarkets/shop-api';
-import { categoryTreeGetters } from '@plentymarkets/shop-api';
+import { categoryEntryGetters } from '@plentymarkets/shop-api';
 
 export const useAddPageModal = () => {
   const { pageModalOpen, togglePageModal, setSettingsCategory } = useSiteConfiguration();
@@ -33,7 +33,7 @@ export const useAddPageModal = () => {
 
   const pageType = ref(getDefaultPageType());
 
-  const noneCategoryItem: CategoryTreeItem = {
+  const noneCategoryItem: CategoryEntry = {
     id: 0,
     type: 'none',
     itemCount: [],
@@ -47,13 +47,41 @@ export const useAddPageModal = () => {
         metaTitle: '',
         imagePath: '',
         image2Path: '',
+        canonicalLink: '',
+        categoryId: '0',
+        description: '',
+        description2: '',
+        fulltext: 'N',
+        image: 0,
+        image2: '',
+        itemListView: '',
+        metaDescription: '',
+        metaKeywords: '',
+        metaRobots: '',
+        pageView: '',
+        position: '0',
+        previewUrl: '',
+        plenty_category_details_image_path: '',
+        plenty_category_details_image2_path: '',
+        plentyId: 0,
+        shortDescription: '',
+        singleItemView: '',
+        updatedAt: '',
+        updatedBy: '',
       },
     ],
+    clients: [],
+    level: 0,
+    linklist: '',
+    parentCategoryId: 0,
+    sitemap: 'N',
+    isLinkedToWebstore: false,
+    hasChildren: false,
   };
 
-  const parentPage = ref<CategoryTreeItem>(noneCategoryItem);
+  const parentPage = ref<CategoryEntry>(noneCategoryItem);
 
-  const buildInitialParentPage = (): CategoryTreeItem => {
+  const buildInitialParentPage = (): CategoryEntry => {
     if (getCurrentCategoryLevel.value === 6 && getParentCategoryId.value && getParentName.value) {
       return {
         ...noneCategoryItem,
@@ -117,8 +145,16 @@ export const useAddPageModal = () => {
 
   const [pageName, pageNameAttributes] = defineField('pageName');
 
-  const getLabel = (option: CategoryTreeItem) => {
-    return option.details && option.details.length ? option.details[0].name : '';
+  const getLabel = (option: CategoryEntry) => {
+    return categoryEntryGetters.getDetails(option)[0].name;
+  };
+
+  const getLevel = (option: CategoryEntry) => {
+    return categoryEntryGetters.getLevel(option);
+  };
+
+  const isValidParentPage = (): boolean => {
+    return getLevel(parentPage.value) !== 6;
   };
 
   const createNewPage = async () => {
@@ -127,7 +163,7 @@ export const useAddPageModal = () => {
     await addCategory({
       name: pageName?.value || '',
       type: pageType.value.value,
-      parentCategoryId: categoryTreeGetters.getId(parentPage.value) || null,
+      parentCategoryId: categoryEntryGetters.getId(parentPage.value) || null,
     });
 
     addNewPageToTree(newCategory.value);
@@ -179,6 +215,8 @@ export const useAddPageModal = () => {
     onSubmit,
     closeModal,
     getLabel,
+    getLevel,
+    isValidParentPage,
     handleSearch,
   };
 };

--- a/apps/web/composables/useAddPage/useAddPage.ts
+++ b/apps/web/composables/useAddPage/useAddPage.ts
@@ -86,6 +86,7 @@ export const useAddPageModal = () => {
       return {
         ...noneCategoryItem,
         id: getParentCategoryId.value,
+        level: getCurrentCategoryLevel.value ?? 0,
         details: [{ ...noneCategoryItem.details[0], name: getParentName.value }],
       };
     }
@@ -94,6 +95,7 @@ export const useAddPageModal = () => {
       return {
         ...noneCategoryItem,
         id: getCategoryId.value,
+        level: getCurrentCategoryLevel.value ?? 0,
         details: [{ ...noneCategoryItem.details[0], name: getCategoryName.value }],
       };
     }
@@ -154,7 +156,7 @@ export const useAddPageModal = () => {
   };
 
   const isValidParentPage = (): boolean => {
-    return getLevel(parentPage.value) !== 6;
+    return getLevel(parentPage.value) !== 1;
   };
 
   const createNewPage = async () => {

--- a/apps/web/composables/useAddPage/useAddPage.ts
+++ b/apps/web/composables/useAddPage/useAddPage.ts
@@ -156,7 +156,7 @@ export const useAddPageModal = () => {
   };
 
   const isValidParentPage = (): boolean => {
-    return getLevel(parentPage.value) !== 1;
+    return getLevel(parentPage.value) !== 6;
   };
 
   const createNewPage = async () => {


### PR DESCRIPTION
## Why:

Closes: [AB#161782](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/161782)

## Describe your changes

- Plenty only supports 6 levels of category.
- When the user adds a new page in the editor and select a lv 6 category as parent page, the editor now displays a warning message.

<img width="474" alt="Screenshot 2025-05-28 at 08 20 31" src="https://github.com/user-attachments/assets/df29533a-9c35-4646-b54e-5b34c6ad92de" />

## Checklist before requesting a review

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
