### PR TITLE
fix: column width in DE homepage default template

### DIFF
--- a/apps/web/app/composables/useCategoryTemplate/homepageTemplateDataDe.json
+++ b/apps/web/app/composables/useCategoryTemplate/homepageTemplateDataDe.json
@@ -128,7 +128,7 @@
       "isGlobalTemplate": false
     },
     "configuration": {
-      "columnWidths": [4, 4]
+      "columnWidths": [6, 6]
     },
     "content": [
       {


### PR DESCRIPTION
## Why:

Now that the MultiGrid widget actively uses the column width setting to determine the width of individual columns, the grid contents are misaligned on the German default homepage. This also affects any shops that stored the misconfiguration in the database.

Users can rectify a misconfiguration stored in the DB by using the multi-grid settings and re-saving the layout.

## Describe your changes

- Changes the column widths in the German homepage template from `[4, 4]` to `[6, 6]`.
- Neither the English template nor the blocks list seems to be affected.

## Checklist before requesting a review

- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
