### PR TITLE
fix: unable to add page in non-default language

### DIFF
--- a/apps/web/components/PagesView/PagesView.vue
+++ b/apps/web/components/PagesView/PagesView.vue
@@ -13,7 +13,7 @@
         </button>
       </header>
 
-      <div class="mx-4 mb-4 mt-4">
+      <div v-if="isDefaultLocale" class="mx-4 mb-4 mt-4">
         <button
           type="button"
           data-testid="add-page-btn"
@@ -22,6 +22,25 @@
         >
           <SfIconAdd /> Add Page
         </button>
+      </div>
+
+      <div v-else class="mx-4 mb-4 mt-4">
+        <SfTooltip
+          label="You can only add pages in the default language of your shop."
+          placement="right"
+          :show-arrow="true"
+          class="flex"
+        >
+          <button
+            type="button"
+            data-testid="add-page-btn"
+            class="border border-editor-button w-full py-1 rounded-md flex align-center justify-center text-editor-button opacity-40 cursor-not-allowed"
+            disabled="true"
+            @click="null"
+          >
+            <SfIconAdd /> Add Page
+          </button>
+        </SfTooltip>
       </div>
 
       <div class="mx-4 mb-4 mt-4">
@@ -106,6 +125,8 @@ const { contentItems, itemItems, loadingContent, loadingItem, fetchCategories } 
 
 const contentPagesOpen = ref(false);
 const productPagesOpen = ref(false);
+
+const isDefaultLocale = computed(() => locale.value === defaultLocale);
 
 const limitAccordionHeight = computed(() => contentPagesOpen.value && productPagesOpen.value);
 

--- a/apps/web/composables/useAddPage/useAddPage.ts
+++ b/apps/web/composables/useAddPage/useAddPage.ts
@@ -148,6 +148,11 @@ export const useAddPageModal = () => {
   const [pageName, pageNameAttributes] = defineField('pageName');
 
   const getLabel = (option: CategoryEntry) => {
+    if (!categoryEntryGetters.getDetails(option)[0]) {
+      const categoryId = categoryEntryGetters.getId(option);
+      return `ID: ${categoryId}`;
+    }
+
     return categoryEntryGetters.getDetails(option)[0].name;
   };
 


### PR DESCRIPTION
## Why:

Closes: [AB#164256](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/164256)

## Describe your changes

- Keeps the **Add page** window responsive by using the category ID as fallback, in case there are no details for a category in the current language.
- Disables the **Add page** button in non-default languages, including am explanatory tooltip.

<img width="714" alt="image" src="https://github.com/user-attachments/assets/60eaf899-0caf-4a96-aa0b-acc85699a895" />

## Checklist before requesting a review

- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
