### PR TITLE
fix: disallow empty value on customer class settings

### DIFF
--- a/apps/web/app/components/settings/general/customer-management/default-B2B-customer-class/B2BCustomerClass.vue
+++ b/apps/web/app/components/settings/general/customer-management/default-B2B-customer-class/B2BCustomerClass.vue
@@ -16,7 +16,7 @@
       class="cursor-pointer"
       select-label=""
       :deselect-label="getEditorTranslation('deselect-label')"
-      :allow-empty="true"
+      :allow-empty="false"
     />
   </div>
 </template>

--- a/apps/web/app/components/settings/general/customer-management/default-B2C-and-guest-customer-class/B2CCustomerClass.vue
+++ b/apps/web/app/components/settings/general/customer-management/default-B2C-and-guest-customer-class/B2CCustomerClass.vue
@@ -16,7 +16,7 @@
       class="cursor-pointer"
       select-label=""
       :deselect-label="getEditorTranslation('deselect-label')"
-      :allow-empty="true"
+      :allow-empty="false"
     />
   </div>
 </template>


### PR DESCRIPTION
## Issue:

Closes: [AB#182311](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/182311)

## Describe your changes

- [What changed]
allow-empty from Multiselect from both b2bCustomerClass.vue and B2cCustomerClass.vue has been set to false
- [Notable implementation decisions]
In order to not allow empty value
- [Known limitations]

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
