### PR TITLE
fix: editing of top-level blocks on content categories

### DIFF
--- a/apps/web/app/pages/[...slug].vue
+++ b/apps/web/app/pages/[...slug].vue
@@ -67,6 +67,7 @@ definePageMeta({
 
 watchEffect(() => {
   route.meta.isBlockified = isBlockified.value;
+  route.meta.identifier = productsCatalog.value.category?.type === 'content' ? productsCatalog.value.category?.id : 0;
 });
 
 const breadcrumbs = computed(() => {

--- a/apps/web/app/pages/[...slug].vue
+++ b/apps/web/app/pages/[...slug].vue
@@ -65,11 +65,6 @@ definePageMeta({
   identifier: 0,
 });
 
-watchEffect(() => {
-  route.meta.isBlockified = isBlockified.value;
-  route.meta.identifier = productsCatalog.value.category?.type === 'content' ? productsCatalog.value.category?.id : 0;
-});
-
 const breadcrumbs = computed(() => {
   if (productsCatalog.value.category) {
     const breadcrumb = categoryTreeGetters.generateBreadcrumbFromCategory(
@@ -150,6 +145,11 @@ watch(
     await handleQueryUpdate().then(() => setCategoriesPageMeta(productsCatalog.value, getFacetsFromURL()));
   },
 );
+
+watchEffect(() => {
+  route.meta.isBlockified = isBlockified.value;
+  route.meta.identifier = productsCatalog.value.category?.type === 'content' ? productsCatalog.value.category?.id : 0;
+});
 
 useHead({
   title: headTitle,


### PR DESCRIPTION
## Why:

Merchants can't edit top-level blocks.

## Describe your changes

- Sets the category template state for content categories depending on the category ID.

## Checklist before requesting a review

- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
