### PR TITLE
fix: banner block template misalignment

### DIFF
--- a/apps/web/public/_nuxt-plenty/editor/blocksLists.json
+++ b/apps/web/public/_nuxt-plenty/editor/blocksLists.json
@@ -343,7 +343,7 @@
                     "title": "h1 heading",
                     "htmlDescription": "Text that supports HTML formatting",
                     "textAlignment": "left",
-                    "justify": "bottom",
+                    "justify": "top",
                     "align": "right"
                   },
                   "button": {
@@ -374,7 +374,7 @@
                     "title": "h1 heading",
                     "htmlDescription": "Text that supports HTML formatting",
                     "textAlignment": "left",
-                    "justify": "bottom",
+                    "justify": "top",
                     "align": "right"
                   },
                   "button": {
@@ -417,7 +417,7 @@
                     "htmlDescription": "Text mit HTML-Formatierung",
                     "textAlignment": "left",
                     "justify": "top",
-                    "align": "left"
+                    "align": "right"
                   },
                   "button": {
                     "label": "Button",
@@ -863,7 +863,7 @@
                     "aspectRatio": "16 / 9"
                   },
                   "text": {
-                    "textOverlay": "Beispiel Overlay Text",
+                    "textOverlay": "Overlay Text",
                     "textOverlayColor": "#00ff00",
                     "textOverlayAlignY": "center",
                     "textOverlayAlignX": "center"
@@ -922,7 +922,7 @@
                     "aspectRatio": "16 / 9"
                   },
                   "text": {
-                    "textOverlay": "Beispiel Overlay Text",
+                    "textOverlay": "Overlay-Text",
                     "textOverlayColor": "#00ff00",
                     "textOverlayAlignY": "center",
                     "textOverlayAlignX": "center"


### PR DESCRIPTION
## Why:

Closes: [AB#180041](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/180041)

## Describe your changes

- Fixed the default text alignment of the banner block in German
- Fixed the default text justification of the banner block in English
- Removed German text from English Image + Text block

## Checklist before requesting a review

- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I've updated `docs/changelog/changelog_en.md` and `docs/changelog/changelog_de.md`. If I'm a non-German speaker, I've still updated the file with the English version as a placeholder.
