### PR TITLE
fix: close block drawer on site navigation

### DIFF
--- a/apps/web/app/composables/useSiteConfiguration/__tests__/useSiteConfiguration.spec.ts
+++ b/apps/web/app/composables/useSiteConfiguration/__tests__/useSiteConfiguration.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest';
+
+const mockRoute = {
+  fullPath: ref('/initial'),
+};
+
+vi.mock('vue-router', () => ({
+  useRoute: () => mockRoute,
+}));
+
+describe('useSiteConfiguration route watcher', () => {
+  it('should reset drawer state on route change', async () => {
+    const { drawerOpen, drawerView, activeSetting } = useSiteConfiguration();
+    mockRoute.fullPath.value = '/new-route';
+    await nextTick();
+
+    expect(drawerOpen.value).toBe(false);
+    expect(drawerView.value).toBe(null);
+    expect(activeSetting.value).toBe('');
+  });
+});

--- a/apps/web/app/composables/useSiteConfiguration/useSiteConfiguration.ts
+++ b/apps/web/app/composables/useSiteConfiguration/useSiteConfiguration.ts
@@ -96,15 +96,16 @@ export const useSiteConfiguration: UseSiteConfigurationReturn = () => {
     state.value.placement = 'left';
     state.value.drawerView = null;
   };
-
   if (import.meta.client) {
     const route = useRoute();
     watch(
       () => route.fullPath,
       () => {
-        state.value.drawerOpen = false;
-        state.value.drawerView = null;
-        state.value.activeSetting = '';
+        if (state.value.drawerView === 'blocksSettings') {
+          state.value.drawerOpen = false;
+          state.value.drawerView = null;
+          state.value.activeSetting = '';
+        }
       },
     );
   }

--- a/apps/web/app/composables/useSiteConfiguration/useSiteConfiguration.ts
+++ b/apps/web/app/composables/useSiteConfiguration/useSiteConfiguration.ts
@@ -97,6 +97,18 @@ export const useSiteConfiguration: UseSiteConfigurationReturn = () => {
     state.value.drawerView = null;
   };
 
+  if (import.meta.client) {
+    const route = useRoute();
+    watch(
+      () => route.fullPath,
+      () => {
+        state.value.drawerOpen = false;
+        state.value.drawerView = null;
+        state.value.activeSetting = '';
+      },
+    );
+  }
+
   return {
     ...toRefs(state.value),
     updateNewBlockPosition,


### PR DESCRIPTION
## Issue:

Closes: [AB#181478](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/181478)

## Describe your changes

- Block navigation drawer now closes on page navigation 
## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

Tested in both 

**Feature flags**:

- No feature flag 

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
