### PR TITLE
chore: indicate that list of global fonts can be searched

### DIFF
--- a/apps/web/app/components/settings/branding-and-design/design/1.fonts/GlobalFonts.vue
+++ b/apps/web/app/components/settings/branding-and-design/design/1.fonts/GlobalFonts.vue
@@ -58,14 +58,14 @@ const font = computed({
     "label": "Global fonts",
     "description": "⚠️ This setting will require a shop redeploy to take effect.",
     "tooltip": "Choose one Google Font for all texts. Fonts are served locally to ensure privacy compliance, with no live requests to Google.",
-    "placeholder": "Select a font",
+    "placeholder": "Search fonts...",
     "deselect-label": "Selected"
   },
   "de": {
     "label": "Global fonts",
     "description": "⚠️ This setting will require a shop redeploy to take effect.",
     "tooltip": "Choose one Google Font for all texts. Fonts are served locally to ensure privacy compliance, with no live requests to Google.",
-    "placeholder": "Select a font",
+    "placeholder": "Search fonts...",
     "deselect-label": "Selected"
   }
 }


### PR DESCRIPTION
## Why:

Some users can't find their font of choice in the global font setting.

The multi-select component only displays the first 1,000 entries of a given list by default. However, there are many more fonts available for selection, which the user can't access through scrolling. Increasing the limit to display all fonts makes the scroll bar very small, which creates a different type of usability issue.

With this change we check if changing the placeholder text is enough to clear up users' confusion or if further design adjustments are required.

## Describe your changes

- Updates multi-select placeholder text in global fonts setting to indicate searchability.

## Checklist before requesting a review

- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
