### PR TITLE
refactor: type any to generic constraint

### DIFF
--- a/apps/web/app/composables/useFullWidthToggle/types.ts
+++ b/apps/web/app/composables/useFullWidthToggle/types.ts
@@ -1,3 +1,7 @@
 export interface UseFullWidthToggleReturn {
   isFullWidth: WritableComputedRef<boolean>;
 }
+
+export interface Layout {
+  fullWidth?: boolean;
+}

--- a/apps/web/app/composables/useFullWidthToggle/useFullWidthToggle.ts
+++ b/apps/web/app/composables/useFullWidthToggle/useFullWidthToggle.ts
@@ -1,5 +1,7 @@
 import type { UseFullWidthToggleReturn, Layout } from './types';
 
+const DEFAULT_LAYOUT: Layout = { fullWidth: false };
+
 /**
  * Composable to manage the full-width toggle state for blocks with a direct `layout` property.
  *
@@ -32,9 +34,6 @@ export const useFullWidthToggleForContent = <Type extends { layout?: Layout }>(
  * @param defaultLayout - The default layout object to use if `layout` is missing.
  * @returns An object with a reactive `isFullWidth` property for two-way binding.
  */
-
-const DEFAULT_LAYOUT: Layout = { fullWidth: false };
-
 export const useFullWidthToggleForConfig = <Type extends { layout?: Layout }>(
   configuration: Ref<Type>,
   defaultLayout: Layout = DEFAULT_LAYOUT,

--- a/apps/web/app/composables/useFullWidthToggle/useFullWidthToggle.ts
+++ b/apps/web/app/composables/useFullWidthToggle/useFullWidthToggle.ts
@@ -1,6 +1,4 @@
-import type { UseFullWidthToggleReturn } from './types';
-
-type Layout = { fullWidth?: boolean };
+import type { UseFullWidthToggleReturn, Layout } from './types';
 
 /**
  * Composable to manage the full-width toggle state for blocks with a direct `layout` property.
@@ -9,9 +7,8 @@ type Layout = { fullWidth?: boolean };
  * @param defaultValue - The default value to use if `fullWidth` is undefined (default: false).
  * @returns An object with a reactive `isFullWidth` property for two-way binding.
  */
-export const useFullWidthToggleForContent = (
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  content: Ref<any>,
+export const useFullWidthToggleForContent = <Type extends { layout?: Layout }>(
+  content: Ref<Type>,
   defaultValue = false,
 ): UseFullWidthToggleReturn => {
   const isFullWidth = computed({
@@ -26,6 +23,7 @@ export const useFullWidthToggleForContent = (
 
   return { isFullWidth };
 };
+
 /**
  * Composable to manage the full-width toggle state for "structure" blocks
  * where the `layout` object is nested inside a `configuration` property.
@@ -35,10 +33,11 @@ export const useFullWidthToggleForContent = (
  * @returns An object with a reactive `isFullWidth` property for two-way binding.
  */
 
-export const useFullWidthToggleForConfig = (
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  configuration: Ref<any>,
-  defaultLayout: Layout = { fullWidth: false },
+const DEFAULT_LAYOUT: Layout = { fullWidth: false };
+
+export const useFullWidthToggleForConfig = <Type extends { layout?: Layout }>(
+  configuration: Ref<Type>,
+  defaultLayout: Layout = DEFAULT_LAYOUT,
 ): UseFullWidthToggleReturn => {
   const isFullWidth = computed({
     get: () => configuration.value?.layout?.fullWidth ?? defaultLayout.fullWidth ?? false,


### PR DESCRIPTION
## Issue:

Follow-up: #2013 

## Describe your changes

- Replaces the `any` type for parameters in `useFullWidthToggle` with a [generic constraint](https://www.typescriptlang.org/docs/handbook/2/generics.html#generic-constraints)
- Improves type safety while staying compatible with various block interfaces

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [x] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
