### PR TITLE
fix: revert pt class because it breaks the spacing for smaller screens

### DIFF
--- a/apps/web/components/PagesView/PagesView.vue
+++ b/apps/web/components/PagesView/PagesView.vue
@@ -61,7 +61,7 @@
       </div>
       <div class="mx-4 mt-4 mb-4 flex items-start gap-2 text-sm text-neutral-600">
         <SfIconWarning class="mt-0.5 shrink-0 text-yellow-500" />
-        <span class="pt-1 italic"> Changes to page settings are only reflected on reload. </span>
+        <span class="italic"> Changes to page settings are only reflected on reload. </span>
       </div>
 
       <UiAccordionItem


### PR DESCRIPTION
Reverts plentymarkets/plentyshop-pwa#1521