### PR TITLE
fix: fake data notification only displays inside the editor

### DIFF
--- a/apps/web/app/composables/useEditModeNotification/__tests__/useEditModeNotification.spec.ts
+++ b/apps/web/app/composables/useEditModeNotification/__tests__/useEditModeNotification.spec.ts
@@ -5,6 +5,8 @@ import { useEditModeNotification } from '../useEditModeNotification';
 const send = vi.fn();
 
 mockNuxtImport('useNotification', () => () => ({ send }));
+mockNuxtImport('useNuxtApp', () => () => ({ $isPreview: true }));
+mockNuxtImport('useEditor', () => () => ({ disableActions: ref(false) }));
 
 describe('useEditModeNotification', () => {
   let disableActions: Ref<boolean>;

--- a/apps/web/app/utils/sendFakeDataNotification.ts
+++ b/apps/web/app/utils/sendFakeDataNotification.ts
@@ -1,3 +1,17 @@
+/**
+ * Sends a notification to inform users about example data in editor preview mode.
+ *
+ * This notification only appears when the application is running in PlentyONE editor
+ * preview mode ($isPreview is true). It informs users that fields without product data
+ * are displaying example data for editing purposes, and suggests switching to preview
+ * mode to view only real data.
+ *
+ * @example
+ * ```ts
+ * // Call when displaying fake/example data in the editor
+ * sendFakeDataNotification();
+ * ```
+ */
 export const sendFakeDataNotification = () => {
   const { $isPreview } = useNuxtApp();
   if (!$isPreview) return;

--- a/apps/web/app/utils/sendFakeDataNotification.ts
+++ b/apps/web/app/utils/sendFakeDataNotification.ts
@@ -1,4 +1,7 @@
 export const sendFakeDataNotification = () => {
+  const { $isPreview } = useNuxtApp();
+  if (!$isPreview) return;
+
   const { send } = useNotification();
   send({
     type: 'warning',


### PR DESCRIPTION
## Issue:

Follow-up: #2000 

## Describe your changes

- Fake data alert only displays inside the editor 

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

Tested in both 

I am using the $isPreview flag 

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
