### PR TITLE
fix: display EmptyGridBlock only when in edit mode

### DIFF
--- a/apps/web/app/components/blocks/structure/MultiGrid/EmptyGridBlock.vue
+++ b/apps/web/app/components/blocks/structure/MultiGrid/EmptyGridBlock.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="$isPreview" class="flex w-full">
+  <div v-if="$isPreview && disableActions" class="flex w-full">
     <div
       v-if="drawerOpen && isActiveColumn"
       data-testid="active-empty-multicolumn"
@@ -25,6 +25,7 @@ import { SfIconAdd } from '@storefront-ui/vue';
 import type { EmptyGridBlockProps } from '~/components/blocks/structure/MultiGrid/types';
 
 const { $isPreview } = useNuxtApp();
+const { disableActions } = useEditor();
 const props = defineProps<EmptyGridBlockProps>();
 const { multigridColumnUuid, updateMultigridColumnUuid, visiblePlaceholder } = useBlockManager();
 const { openDrawerWithView, drawerOpen } = useSiteConfiguration();


### PR DESCRIPTION
## Why:

Closes: [AB#180267](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/180267)

## Describe your changes

## Checklist before requesting a review

- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
