### PR TITLE
fix(a11y): headings in item category blocks

### DIFF
--- a/apps/web/app/components/CategoryFilters/Filter.vue
+++ b/apps/web/app/components/CategoryFilters/Filter.vue
@@ -2,9 +2,9 @@
   <SfAccordionItem v-if="facet" v-model="open">
     <template #summary>
       <div class="flex justify-between py-1 px-4 mb-2 select-none bg-primary-50/50">
-        <h6 class="py-1 rounded-none uppercase typography-headline-6 font-bold tracking-widest select-none">
+        <div class="py-1 rounded-none uppercase typography-headline-6 font-bold tracking-widest select-none">
           {{ facetGetters.getName(facet) }}
-        </h6>
+        </div>
         <SfIconChevronLeft :class="['text-neutral-500', open ? 'rotate-90' : '-rotate-90']" />
       </div>
     </template>

--- a/apps/web/app/components/CategoryFilters/SortSections.vue
+++ b/apps/web/app/components/CategoryFilters/SortSections.vue
@@ -3,9 +3,9 @@
     <SfAccordionItem v-if="facet" v-model="open">
       <template #summary>
         <div class="flex justify-between py-1 px-4 mb-2 select-none bg-primary-50/50">
-          <h6 class="py-1 rounded-none uppercase typography-headline-6 font-bold tracking-widest select-none">
+          <div class="py-1 rounded-none uppercase typography-headline-6 font-bold tracking-widest select-none">
             {{ facetGetters.getName(facet) }}
-          </h6>
+          </div>
 
           <SfIconChevronLeft :class="['text-neutral-500', open ? 'rotate-90' : '-rotate-90']" />
         </div>

--- a/apps/web/app/components/CategoryItemsPerPage/CategoryItemsPerPage.vue
+++ b/apps/web/app/components/CategoryItemsPerPage/CategoryItemsPerPage.vue
@@ -1,12 +1,11 @@
 <template>
   <div class="w-full" data-testid="category-items-per-page">
-    <h6
+    <div
       v-if="!selectionModeCompact"
       class="bg-primary-50/50 mb-4 px-4 py-2 rounded-none uppercase typography-headline-6 font-bold tracking-widest select-none"
     >
       {{ t('common.labels.perPage') }}
-    </h6>
-
+    </div>
     <div class="px-4">
       <SfSelect
         id="perPage"

--- a/apps/web/app/components/CategorySorting/CategorySorting.vue
+++ b/apps/web/app/components/CategorySorting/CategorySorting.vue
@@ -1,12 +1,11 @@
 <template>
   <div class="w-full" data-testid="category-sorting">
-    <h6
+    <div
       v-if="!selectionModeCompact"
       class="bg-primary-50/50 mb-4 px-4 py-2 rounded-none uppercase typography-headline-6 font-bold tracking-widest select-none"
     >
       {{ t('common.labels.sortBy') }}
-    </h6>
-
+    </div>
     <div class="px-4">
       <SfSelect id="sortBy" v-model="selected" :aria-label="t('common.labels.sortBy')" data-testid="select-sort-by">
         <option v-if="selectionModeCompact" value="" disabled hidden>{{ t('common.labels.sortBy') }}</option>

--- a/apps/web/app/components/CategoryTree/CategoryTree.vue
+++ b/apps/web/app/components/CategoryTree/CategoryTree.vue
@@ -3,12 +3,12 @@
     v-if="parent || (categoryTreeItem && categoryTreeGetters.getItems(categoryTreeItem)?.length)"
     class="category-tree"
   >
-    <h6
+    <div
       class="py-2 px-4 mb-4 bg-primary-50/50 typography-headline-6 font-bold text-neutral-900 uppercase tracking-widest rounded-none select-none"
       data-testid="category-tree"
     >
       {{ t('common.labels.category') }}
-    </h6>
+    </div>
     <template v-if="parent">
       <CategoryTreeItem
         :name="categoryTreeGetters.getName(parent)"


### PR DESCRIPTION
## Issue:

PSI report for item category page:

`Heading elements are not in a sequentially-descending order`

## Describe your changes

- Replaces `h6` elements with `div` elements
- Retains Tailwind styles for visual presentation

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [x] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [x] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [x] Checked accessibility (mobile & desktop)
  - Issue was only reported on desktop

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
