### PR TITLE
perf: improve lcp, fcp, and speed index

### DIFF
--- a/apps/web/app/app.vue
+++ b/apps/web/app/app.vue
@@ -131,3 +131,7 @@ const UnlinkCategoryModal = defineAsyncComponent(
   () => import('~/components/ui/UnlinkCategoryModal/UnlinkCategoryModal.vue'),
 );
 </script>
+
+<style lang="scss">
+@use '~/assets/style.scss';
+</style>

--- a/apps/web/app/error.vue
+++ b/apps/web/app/error.vue
@@ -67,3 +67,7 @@ await callOnce(async () => {
   await setInitialDataSSR();
 });
 </script>
+
+<style lang="scss">
+@use '~/assets/style.scss';
+</style>

--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -73,7 +73,6 @@ export default defineNuxtConfig({
       },
     },
   },
-  css: ['~/assets/style.scss'],
   // TODO: build is consistently failing because of this. check whether we need pre-render check.
   nitro: {
     prerender: {


### PR DESCRIPTION
## Why:

A diagnosis of page load performance has indicated room for improvement in First Contentful Paint, Largest Contentful Paint, and Speed Index. The biggest bottleneck was render blocking requests, specifically of `/_nuxt/entry.<hash>.css`, a file Nuxt automatically generates.

## Describe your changes

- Inlined global CSS in `app.vue`
- Removed `css` property in `nuxt.config.css`

In combination, these changes significantly improve the target metrics. The following screenshots are a before/after comparison from the same reference system:

<img width="961" height="265" alt="Screenshot 2025-11-14 at 08 57 36" src="https://github.com/user-attachments/assets/2367a3ce-cc5f-4db7-9aa7-a8dd929426d0" />
<img width="962" height="253" alt="Screenshot 2025-11-14 at 08 58 41" src="https://github.com/user-attachments/assets/7bd9682e-1ab5-454d-b61e-05fe156cffed" />

Comparing these two runs, the render blocking request time decreased from 350ms to 60ms.

**Important**: These are Desktop values. Mobile has seen gains as well, but there's more room for improvement on mobile devices.

### What hasn't worked

As noted above, the `entry.css` file is generated by Nuxt and our app isn't the only one struggling with it. The following changes were also tested, but ultimately discarded:

- Using the [nuxt-vitalizer](https://nuxt.com/modules/vitalizer) module
- Removing `entry.css` via a [build hook](https://nuxt.com/docs/4.x/getting-started/styling#lcp-advanced-optimizations)

While the vitalizer approach improved LCP as advertised, it had a negative impact on CLS, pushing the application from under 0.1 to over 1.0.

## Checklist before requesting a review

- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
