### PR TITLE
fix: default footer couldn't be edited

### DIFF
--- a/apps/web/app/composables/useFooter/__tests__/useFooter.spec.ts
+++ b/apps/web/app/composables/useFooter/__tests__/useFooter.spec.ts
@@ -187,10 +187,11 @@ describe('useFooter', () => {
         setupApiResponse(apiResponse);
 
         const { fetchFooterSettings } = useFooter();
+        const { $i18n } = useNuxtApp();
 
         const result = await fetchFooterSettings();
 
-        expect(useAsyncData).toHaveBeenCalledWith('footer-settings', expect.any(Function));
+        expect(useAsyncData).toHaveBeenCalledWith(`footer-settings-${$i18n.locale}`, expect.any(Function));
         expect(result).toEqual(mockFooterData);
         expect(mockStateRef.value).toBe(mockFooterData);
       });

--- a/apps/web/app/composables/useFooter/useFooter.ts
+++ b/apps/web/app/composables/useFooter/useFooter.ts
@@ -25,8 +25,10 @@ export const useFooter = () => {
       return footerCache.value;
     }
 
+    const { $i18n } = useNuxtApp();
+
     try {
-      const { data } = await useAsyncData('footer-settings', () =>
+      const { data } = await useAsyncData(`footer-settings-${$i18n.locale}`, () =>
         useSdk().plentysystems.getBlocks({
           identifier: 'index',
           type: 'immutable',

--- a/apps/web/app/utils/footerHelper.ts
+++ b/apps/web/app/utils/footerHelper.ts
@@ -1,7 +1,7 @@
 import type { FooterSettings, FooterSwitchDefinition, AddFooterBlock } from '~/components/blocks/Footer/types';
 import { v4 as uuid } from 'uuid';
 
-export const FOOTER_SWITCH_DEFINITIONS: readonly FooterSwitchDefinition[] = [
+export const FOOTER_SWITCH_DEFINITIONS: FooterSwitchDefinition[] = [
   {
     columnGroup: 'legal',
     key: 'showTermsAndConditions',


### PR DESCRIPTION
## Why:

Closes: [AB#178676](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/178676)

## Describe your changes

- Removes readonly from default toggles
- Adds locale to footer data identifier

## Checklist before requesting a review

- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
