### PR TITLE
fix: dynamic import paths for Nuxt modules

### DIFF
--- a/apps/web/app/utils/blocks-imports.ts
+++ b/apps/web/app/utils/blocks-imports.ts
@@ -6,7 +6,7 @@ const customerBlocks = import.meta.glob('/node_modules/*/runtime/components/bloc
   import: 'default',
 }) as Record<string, Loader>;
 
-const nuxtModuleBlocks = import.meta.glob('/modules/*/runtime/components/blocks/**/*.vue', {
+const nuxtModuleBlocks = import.meta.glob('~~/modules/*/runtime/components/blocks/**/*.vue', {
   import: 'default',
 }) as Record<string, Loader>;
 

--- a/apps/web/app/utils/settings-groups-imports.ts
+++ b/apps/web/app/utils/settings-groups-imports.ts
@@ -8,7 +8,7 @@ const customer = import.meta.glob('/node_modules/*/runtime/components/settings/*
   import: 'default',
 }) as Record<string, Loader>;
 
-const nuxtModules = import.meta.glob('/modules/*/runtime/components/settings/**/*.vue', {
+const nuxtModules = import.meta.glob('~~/modules/*/runtime/components/settings/**/*.vue', {
   import: 'default',
 }) as Record<string, Loader>;
 

--- a/apps/web/app/utils/settings-translations-imports.ts
+++ b/apps/web/app/utils/settings-translations-imports.ts
@@ -4,7 +4,7 @@ const localeFilesCustomer = import.meta.glob('/node_modules/*/runtime/components
   eager: true,
   import: 'default',
 }) as Messages;
-const localeFilesNuxtModules = import.meta.glob('/modules/*/runtime/components/settings/**/lang.json', {
+const localeFilesNuxtModules = import.meta.glob('~~/modules/*/runtime/components/settings/**/lang.json', {
   eager: true,
   import: 'default',
 }) as Messages;

--- a/apps/web/app/utils/triggers-imports.ts
+++ b/apps/web/app/utils/triggers-imports.ts
@@ -6,7 +6,7 @@ const customerTriggers = import.meta.glob('/node_modules/*/runtime/components/**
   import: 'default',
 }) as Record<string, Loader>;
 
-const nuxtModuleTriggers = import.meta.glob('/modules/*/runtime/components/**/settings/*/*ToolbarTrigger.vue', {
+const nuxtModuleTriggers = import.meta.glob('~~/modules/*/runtime/components/**/settings/*/*ToolbarTrigger.vue', {
   import: 'default',
 }) as Record<string, Loader>;
 


### PR DESCRIPTION
## Why:

Closes: [AB#178473](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/178473)

## Describe your changes

- Updates paths for dynamic imports to read from root directory
- Addresses changed directory structure introduced in Nuxt 4

## Checklist before requesting a review

- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
