### PR TITLE
fix: build failure if default language isn't en/de

### DIFF
--- a/apps/web/build/configurator/AppConfigurator.ts
+++ b/apps/web/build/configurator/AppConfigurator.ts
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv';
 import path, { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { rmSync, readFileSync } from 'node:fs';
+import { rmSync } from 'node:fs';
 import type { Languages } from './types';
 import type { Writer } from '../writers/types';
 import type { Logger } from '../logs/types';
@@ -31,15 +31,36 @@ export class AppConfigurator {
       this.writer.writeMissing(fileData, languageFile);
 
       const tsFilePath = path.resolve(languageFilesPath, `${language}.ts`);
-      const tsFileContent = this.getTsFileContent(languages.default);
+      const tsFileContent = this.getTsFileContent();
 
       this.writer.writeMissing(tsFileContent, tsFilePath);
     });
   }
 
-  private getTsFileContent(language: string): string {
-    const filePath = path.resolve(__dirname, `../../i18n/lang/${language}.ts`);
-    return readFileSync(filePath, 'utf-8');
+  private getTsFileContent(): string {
+    return `import { defineI18nLocale } from '#i18n';
+    const localeFiles = import.meta.glob('./*.json', { eager: true, import: 'default' });
+    
+    export default defineI18nLocale(async (locale) => {
+      const config = useRuntimeConfig().public;
+      let remoteTranslations = {};
+    
+      const defaultLocale = localeFiles[\`./\${locale}.json\`] ?? {};
+    
+      if (config.fetchDynamicTranslations) {
+        const { data, fetchTranslations } = useTranslations();
+    
+        await fetchTranslations(locale);
+    
+        remoteTranslations = JSON.parse(data?.value) || {};
+      }
+    
+      return {
+        ...defaultLocale,
+        ...remoteTranslations,
+      };
+    });
+    `;
   }
 
   private cleanUpInactiveLanguages(languages: Languages, languageFilesPath: string) {


### PR DESCRIPTION
## Why:

Closes: [AB#172296](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/172296)

## Describe your changes

- I18n requires language files, one JSON and one TS in our setup
- The build tries to create language files if they don't yet exist
- To create the TS file, the build fetches contents from the default language's file
- If the default language isn't English or German, there's no file to draw content from
- This change moves the file contents, so that no particular language is required anymore

## Checklist before requesting a review

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
