### PR TITLE
ci: add cypress-external to turbo

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -38,6 +38,9 @@
     "test:cypress-checkout": {
       "cache": false
     },
+    "test:cypress-external": {
+      "cache": false
+    },
     "test:cypress-feature": {
       "cache": false
     },


### PR DESCRIPTION
## Why:

Turbo task was missing, leading to a CI failure.

## Describe your changes

- Adds `test:cypress-external` task to turbo config

## Checklist before requesting a review

- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
