### PR TITLE
fix: translation strings for fake category pages

### DIFF
--- a/apps/web/app/components/CategoryFilters/Sort.vue
+++ b/apps/web/app/components/CategoryFilters/Sort.vue
@@ -18,7 +18,7 @@
       @click="isExpanded = true"
     >
       <SfIconExpandMore class="shrink-0" />
-      {{ getEditorTranslation('show-all-filters') }}
+      {{ t('product.showAll') }}
     </button>
   </div>
 </template>
@@ -95,14 +95,3 @@ watch(
   },
 );
 </script>
-
-<i18n lang="json">
-{
-  "en": {
-    "show-all-filters": "Show all"
-  },
-  "de": {
-    "show-all-filters": "Alle anzeigen"
-  }
-}
-</i18n>

--- a/apps/web/app/lang/de.json
+++ b/apps/web/app/lang/de.json
@@ -1010,6 +1010,7 @@
     "priceInclVAT": "inkl. ges. MwSt",
     "reviewsCount": "{Anzahl} Bewertungen",
     "showAllReviews": "Alle Bewertungen anzeigen",
+    "showAll": "alle Filter",
     "graduatedPrices": {
       "discount": "RABATT",
       "price": "PREIS",

--- a/apps/web/app/lang/en.json
+++ b/apps/web/app/lang/en.json
@@ -355,7 +355,6 @@
       "estimatedTax": "VAT",
       "excludedTax": "plus VAT",
       "filters": "Filters",
-
       "grossPrice": "Gross",
       "home": "Home",
       "includedTax": "included VAT",

--- a/apps/web/app/lang/en.json
+++ b/apps/web/app/lang/en.json
@@ -355,6 +355,7 @@
       "estimatedTax": "VAT",
       "excludedTax": "plus VAT",
       "filters": "Filters",
+
       "grossPrice": "Gross",
       "home": "Home",
       "includedTax": "included VAT",
@@ -1010,6 +1011,7 @@
     "priceInclVAT": "Incl. VAT",
     "reviewsCount": "{count} reviews",
     "showAllReviews": "Show all reviews",
+    "showAll": "Show all",
     "graduatedPrices": {
       "discount": "DISCOUNT",
       "price": "PRICE",

--- a/apps/web/app/utils/facets/fakeFacetCallDE.ts
+++ b/apps/web/app/utils/facets/fakeFacetCallDE.ts
@@ -120,7 +120,7 @@ export const fakeFacetCallDE = {
         values: [
           {
             id: 1,
-            name: 'Exclusive Leather',
+            name: 'Exklusives Leder',
             cssClass: '',
             position: 1,
             count: 5,

--- a/apps/web/app/utils/facets/fakeFacetCallEN.ts
+++ b/apps/web/app/utils/facets/fakeFacetCallEN.ts
@@ -198,7 +198,7 @@ export const fakeFacetCallEN = {
         values: [
           {
             id: 14,
-            name: 'Sofort versandfertig, Lieferzeit 48h',
+            name: 'Ready for immediate dispatch, delivery time 48h',
             cssClass: '',
             position: 1,
             count: 18,


### PR DESCRIPTION
## Issue:

Closes: [AB#181221](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/181221)

## Describe your changes

- Proper translations for the fake data category page 

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

Tested in both 

**Feature flags**:

- No features flag

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
