### PR TITLE
chore: fix dry run condition for release step

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -191,7 +191,7 @@ jobs:
           cat release_notes.md
 
       - name: Create release
-        if: ${{ github.event.inputs.dryRun == 'false' }}
+        if: github.event.inputs.dryRun != 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
           NEW_VERSION: v${{ steps.version.outputs.new }}


### PR DESCRIPTION
- `input` is undefined when triggered via cron