### PR TITLE
fix: call getBlocks on language switch

### DIFF
--- a/apps/web/__tests__/support/pageObjects/EditorObject.ts
+++ b/apps/web/__tests__/support/pageObjects/EditorObject.ts
@@ -100,19 +100,19 @@ export class EditorObject extends PageObject {
   }
 
   blockIsBanner(el: JQuery<HTMLElement>) {
-    return el[0].innerHTML.includes('banner-image');
+    return el[0]?.innerHTML.includes('banner-image');
   }
 
-  isMultiGrid(el: JQuery<HTMLElement>): boolean {
-    return el[0].innerHTML.includes('multi-grid-structure');
+  isMultiGrid(el: JQuery<HTMLElement>) {
+    return el[0]?.innerHTML.includes('multi-grid-structure');
   }
 
-  isInnerBlock(el: JQuery<HTMLElement>): boolean {
-    return el[0].innerHTML.includes('multi-grid-structure') || false;
+  isInnerBlock(el: JQuery<HTMLElement>) {
+    return el[0]?.innerHTML.includes('multi-grid-structure');
   }
 
   blockIsNewsletter(el: JQuery<HTMLElement>) {
-    return el[0].innerHTML.includes('newsletter-block');
+    return el[0]?.innerHTML.includes('newsletter-block');
   }
 
   blockIsFooter(el: HTMLElement) {
@@ -319,7 +319,10 @@ export class EditorObject extends PageObject {
   }
 
   assertDefaultBlockOrder() {
-    this.blockWrappers.first().should('contain.text', 'Feel the music').next().should('contain.text', 'Discover Tech');
+    this.blockWrappers.then(($blocks) => {
+      cy.wrap($blocks.eq(0)).should('contain.text', 'Feel the music');
+      cy.wrap($blocks.eq(1)).should('contain.text', 'Discover Tech');
+    });
   }
 
   moveBlock() {
@@ -329,7 +332,10 @@ export class EditorObject extends PageObject {
   }
 
   assertChangedBlockOrder() {
-    this.blockWrappers.first().should('contain.text', 'Discover Tech').next().should('contain.text', 'Feel the music');
+    this.blockWrappers.then(($blocks) => {
+      cy.wrap($blocks.eq(0)).should('contain.text', 'Discover Tech');
+      cy.wrap($blocks.eq(1)).should('contain.text', 'Feel the music');
+    });
   }
 
   checkWrapperSpacings() {

--- a/apps/web/app/composables/useCategoryTemplate/useCategoryTemplate.ts
+++ b/apps/web/app/composables/useCategoryTemplate/useCategoryTemplate.ts
@@ -51,9 +51,10 @@ export const useCategoryTemplate: UseCategoryTemplateReturn = (blocks?: string) 
   const getBlocksServer: GetBlocks = async (identifier, type, blocks?) => {
     state.value.loading = true;
 
+    const { locale } = useI18n();
     const { data: productsCatalog } = useProducts();
 
-    const { data, error } = await useAsyncData(`${type}-${identifier}-${blocks}`, () =>
+    const { data, error } = await useAsyncData(`${locale.value}-${type}-${identifier}-${blocks}`, () =>
       useSdk().plentysystems.getBlocks({ identifier, type, blocks }),
     );
 
@@ -87,6 +88,7 @@ export const useCategoryTemplate: UseCategoryTemplateReturn = (blocks?: string) 
 
   const getBlocks: GetBlocks = async (identifier, type, blocks?) => {
     state.value.loading = true;
+
     const { data: productsCatalog } = useProducts();
 
     const response = await useSdk().plentysystems.getBlocks({ identifier, type, blocks });


### PR DESCRIPTION
## Why:

- Page content doesn't get refetched anymore when switching languages.
- Probably related to how Nuxt 4 [changed caching](https://nuxt.com/docs/4.x/getting-started/upgrade#singleton-data-fetching-layer) of `useAsyncData`

## Describe your changes

- Adds locale to `getBlocks` server call identifier.

## Checklist before requesting a review

- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
