### PR TITLE
fix: always display homepage in page management

### DIFF
--- a/apps/web/components/PagesView/PagesItem.vue
+++ b/apps/web/components/PagesView/PagesItem.vue
@@ -10,8 +10,8 @@
         <SfIconExpandLess v-else />
       </span>
       <router-link v-if="!isTablet" :to="pagePath" class="flex-1 overflow-hidden whitespace-nowrap overflow-ellipsis">
-        <span v-if="item.details[0].name === 'Homepage'">
-          <SfIconHome class="w-4 h-4 mr-2" />
+        <span v-if="props.icon">
+          <component :is="icon" class="w-4 h-4 mr-2" />
         </span>
         {{ item.details[0].name }}
       </router-link>
@@ -21,8 +21,8 @@
         class="flex-1 overflow-hidden whitespace-nowrap overflow-ellipsis cursor-pointer"
         @click="handleSettingsClick"
       >
-        <span v-if="item.details[0].name === 'Homepage'">
-          <SfIconHome class="w-4 h-4 mr-2" />
+        <span v-if="props.icon">
+          <component :is="icon" class="w-4 h-4 mr-2" />
         </span>
         {{ item.details[0].name }}
       </span>
@@ -37,6 +37,7 @@
           <SfIconError viewBox="0 0 24 24" class="w-5 h-5" />
         </SfTooltip>
         <SfIconBase
+          v-if="!props.hideSettings"
           size="base"
           viewBox="0 0 24 24"
           class="text-primary-900 transition-opacity duration-200"
@@ -78,7 +79,6 @@
 </template>
 <script setup lang="ts">
 import {
-  SfIconHome,
   SfIconExpandMore,
   SfIconExpandLess,
   SfIconError,
@@ -86,7 +86,7 @@ import {
   SfLoaderCircular,
   SfIconBase,
 } from '@storefront-ui/vue';
-import type { CategoryEntry } from '@plentymarkets/shop-api';
+import type { PagesItemProps } from './types';
 import { gearPath } from 'assets/icons/paths/gear';
 const { isCategoryDirty } = useCategorySettingsCollection();
 const { usePaginatedChildren } = useCategoriesSearch();
@@ -95,10 +95,9 @@ const { getCategoryId, setCategoryId, setParentName, setPageType, setPageHasChil
 const viewport = useViewport();
 const isTablet = computed(() => viewport.isLessThan('lg') && viewport.isGreaterThan('sm'));
 
-const { item, parentId } = defineProps<{
-  item: CategoryEntry;
-  parentId: number | undefined;
-}>();
+const props = defineProps<PagesItemProps>();
+const item = props.item;
+
 const pagePath = computed(() => {
   const firstSlashIndex = item.details[0]?.previewUrl?.indexOf('/', 8) ?? -1;
   return firstSlashIndex !== -1 ? item.details[0]?.previewUrl?.slice(firstSlashIndex) ?? '/' : '/';
@@ -126,7 +125,7 @@ const handleSettingsClick = () => {
   openSettingsMenu(item.id, item.type);
   setCategoryId({
     id: item.id,
-    parentId: parentId,
+    parentId: props.parentId,
     name: item.details[0].name,
     path: item.details[0].nameUrl,
     level: item.level,

--- a/apps/web/components/PagesView/PagesView.vue
+++ b/apps/web/components/PagesView/PagesView.vue
@@ -53,6 +53,7 @@
 
         <div :class="['mb-6 mt-4 overflow-auto', limitAccordionHeight ? 'max-h-[400px]' : 'max-h-[500px]']">
           <ul class="rounded-lg" @scroll="(e) => handleScroll(e, 'content')">
+            <PagesItem :item="homepageItem" :parent-id="undefined" :icon="SfIconHome" :hide-settings="true" />
             <PagesItem v-for="item in contentItems" :key="item.id" :item="item" :parent-id="item.id" />
             <li v-if="loadingContent" class="flex justify-center items-center py-4">
               <SfLoaderCircular size="sm" />
@@ -88,7 +89,8 @@
 
 <script setup lang="ts">
 import PagesItem from '~/components/PagesView/PagesItem.vue';
-import { SfIconClose, SfIconHelp, SfTooltip, SfIconAdd, SfLoaderCircular } from '@storefront-ui/vue';
+import { SfIconClose, SfIconHelp, SfTooltip, SfIconAdd, SfIconHome, SfLoaderCircular } from '@storefront-ui/vue';
+import type { CategoryEntry } from '@plentymarkets/shop-api';
 const { locale } = useI18n();
 
 const { closeDrawer, togglePageModal, settingsCategory } = useSiteConfiguration();
@@ -130,5 +132,48 @@ const openHelpPage = () => {
 
   const targetUrl = urls[locale.value] ?? urls['en'] ?? null;
   if (targetUrl) window.open(targetUrl, '_blank');
+};
+
+const homepageItem: CategoryEntry = {
+  clients: [],
+  details: [
+    {
+      canonicalLink: '/',
+      categoryId: '0',
+      description: '',
+      description2: '',
+      fulltext: '',
+      image: null,
+      image2: null,
+      image2Path: null,
+      imagePath: null,
+      itemListView: '',
+      lang: locale.value,
+      metaDescription: '',
+      metaKeywords: '',
+      metaRobots: 'index, follow',
+      metaTitle: 'Homepage',
+      name: 'Homepage',
+      nameUrl: '/',
+      pageView: 'homepage',
+      plenty_category_details_image_path: '',
+      plenty_category_details_image2_path: '',
+      plentyId: 0,
+      position: '0',
+      shortDescription: '',
+      singleItemView: '',
+      updatedAt: '',
+      updatedBy: '',
+    },
+  ],
+  hasChildren: false,
+  id: 0,
+  level: 1,
+  linklist: '',
+  parentCategoryId: 0,
+  right: 'ALL',
+  sitemap: 'Y',
+  type: 'immutable',
+  isLinkedToWebstore: true,
 };
 </script>

--- a/apps/web/components/PagesView/types.ts
+++ b/apps/web/components/PagesView/types.ts
@@ -1,3 +1,11 @@
+import type { CategoryEntry } from '@plentymarkets/shop-api';
+
+export interface PagesItemProps {
+  item: CategoryEntry;
+  parentId: number | undefined;
+  icon?: Component;
+  hideSettings?: boolean;
+}
 export interface MenuItemType {
   id: number;
   parentId?: number;

--- a/apps/web/composables/usePages/usePages.ts
+++ b/apps/web/composables/usePages/usePages.ts
@@ -1,12 +1,12 @@
 import type { CategoryTreeItem } from '~/composables/usePages/types';
 
 export const usePages = async () => {
-  const { t, locale } = useI18n();
+  const { locale } = useI18n();
   const { data } = useCategoryTree();
 
   const pages = useState<Page[]>('pages', () => []);
   const transformCategoryTreeToPages = () => {
-    const transformData = (data: CategoryTreeItem[], parentPath = '', isRoot = true): Page[] => {
+    const transformData = (data: CategoryTreeItem[], parentPath = ''): Page[] => {
       const transformedData = data
         .map((item: CategoryTreeItem) => {
           if (!item.details || item.details.length === 0) {
@@ -15,7 +15,7 @@ export const usePages = async () => {
 
           const currentPath = `${parentPath}/${item.details[0].nameUrl}`;
 
-          const children = item.children ? transformData(item.children, currentPath, false) : undefined;
+          const children = item.children ? transformData(item.children, currentPath) : undefined;
 
           return {
             id: item.id,
@@ -35,25 +35,6 @@ export const usePages = async () => {
           };
         })
         .filter(Boolean);
-
-      if (isRoot && !transformedData.some((page) => page && page.name === 'Homepage')) {
-        transformedData.unshift({
-          id: 1,
-          name: t('homepage.title'),
-          path: '/',
-          children: undefined,
-          type: 'content',
-          right: 'all',
-          parentCategoryId: '',
-          sitemap: '',
-          linklist: '',
-          canonicalLink: '',
-          position: '',
-          metaDescription: '',
-          metaKeywords: '',
-          metaRobots: '',
-        });
-      }
 
       return transformedData as {
         id: number;


### PR DESCRIPTION
## Why:

Closes: [AB#159870](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/159870)

## Describe your changes

- Statically inserts the homepage.
- Extends `PagesItem` API to inject homepage attributes instead of defining exceptions within the component.

## Checklist before requesting a review

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
