### PR TITLE
ci: set timeout for integration jobs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   meta:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Assign author to PR
         if: github.event.action == 'opened'
@@ -40,6 +41,7 @@ jobs:
           apply-changes: true
   fitness-compliance:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: meta
     steps:
       - uses: actions/checkout@v4
@@ -62,6 +64,7 @@ jobs:
           .
   fitness-code-quality:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node
@@ -74,6 +77,7 @@ jobs:
         run: npm run lint
   test-unit:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node
@@ -88,6 +92,7 @@ jobs:
           working-directory: './apps/web/'
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node
@@ -118,6 +123,7 @@ jobs:
           path: build.tar.gz
   test-e2e-stable:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: build
     steps:
       - uses: actions/checkout@v4
@@ -158,6 +164,7 @@ jobs:
           if-no-files-found: ignore
   test-e2e-checkout:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: build
     steps:
       - uses: actions/checkout@v4
@@ -195,6 +202,7 @@ jobs:
           if-no-files-found: ignore
   test-e2e-editor:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: build
     steps:
       - uses: actions/checkout@v4
@@ -233,6 +241,7 @@ jobs:
           if-no-files-found: ignore
   test-e2e-flakey:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: build
     steps:
       - uses: actions/checkout@v4
@@ -270,6 +279,7 @@ jobs:
           if-no-files-found: ignore
   fitness-web-vitals-mobile:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: build
     steps:
       - uses: actions/checkout@v4
@@ -297,6 +307,7 @@ jobs:
           NUXT_PUBLIC_CONFIG_ID: 1
   fitness-web-vitals-desktop:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: build
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Why:

Cancel jobs automatically if they run significantly longer than expected.

## Describe your changes

- 5 minutes for short-running jobs
- 15 minutes for long-running jobs

<img width="704" alt="image" src="https://github.com/user-attachments/assets/4f1d3964-119a-47ec-af84-69c9c7b5e2b6" />

## Checklist before requesting a review

- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
