### PR TITLE
fix: empty page with fake data ignores global template

### DIFF
--- a/apps/web/app/utils/facets/fakeFacetCall.ts
+++ b/apps/web/app/utils/facets/fakeFacetCall.ts
@@ -210,8 +210,8 @@ export const facetMock = {
     ],
     languageUrls: {
       'x-default': '/living-room/armchair-stool/',
-      de: '/wohnzimmer/sessel-hocker/',
-      en: '/living-room/armchair-stool/',
+      de: '/',
+      en: '/',
     },
     pagination: {
       perPageOptions: [20, 40, 100],

--- a/apps/web/app/utils/handle-preview-products.ts
+++ b/apps/web/app/utils/handle-preview-products.ts
@@ -7,7 +7,8 @@ export const handlePreviewProducts = (state: Ref<UseProductsState>) => {
   const { $isPreview } = useNuxtApp();
 
   if (state.value.data.category.type === 'item' && $isPreview && state.value.data.products.length === 0) {
-    state.value.data = facetMock.data;
+    state.value.data = { ...state.value.data, facets: facetMock.data.facets };
+
     state.value.data.products = Array.from({ length: 8 }, (_, ind) => ({
       ...fakeProduct,
       texts: {

--- a/apps/web/app/utils/handle-preview-products.ts
+++ b/apps/web/app/utils/handle-preview-products.ts
@@ -8,7 +8,6 @@ export const handlePreviewProducts = (state: Ref<UseProductsState>) => {
 
   if (state.value.data.category.type === 'item' && $isPreview && state.value.data.products.length === 0) {
     state.value.data = { ...state.value.data, facets: facetMock.data.facets };
-
     state.value.data.products = Array.from({ length: 8 }, (_, ind) => ({
       ...fakeProduct,
       texts: {


### PR DESCRIPTION
## Issue:

Closes: [AB#180270](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/180270)

## Describe your changes

Used the spread operator instead of direct assignation so we don't lose the 'blocks' property from the getFacet calls 

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:
- ENABLE_CATEGORY_EDITING='1'

### Functionality

- [x] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [x] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
