### PR TITLE
fix: configuration key for header bg color

### DIFF
--- a/apps/web/composables/useSiteConfiguration/useSiteConfiguration.ts
+++ b/apps/web/composables/useSiteConfiguration/useSiteConfiguration.ts
@@ -246,7 +246,7 @@ export const useSiteConfiguration: UseSiteConfigurationReturn = () => {
         value: state.value.iconColor,
       },
       {
-        key: 'iconBackgroundColor',
+        key: 'headerBackgroundColor',
         value: state.value.headerBackgroundColor,
       },
     ];


### PR DESCRIPTION
## Why:

Stored header background value isn't read.

## Describe your changes

- Aligns the configuration key between Nuxt config and save map.

## Checklist before requesting a review

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
