### PR TITLE
perf: improve mobile page load performance

### DIFF
--- a/apps/web/app/assets/style.scss
+++ b/apps/web/app/assets/style.scss
@@ -37,16 +37,6 @@ apple-pay-button {
   --apple-pay-button-box-sizing: border-box;
 }
 
-.swiper-button-prev {
-  color: rgb(var(--colors-2-primary-500)) !important;
-  z-index: 0 !important;
-}
-
-.swiper-button-next {
-  color: rgb(var(--colors-2-primary-500)) !important;
-  z-index: 0 !important;
-}
-
 #google-pay-button {
   div {
     button {

--- a/apps/web/app/components/ui/ImageSelectorModal/ImageSelectorModal.vue
+++ b/apps/web/app/components/ui/ImageSelectorModal/ImageSelectorModal.vue
@@ -216,13 +216,3 @@ onBeforeUnmount(() => {
   revokeAllBlobUrls();
 });
 </script>
-
-<style>
-.v-field--prepended {
-  padding-inline-start: 0;
-}
-.fa-solid.fa-magnifying-glass {
-  --v-icon-size-multiplier: 0.55;
-  padding: 0 20px;
-}
-</style>

--- a/apps/web/app/components/ui/ImageTable/ImageTable.vue
+++ b/apps/web/app/components/ui/ImageTable/ImageTable.vue
@@ -1,16 +1,18 @@
 <template>
   <VCard flat>
-    <v-text-field
-      v-model="search"
-      density="compact"
-      label="Search"
-      prepend-inner-icon="fa-solid fa-magnifying-glass"
-      variant="solo-filled"
-      class="mb-5 border border-gray-300 rounded"
-      flat
-      hide-details
-      single-line
-    />
+    <div class="flex items-center gap-2 mb-5 border border-gray-300 rounded pr-2">
+      <v-text-field
+        v-model="search"
+        density="compact"
+        prepend-inner-icon="magnify"
+        label="Search file or path..."
+        variant="solo"
+        flat
+        hide-details
+        single-line
+      />
+      <SfIconSearch />
+    </div>
 
     <div v-if="loading" class="flex justify-center items-center min-h-[300px]">
       <SfLoaderCircular size="2xl" class="text-gray-400" />
@@ -50,7 +52,7 @@
 <script setup lang="ts">
 import { VCard, VTextField, VDataTable } from 'vuetify/components';
 import type { StorageObject } from '@plentymarkets/shop-api';
-import { SfLoaderCircular } from '@storefront-ui/vue';
+import { SfLoaderCircular, SfIconSearch } from '@storefront-ui/vue';
 
 const { data: items, loading, headers, bytesToMB, formatDate, getStorageMetadata } = useItemsTable();
 
@@ -138,13 +140,13 @@ const handleRowClick = (item: StorageObject) => {
   display: none !important;
 }
 
-.v-icon {
+/* .v-icon {
   --v-icon-size-multiplier: 0.55;
 }
 
 .v-btn--icon .v-icon {
   --v-icon-size-multiplier: 0.55;
-}
+} */
 
 .v-ripple__container {
   display: none !important;

--- a/apps/web/app/components/ui/ImageTable/ImageTable.vue
+++ b/apps/web/app/components/ui/ImageTable/ImageTable.vue
@@ -139,14 +139,6 @@ const handleRowClick = (item: StorageObject) => {
   display: none !important;
 }
 
-/* .v-icon {
-  --v-icon-size-multiplier: 0.55;
-}
-
-.v-btn--icon .v-icon {
-  --v-icon-size-multiplier: 0.55;
-} */
-
 .v-ripple__container {
   display: none !important;
 }

--- a/apps/web/app/components/ui/ImageTable/ImageTable.vue
+++ b/apps/web/app/components/ui/ImageTable/ImageTable.vue
@@ -1,17 +1,16 @@
 <template>
   <VCard flat>
-    <div class="flex items-center gap-2 mb-5 border border-gray-300 rounded pr-2">
+    <div class="flex items-center gap-2 mb-5 bg-gray-100 border border-gray-300 rounded pl-2">
+      <SfIconSearch />
       <v-text-field
         v-model="search"
         density="compact"
-        prepend-inner-icon="magnify"
         label="Search file or path..."
         variant="solo"
         flat
         hide-details
         single-line
       />
-      <SfIconSearch />
     </div>
 
     <div v-if="loading" class="flex justify-center items-center min-h-[300px]">

--- a/apps/web/app/configuration/tailwind.config.ts
+++ b/apps/web/app/configuration/tailwind.config.ts
@@ -22,6 +22,9 @@ export default {
         'display-2': {
           fontFamily: 'inherit',
         },
+        'display-3': {
+          fontFamily: 'inherit',
+        },
         'headline-1': {
           fontFamily: 'inherit',
         },

--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -64,10 +64,11 @@ export default defineNuxtConfig({
       ],
     },
     build: {
+      cssCodeSplit: true,
       rollupOptions: {
         output: {
           manualChunks: {
-            vuetify: ['vuetify'],
+            vuetify: ['vuetify', '@mdi/js'],
           },
         },
       },
@@ -268,6 +269,7 @@ export default defineNuxtConfig({
   fonts: {
     defaults: {
       weights: [300, 400, 500, 700],
+      preload: true,
     },
     assets: {
       prefix: '/_nuxt-plenty/fonts/',

--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -64,7 +64,6 @@ export default defineNuxtConfig({
       ],
     },
     build: {
-      // cssCodeSplit: true,
       rollupOptions: {
         output: {
           manualChunks: {

--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -64,7 +64,7 @@ export default defineNuxtConfig({
       ],
     },
     build: {
-      cssCodeSplit: true,
+      // cssCodeSplit: true,
       rollupOptions: {
         output: {
           manualChunks: {

--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -67,7 +67,7 @@ export default defineNuxtConfig({
       rollupOptions: {
         output: {
           manualChunks: {
-            vuetify: ['vuetify', '@fortawesome/fontawesome-free'],
+            vuetify: ['vuetify'],
           },
         },
       },
@@ -253,7 +253,7 @@ export default defineNuxtConfig({
     },
     vuetifyOptions: {
       icons: {
-        defaultSet: 'fa',
+        defaultSet: 'mdi-svg',
       },
     },
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,7 +32,6 @@
     "test:cypress-dev": "cypress open --e2e"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^7.1.0",
     "@nuxt/fonts": "^0.12.1",
     "@plentymarkets/tailwind-colors": "^1.0.1",
     "@vueuse/core": "^10.11.0",
@@ -41,6 +40,7 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
+    "@mdi/js": "7.4.47",
     "@nuxt/eslint": "^1.9.0",
     "@nuxt/image": "^1.11.0",
     "@nuxt/test-utils": "^3.20.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,7 +40,7 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "@mdi/js": "7.4.47",
+    "@mdi/js": "^7.4.47",
     "@nuxt/eslint": "^1.9.0",
     "@nuxt/image": "^1.11.0",
     "@nuxt/test-utils": "^3.20.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,6 @@
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@fortawesome/fontawesome-free": "^7.1.0",
         "@nuxt/fonts": "^0.12.1",
         "@plentymarkets/tailwind-colors": "^1.0.1",
         "@vueuse/core": "^10.11.0",
@@ -102,6 +101,7 @@
         "uuid": "^9.0.1"
       },
       "devDependencies": {
+        "@mdi/js": "7.4.47",
         "@nuxt/eslint": "^1.9.0",
         "@nuxt/image": "^1.11.0",
         "@nuxt/test-utils": "^3.20.1",
@@ -4088,15 +4088,6 @@
         "tslib": "^2.8.0"
       }
     },
-    "node_modules/@fortawesome/fontawesome-free": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.1.0.tgz",
-      "integrity": "sha512-+WxNld5ZCJHvPQCr/GnzCTVREyStrAJjisUPtUxG5ngDA8TMlPnKp6dddlTpai4+1GNmltAeuk1hJEkBohwZYA==",
-      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@gerrit0/mini-shiki": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.13.0.tgz",
@@ -5310,6 +5301,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@mdi/js": {
+      "version": "7.4.47",
+      "resolved": "https://registry.npmjs.org/@mdi/js/-/js-7.4.47.tgz",
+      "integrity": "sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@mdit-vue/plugin-component": {
       "version": "2.1.4",


### PR DESCRIPTION
## Issue:

A diagnosis of page load performance has flagged the Network Dependency Tree as a point for improvement. This indicator may affect First Contentful Paint, Largest Contentful Paint, Total Blocking Time, and Speed Index, most notably on mobile devices.

## Describe your changes

- Reduces the size of `entry.<hash>.css` from 50.20kb to 21.43kb on the reference system.
  - Swaps Font Awesome for Material Design Icon dependency. The former was included in the entry file, the latter is not. It's worth noting that we don't use any of the `mdi/svg` fonts either, but configuring an icon font is necessary because otherwise Vuetify loads them from JSDeliver.
  - Configures `fontFamily` inheritance for `display-3` font, which removes fallback fonts from the entry file.
- Removes unused `.swiper` styles.

### What hasn't worked

[Vite](https://vite.dev/config/build-options#build-csscodesplit) has an option called `bundle.cssCodeSplit`. Testing has revealed mixed results. In a vacuum it improved performance scores, but coupled with the other changes made, performance slightly decreases. There may be cases where activating this option is better.

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- None

### Functionality

- [x] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [x] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [x] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

In combination, these changes significantly improve the target metrics. The following screenshots are a before/after comparison from the same reference system:

<img width="962" height="254" alt="Screenshot 2025-11-21 at 15 25 15" src="https://github.com/user-attachments/assets/da9a1526-b708-4c0b-b335-ac180d51b79c" />

<img width="960" height="254" alt="Screenshot 2025-11-21 at 15 25 28" src="https://github.com/user-attachments/assets/c4a964db-48c6-423c-8fb6-efa4c5e8dea0" />

**Important**: These are Mobile values.

