### PR TITLE
fix: getEditorUiTranslations error when not called during setup

### DIFF
--- a/apps/web/app/utils/editorTranslationsHelper.ts
+++ b/apps/web/app/utils/editorTranslationsHelper.ts
@@ -7,7 +7,7 @@ export const editorTranslations = {
 };
 
 export const getEditorUITranslation = (key: string, params: Record<string, string | number> = {}): string => {
-  const { locale } = useI18n();
+  const { locale } = useNuxtApp().$i18n;
   const lang = (locale.value as keyof typeof editorTranslations) || 'en';
   let template: string =
     editorTranslations[lang]?.[key as keyof (typeof editorTranslations)['en']] ??


### PR DESCRIPTION
## Issue:

Closes: [AB#182885](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/182885)

## Describe your changes

- [What changed]
- [Notable implementation decisions]
- [Known limitations]

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
