### PR TITLE
fix: max file size hint in image upload

### DIFF
--- a/apps/web/app/components/ui/ImageUpload/ImageUpload.vue
+++ b/apps/web/app/components/ui/ImageUpload/ImageUpload.vue
@@ -7,10 +7,10 @@
   >
     <SfIconUpload size="2xl" class="mb-2" />
     <p>
-      Drag file here or
-      <span class="text-green-600 underline"> click to select file</span>
+      {{ getEditorTranslation('imageUpload.dragFile') }}
+      <span class="text-green-600 underline"> {{ getEditorTranslation('imageUpload.selectFile') }}</span>
     </p>
-    <p class="text-sm text-gray-400 mt-1">Maximum upload file size 512MB</p>
+    <p class="text-sm text-gray-400 mt-1">{{ getEditorTranslation('imageUpload.maxFileSize') }}</p>
     <input ref="fileInput" type="file" class="hidden" :accept="accept" @change="handleFileChange" />
   </div>
 </template>
@@ -36,3 +36,22 @@ const handleFileChange = makeHandleFileChange((file) => emit('file-selected', fi
 
 const handleDrop = makeHandleDrop((file) => emit('file-selected', file), notifyInvalid);
 </script>
+
+<i18n lang="json">
+{
+  "en": {
+    "imageUpload": {
+      "dragFile": "Drag file here or",
+      "selectFile": "click to select file",
+      "maxFileSize": "Maximum upload file size is 100 MB"
+    }
+  },
+  "de": {
+    "imageUpload": {
+      "invalidFileType": "Drag file here or",
+      "selectFile": "click to select file",
+      "maxFileSize": "Maximum upload file size is 100 MB"
+    }
+  }
+}
+</i18n>


### PR DESCRIPTION
## Why:

Closes: [AB#177902](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/177902)

## Describe your changes

- Updates text on image upload to correct upload limit (100 MB)

## Checklist before requesting a review

- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
