### PR TITLE
fix: item data table review comments

### DIFF
--- a/apps/web/app/components/blocks/ItemData/ItemData.vue
+++ b/apps/web/app/components/blocks/ItemData/ItemData.vue
@@ -62,7 +62,7 @@ import { SfIconWarning } from '@storefront-ui/vue';
 const props = defineProps<{
   content: ItemDataContent;
 }>();
-const { t } = useI18n({});
+const { t } = useI18n();
 const { currentProduct } = useProducts();
 
 const { $isPreview } = useNuxtApp();

--- a/apps/web/app/components/blocks/ItemData/ItemData.vue
+++ b/apps/web/app/components/blocks/ItemData/ItemData.vue
@@ -62,9 +62,7 @@ import { SfIconWarning } from '@storefront-ui/vue';
 const props = defineProps<{
   content: ItemDataContent;
 }>();
-const { t } = useI18n({
-  useScope: 'local',
-});
+const { t } = useI18n({});
 const { currentProduct } = useProducts();
 
 const { $isPreview } = useNuxtApp();

--- a/apps/web/app/components/blocks/ItemData/ItemData.vue
+++ b/apps/web/app/components/blocks/ItemData/ItemData.vue
@@ -1,6 +1,6 @@
 <template>
   <div :style="inlineStyle" data-testid="item-data-block">
-    <div v-if="!hasTitle && noFieldsSelected" class="mx-4 mt-4 mb-4 flex items-start gap-2 text-sm text-neutral-600">
+    <div v-if="showNoDataMessage" class="mx-4 mt-4 mb-4 flex items-start gap-2 text-sm text-neutral-600">
       <SfIconWarning class="mt-0.5 shrink-0 text-yellow-500" />
       <span class="italic">{{ getEditorTranslation('no-data-to-show') }}</span>
     </div>
@@ -62,8 +62,14 @@ import { SfIconWarning } from '@storefront-ui/vue';
 const props = defineProps<{
   content: ItemDataContent;
 }>();
-
+const { t } = useI18n({
+  useScope: 'local',
+});
 const { currentProduct } = useProducts();
+
+const { $isPreview } = useNuxtApp();
+
+const { disableActions } = useEditor();
 
 const { fieldValues } = useItemDataTable(currentProduct as Ref<Product | null>);
 
@@ -101,6 +107,10 @@ const noFieldsSelected = computed(() => {
 
   return values.every((v) => !v);
 });
+
+const showNoDataMessage = computed(
+  () => $isPreview && disableActions.value && !hasTitle.value && noFieldsSelected.value,
+);
 
 const visibleRows = computed(() => {
   const order =

--- a/apps/web/app/components/blocks/ItemData/ItemData.vue
+++ b/apps/web/app/components/blocks/ItemData/ItemData.vue
@@ -71,8 +71,9 @@ const { $isPreview } = useNuxtApp();
 
 const { disableActions } = useEditor();
 
-const { fieldValues } = useItemDataTable(currentProduct as Ref<Product | null>);
-
+const { fieldValues } = useItemDataTable(currentProduct as Ref<Product | null>, {
+  t,
+});
 const fieldLabels = computed<ItemDataFieldLabels>(() => ({
   itemId: t('field-itemId'),
   condition: t('field-condition'),
@@ -137,8 +138,6 @@ const visibleRows = computed(() => {
 
 const hasRows = computed(() => visibleRows.value.length > 0);
 
-const isOpen = ref(!(props.content.layout?.initiallyCollapsed ?? false));
-
 const inlineStyle = computed(() => {
   const layout = props.content.layout;
   return {
@@ -149,11 +148,13 @@ const inlineStyle = computed(() => {
   };
 });
 
+const isOpen = ref(!(props.content.layout?.initiallyCollapsed ?? false));
+
 watch(
   () => props.content.layout?.initiallyCollapsed,
   (val) => {
     if (val === undefined) return;
-    isOpen.value = !val;
+    isOpen.value = !(val ?? false);
   },
 );
 </script>
@@ -182,24 +183,24 @@ watch(
     "no-data-to-show": "You haven’t selected any field to display. Please choose a field or remove this block."
   },
   "de": {
-    "field-itemId": "Item ID",
-    "field-condition": "Condition",
-    "field-externalVariationId": "External variation ID",
-    "field-model": "Model",
-    "field-manufacturer": "Manufacturer",
-    "field-manufacturingCountry": "Manufacturing country",
-    "field-content": "Content",
-    "field-grossWeight": "Gross weight",
-    "field-netWeight": "Net weight",
-    "field-dimensions": "Dimensions",
-    "field-customTariffNumber": "Custom tariff number",
-    "field-properties": "Properties",
-    "field-ageRating": "Age rating",
-    "single-item-age-restriction": " {age} and older",
-    "single-item-age-restriction-none": "No age restriction",
-    "single-item-age-restriction-not-flagged": "Not rated",
-    "single-item-age-restriction-not-required": "Not required",
-    "single-item-age-restriction-unknown": "Unknown",
+    "field-itemId": "Art.-ID",
+    "field-condition": "Zustand",
+    "field-externalVariationId": "Varianten-ID",
+    "field-model": "Modell",
+    "field-manufacturer": "Hersteller",
+    "field-manufacturingCountry": "Herstellungsland",
+    "field-content": "Inhalt",
+    "field-grossWeight": "Gewicht",
+    "field-netWeight": "Netto-Gewicht",
+    "field-dimensions": "Maße",
+    "field-customTariffNumber": "Zolltarifnummer",
+    "field-properties": "Eigenschaften",
+    "field-ageRating": "Altersfreigabe",
+    "single-item-age-restriction": "Ab {age} freigegeben",
+    "single-item-age-restriction-none": "Ohne Altersbeschränkung",
+    "single-item-age-restriction-not-flagged": "Nicht gekennzeichnet",
+    "single-item-age-restriction-not-required": "Nicht erforderlich",
+    "single-item-age-restriction-unknown": "Noch nicht bekannt",
     "no-data-to-show": "You haven’t selected any field to display. Please choose a field or remove this block."
   }
 }

--- a/apps/web/app/composables/useItemDataTable/__tests__/useItemDataTable.spec.ts
+++ b/apps/web/app/composables/useItemDataTable/__tests__/useItemDataTable.spec.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 import type { Product } from '@plentymarkets/shop-api';
 import { useItemDataTable } from '~/composables/useItemDataTable/useItemDataTable';
 
-// Mock the auto-imported t function
 const mockT = (key: string, params?: Record<string, unknown>) => {
   const p = params as { age?: number } | undefined;
   switch (key) {

--- a/apps/web/app/composables/useItemDataTable/__tests__/useItemDataTable.spec.ts
+++ b/apps/web/app/composables/useItemDataTable/__tests__/useItemDataTable.spec.ts
@@ -62,7 +62,7 @@ describe('useItemDataTable', () => {
       variationProperties: [],
     } as unknown as Product);
 
-    const { fieldValues } = useItemDataTable(productRef);
+    const { fieldValues } = useItemDataTable(productRef, { t: mockT });
 
     expect(fieldValues.value.itemId).toBe('109');
     expect(fieldValues.value.manufacturer).toBe('Teston Testerton');

--- a/apps/web/app/composables/useItemDataTable/__tests__/useItemDataTable.spec.ts
+++ b/apps/web/app/composables/useItemDataTable/__tests__/useItemDataTable.spec.ts
@@ -1,33 +1,30 @@
 import { describe, it, expect } from 'vitest';
-import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import type { Product } from '@plentymarkets/shop-api';
 import { useItemDataTable } from '~/composables/useItemDataTable/useItemDataTable';
 
 // Mock the auto-imported t function
-mockNuxtImport('t', () => {
-  return (key: string, params?: Record<string, unknown>) => {
-    const p = params as { age?: number } | undefined;
-    switch (key) {
-      case 'single-item-age-restriction':
-        return `${p?.age} and older`;
-      case 'single-item-age-restriction-none':
-        return 'No age restriction';
-      case 'single-item-age-restriction-not-flagged':
-        return 'Not rated';
-      case 'single-item-age-restriction-not-required':
-        return 'Not required';
-      case 'single-item-age-restriction-unknown':
-        return 'Unknown';
-      default:
-        return key;
-    }
-  };
-});
+const mockT = (key: string, params?: Record<string, unknown>) => {
+  const p = params as { age?: number } | undefined;
+  switch (key) {
+    case 'single-item-age-restriction':
+      return `${p?.age} and older`;
+    case 'single-item-age-restriction-none':
+      return 'No age restriction';
+    case 'single-item-age-restriction-not-flagged':
+      return 'Not rated';
+    case 'single-item-age-restriction-not-required':
+      return 'Not required';
+    case 'single-item-age-restriction-unknown':
+      return 'Unknown';
+    default:
+      return key;
+  }
+};
 
 describe('useItemDataTable', () => {
   it('should return empty values when product is null', () => {
     const productRef = ref<Product | null>(null);
-    const { fieldValues } = useItemDataTable(productRef);
+    const { fieldValues } = useItemDataTable(productRef, { t: mockT });
 
     expect(fieldValues.value.itemId).toBe('');
     expect(fieldValues.value.manufacturer).toBe('');

--- a/apps/web/app/composables/useItemDataTable/helpers/ItemDataHelpers.ts
+++ b/apps/web/app/composables/useItemDataTable/helpers/ItemDataHelpers.ts
@@ -89,25 +89,24 @@ export const formatVariationProperties = (product: Product): string => {
     .join('; ');
 };
 
-export const formatAgeRating = (
-  t: (key: string, listOrNamed?: Record<string, unknown>) => string,
-  age: number | null | undefined,
-): string => {
-  if (age == null) return '';
+export type AgeRatingDescriptor = { key: string; params?: Record<string, unknown> } | null;
+
+export const getAgeRatingDescriptor = (age: number | null | undefined): AgeRatingDescriptor => {
+  if (age == null) return null;
 
   const a = Number(age);
 
   switch (a) {
     case 0:
-      return t('single-item-age-restriction-none');
+      return { key: 'single-item-age-restriction-none' };
     case 50:
-      return t('single-item-age-restriction-not-flagged');
+      return { key: 'single-item-age-restriction-not-flagged' };
     case 80:
-      return t('single-item-age-restriction-not-required');
+      return { key: 'single-item-age-restriction-not-required' };
     default:
       if (a > 0 && a <= 18) {
-        return t('single-item-age-restriction', { age: a });
+        return { key: 'single-item-age-restriction', params: { age: a } };
       }
-      return t('single-item-age-restriction-unknown');
+      return { key: 'single-item-age-restriction-unknown' };
   }
 };

--- a/apps/web/app/composables/useItemDataTable/helpers/__tests__/ItemDataHelpers.spec.ts
+++ b/apps/web/app/composables/useItemDataTable/helpers/__tests__/ItemDataHelpers.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { Product } from '@plentymarkets/shop-api';
 import {
-  formatAgeRating,
+  getAgeRatingDescriptor,
   formatContent,
   formatWeight,
   formatDimensions,
@@ -11,7 +11,7 @@ import {
   getManufacturerName,
 } from '../ItemDataHelpers';
 
-const tMock = (key: string, params?: object) => {
+const tMock = (key: string, params?: Record<string, unknown>) => {
   const p = params as { age?: number } | undefined;
 
   switch (key) {
@@ -30,33 +30,49 @@ const tMock = (key: string, params?: object) => {
   }
 };
 
-describe('formatAgeRating', () => {
-  it('should return empty string when age is null/undefined', () => {
-    expect(formatAgeRating(tMock, null)).toBe('');
-    expect(formatAgeRating(tMock, undefined)).toBe('');
+describe('getAgeRatingDescriptor', () => {
+  it('should return null when age is null/undefined', () => {
+    expect(getAgeRatingDescriptor(null)).toBeNull();
+    expect(getAgeRatingDescriptor(undefined)).toBeNull();
   });
 
   it('should handle age = 0 (no restriction)', () => {
-    expect(formatAgeRating(tMock, 0)).toBe('No age restriction');
+    expect(getAgeRatingDescriptor(0)).toEqual({
+      key: 'single-item-age-restriction-none',
+    });
   });
 
   it('should handle age between 1 and 18', () => {
-    expect(formatAgeRating(tMock, 16)).toBe('16 and older');
+    expect(getAgeRatingDescriptor(16)).toEqual({
+      key: 'single-item-age-restriction',
+      params: { age: 16 },
+    });
   });
 
   it('should handle age = 50 (not flagged)', () => {
-    expect(formatAgeRating(tMock, 50)).toBe('Not rated');
+    expect(getAgeRatingDescriptor(50)).toEqual({
+      key: 'single-item-age-restriction-not-flagged',
+    });
   });
 
   it('should handle age = 80 (not required)', () => {
-    expect(formatAgeRating(tMock, 80)).toBe('Not required');
+    expect(getAgeRatingDescriptor(80)).toEqual({
+      key: 'single-item-age-restriction-not-required',
+    });
   });
 
   it('should handle unknown age', () => {
-    expect(formatAgeRating(tMock, 999)).toBe('Unknown');
+    expect(getAgeRatingDescriptor(999)).toEqual({
+      key: 'single-item-age-restriction-unknown',
+    });
+  });
+
+  it('should integrate with a translate function correctly', () => {
+    const descriptor = getAgeRatingDescriptor(16);
+    const label = descriptor ? tMock(descriptor.key, descriptor.params) : '';
+    expect(label).toBe('16 and older');
   });
 });
-
 describe('formatWeight', () => {
   it('should return empty string for null/undefined', () => {
     expect(formatWeight(null)).toBe('');

--- a/apps/web/app/composables/useItemDataTable/types.ts
+++ b/apps/web/app/composables/useItemDataTable/types.ts
@@ -1,0 +1,1 @@
+export type TranslateFn = (key: string, listOrNamed?: Record<string, unknown>) => string;

--- a/apps/web/app/composables/useItemDataTable/useItemDataTable.ts
+++ b/apps/web/app/composables/useItemDataTable/useItemDataTable.ts
@@ -9,9 +9,9 @@ import {
   formatDimensions,
   formatContent,
   formatVariationProperties,
-  formatAgeRating,
+  getAgeRatingDescriptor,
 } from './helpers/ItemDataHelpers';
-type TranslateFn = (key: string, listOrNamed?: Record<string, unknown>) => string;
+import type { TranslateFn } from '~/composables/useItemDataTable/types';
 
 export function useItemDataTable(productRef: Ref<Product | null>, options?: { t?: TranslateFn }) {
   const { $isPreview } = useNuxtApp();
@@ -49,14 +49,16 @@ export function useItemDataTable(productRef: Ref<Product | null>, options?: { t?
 
     const shouldHideWeightG = hideZeroInPreview && weightG === 0;
     const shouldHideWeightNetG = hideZeroInPreview && weightNetG === 0;
-    const allDimsZero = hideZeroInPreview && (lengthMM ?? 0) === 0 && (widthMM ?? 0) === 0 && (heightMM ?? 0) === 0;
+    const allDimensionsZero =
+      hideZeroInPreview && (lengthMM ?? 0) === 0 && (widthMM ?? 0) === 0 && (heightMM ?? 0) === 0;
+    const ageDescriptor = getAgeRatingDescriptor(item.ageRestriction);
 
     return {
       itemId: item.id?.toString() ?? '',
 
       condition: getConditionName(product),
 
-      ageRating: translate ? formatAgeRating(translate, item.ageRestriction) : '',
+      ageRating: translate && ageDescriptor ? translate(ageDescriptor.key, ageDescriptor.params) : '',
 
       externalVariationId: variation.externalId ?? '',
 
@@ -72,7 +74,7 @@ export function useItemDataTable(productRef: Ref<Product | null>, options?: { t?
 
       netWeight: shouldHideWeightNetG ? '' : formatWeight(weightNetG),
 
-      dimensions: allDimsZero ? '' : formatDimensions(lengthMM, widthMM, heightMM),
+      dimensions: allDimensionsZero ? '' : formatDimensions(lengthMM, widthMM, heightMM),
 
       customTariffNumber: variation.customsTariffNumber ?? item.customsTariffNumber ?? '',
 

--- a/apps/web/app/composables/useItemDataTable/useItemDataTable.ts
+++ b/apps/web/app/composables/useItemDataTable/useItemDataTable.ts
@@ -43,7 +43,7 @@ export function useItemDataTable(productRef: Ref<Product | null>) {
     const widthMM = variation.widthMM ?? null;
     const heightMM = variation.heightMM ?? null;
 
-    const hideZeroInPreview = $isPreview === true;
+    const hideZeroInPreview = $isPreview;
 
     const shouldHideWeightG = hideZeroInPreview && weightG === 0;
     const shouldHideWeightNetG = hideZeroInPreview && weightNetG === 0;

--- a/apps/web/app/composables/useItemDataTable/useItemDataTable.ts
+++ b/apps/web/app/composables/useItemDataTable/useItemDataTable.ts
@@ -13,6 +13,8 @@ import {
 } from './helpers/ItemDataHelpers';
 
 export function useItemDataTable(productRef: Ref<Product | null>) {
+  const { $isPreview } = useNuxtApp();
+
   const fieldValues = computed<ItemDataFieldValues>(() => {
     const product = productRef.value as Product | null;
 
@@ -35,6 +37,21 @@ export function useItemDataTable(productRef: Ref<Product | null>) {
     }
 
     const { item, variation } = product;
+    const weightG = variation.weightG ?? null;
+    const weightNetG = variation.weightNetG ?? null;
+    const lengthMM = variation.lengthMM ?? null;
+    const widthMM = variation.widthMM ?? null;
+    const heightMM = variation.heightMM ?? null;
+
+    const hideZeroInPreview = $isPreview === true;
+
+    const shouldHideWeightG = hideZeroInPreview && weightG === 0;
+    const shouldHideWeightNetG = hideZeroInPreview && weightNetG === 0;
+    const allDimsZero =
+      hideZeroInPreview &&
+      (lengthMM ?? 0) === 0 &&
+      (widthMM ?? 0) === 0 &&
+      (heightMM ?? 0) === 0;
 
     return {
       itemId: item.id?.toString() ?? '',
@@ -53,11 +70,13 @@ export function useItemDataTable(productRef: Ref<Product | null>) {
 
       content: formatContent(product),
 
-      grossWeight: formatWeight(variation.weightG),
+      grossWeight: shouldHideWeightG ? '' : formatWeight(weightG),
 
-      netWeight: formatWeight(variation.weightNetG),
+      netWeight: shouldHideWeightNetG ? '' : formatWeight(weightNetG),
 
-      dimensions: formatDimensions(variation.lengthMM, variation.widthMM, variation.heightMM),
+      dimensions: allDimsZero
+        ? ''
+        : formatDimensions(lengthMM, widthMM, heightMM),
 
       customTariffNumber: variation.customsTariffNumber ?? item.customsTariffNumber ?? '',
 

--- a/apps/web/app/utils/handle-preview-product.ts
+++ b/apps/web/app/utils/handle-preview-product.ts
@@ -60,6 +60,14 @@ const cloneValue = (v: unknown): unknown => {
 const matches = (set: Set<string>, key: string, path: string): boolean =>
   set.has(key) || (path ? set.has(`${path}.${key}`) : set.has(key));
 
+const ZERO_MISSING_PATHS = new Set([
+  'variation.weightG',
+  'variation.weightNetG',
+  'variation.lengthMM',
+  'variation.widthMM',
+  'variation.heightMM',
+]);
+
 const mergeComplement = ({ a, b, forced, ignored, path }: MergeOpts): unknown => {
   if (isPlainObject(a) && isPlainObject(b)) {
     const result: PlainObject = {};
@@ -80,6 +88,17 @@ const mergeComplement = ({ a, b, forced, ignored, path }: MergeOpts): unknown =>
       if (aHas) {
         const av = (a as PlainObject)[key];
         const bv = bHas ? (b as PlainObject)[key] : undefined;
+
+        if (
+          ZERO_MISSING_PATHS.has(nextPath) &&
+          typeof av === 'number' &&
+          av === 0
+        ) {
+          if (bHas) {
+            result[key] = cloneValue(bv);
+          }
+          continue;
+        }
 
         if (forcedHere && bHas) {
           result[key] = cloneValue(bv);

--- a/apps/web/app/utils/handle-preview-product.ts
+++ b/apps/web/app/utils/handle-preview-product.ts
@@ -89,11 +89,7 @@ const mergeComplement = ({ a, b, forced, ignored, path }: MergeOpts): unknown =>
         const av = (a as PlainObject)[key];
         const bv = bHas ? (b as PlainObject)[key] : undefined;
 
-        if (
-          ZERO_MISSING_PATHS.has(nextPath) &&
-          typeof av === 'number' &&
-          av === 0
-        ) {
+        if (ZERO_MISSING_PATHS.has(nextPath) && typeof av === 'number' && av === 0) {
           if (bHas) {
             result[key] = cloneValue(bv);
           }

--- a/apps/web/app/utils/handle-preview-product.ts
+++ b/apps/web/app/utils/handle-preview-product.ts
@@ -86,24 +86,24 @@ const mergeComplement = ({ a, b, forced, ignored, path }: MergeOpts): unknown =>
       }
 
       if (aHas) {
-        const av = (a as PlainObject)[key];
-        const bv = bHas ? (b as PlainObject)[key] : undefined;
+        const valueA = (a as PlainObject)[key];
+        const valueB = bHas ? (b as PlainObject)[key] : undefined;
 
-        if (ZERO_MISSING_PATHS.has(nextPath) && typeof av === 'number' && av === 0) {
+        if (ZERO_MISSING_PATHS.has(nextPath) && typeof valueA === 'number' && valueA === 0) {
           if (bHas) {
-            result[key] = cloneValue(bv);
+            result[key] = cloneValue(valueB);
           }
           continue;
         }
 
         if (forcedHere && bHas) {
-          result[key] = cloneValue(bv);
-        } else if (isMissing(av) && bHas) {
-          result[key] = cloneValue(bv);
-        } else if (isPlainObject(av) && isPlainObject(bv)) {
-          result[key] = mergeComplement({ a: av, b: bv, forced, ignored, path: nextPath });
+          result[key] = cloneValue(valueB);
+        } else if (isMissing(valueA) && bHas) {
+          result[key] = cloneValue(valueB);
+        } else if (isPlainObject(valueA) && isPlainObject(valueB)) {
+          result[key] = mergeComplement({ a: valueA, b: valueB, forced, ignored, path: nextPath });
         } else {
-          result[key] = cloneValue(av);
+          result[key] = cloneValue(valueA);
         }
       } else if (bHas) {
         result[key] = cloneValue((b as PlainObject)[key]);

--- a/apps/web/public/_nuxt-plenty/editor/blocksLists.json
+++ b/apps/web/public/_nuxt-plenty/editor/blocksLists.json
@@ -1805,8 +1805,8 @@
                 "manufacturingCountry": true,
                 "content": true,
                 "grossWeight": true,
-                "netWeight": false,
-                "dimensions": false,
+                "netWeight": true,
+                "dimensions": true,
                 "customTariffNumber": true,
                 "properties": true
               },

--- a/apps/web/public/_nuxt-plenty/editor/blocksLists.json
+++ b/apps/web/public/_nuxt-plenty/editor/blocksLists.json
@@ -1756,8 +1756,8 @@
                 "manufacturingCountry": true,
                 "content": true,
                 "grossWeight": true,
-                "netWeight": false,
-                "dimensions": false,
+                "netWeight": true,
+                "dimensions": true,
                 "customTariffNumber": true,
                 "properties": true
               },
@@ -1781,8 +1781,8 @@
                 "paddingBottom": 0,
                 "paddingRight": 0,
                 "paddingLeft": 0,
-                "displayAsCollapsable": "true",
-                "initiallyCollapsed": "true"
+                "displayAsCollapsable": false,
+                "initiallyCollapsed": false
               }
             }
           },
@@ -1830,8 +1830,8 @@
                 "paddingBottom": 0,
                 "paddingRight": 0,
                 "paddingLeft": 0,
-                "displayAsCollapsable": "true",
-                "initiallyCollapsed": "true"
+                "displayAsCollapsable": false,
+                "initiallyCollapsed": false
               }
             }
           }


### PR DESCRIPTION
## Issue:

Follow-up: #2027 

## Describe your changes

- Data for certain fields will be checked if it comes 0 from backend response and if so, the fake data will be shown in the editor. For preview, we will also check for that data and will remove the fields if they have 0 as values
- Also added condition for the "no data to show" line only for the editor and not in preview


## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

NUXT_PUBLIC_IS_PREVIEW='1'
ENABLE_PRODUCT_EDITING='1'

### Functionality

- [x] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [x] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
