### PR TITLE
fix: aria-controls in carousel navigation

### DIFF
--- a/apps/web/app/components/blocks/structure/Carousel/Carousel.vue
+++ b/apps/web/app/components/blocks/structure/Carousel/Carousel.vue
@@ -40,7 +40,7 @@
       v-if="enableModules && handleArrows()"
       :key="`prev-${index}`"
       :class="`swiper-button-prev swiper-button-prev-${index}`"
-      aria-controls="carousel-{{index}}"
+      :aria-controls="`carousel-${index}`"
       :aria-label="t('homepage.banner.ariaLabelPreviousSlide')"
       :style="{ color: configuration.controls.color + ' !important' }"
     />
@@ -48,7 +48,7 @@
       v-if="enableModules && handleArrows()"
       :key="`next-${index}`"
       :class="`swiper-button-next swiper-button-next-${index}`"
-      aria-controls="carousel-{{index}}"
+      :aria-controls="`carousel-${index}`"
       :aria-label="t('homepage.banner.ariaLabelNextSlide')"
       :style="{ color: configuration.controls.color + ' !important' }"
     />


### PR DESCRIPTION
## Why:

Aria labels on carousel's previous/next navigation arrows don't interpret the index variable correctly.

## Describe your changes

- Fixes the binding of the aria controls.

## Checklist before requesting a review

- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
