### PR TITLE
ci: fix e2e test missing config id header

### DIFF
--- a/apps/web/__tests__/support/commands.ts
+++ b/apps/web/__tests__/support/commands.ts
@@ -79,7 +79,16 @@ Cypress.Commands.add(
       basketItemOrderParams,
     };
 
-    cy.request('POST', 'http://localhost:8181/plentysystems/doAddCartItem', payload);
+    const configID = Cypress.env('CONFIG_ID') ?? '';
+
+    cy.request({
+      method: 'POST',
+      url: 'http://localhost:8181/plentysystems/doAddCartItem',
+      headers: {
+        'x-config-id': configID
+      },
+      body: payload
+    });
   },
 );
 

--- a/apps/web/__tests__/support/commands.ts
+++ b/apps/web/__tests__/support/commands.ts
@@ -85,9 +85,9 @@ Cypress.Commands.add(
       method: 'POST',
       url: 'http://localhost:8181/plentysystems/doAddCartItem',
       headers: {
-        'x-config-id': configID
+        'x-config-id': configID,
       },
-      body: payload
+      body: payload,
     });
   },
 );

--- a/apps/web/cypress.config.ts
+++ b/apps/web/cypress.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     POST_CODE_VALIDATION_COUNTRY: 'United Kingdom',
     E2E_TEST_PAYPAL_EMAIL: process.env.E2E_TEST_PAYPAL_EMAIL || '',
     E2E_TEST_PAYPAL_PASSWORD: process.env.E2E_TEST_PAYPAL_PASSWORD || '',
+    CONFIG_ID: process.env.CONFIG_ID || '1',
   },
   e2e: {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
## Why:

Closes: #ID
[AB#171713](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/171713)

## Describe your changes

## Checklist before requesting a review

- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
