### PR TITLE
fix: show category fake data

### DIFF
--- a/apps/web/app/utils/handle-preview-products.ts
+++ b/apps/web/app/utils/handle-preview-products.ts
@@ -9,7 +9,7 @@ export const handlePreviewProducts = (state: Ref<UseProductsState>, lang: string
   const { $isPreview } = useNuxtApp();
   if (!$isPreview || state.value.data.products.length !== 0) return;
 
-  if (state.value.data.category.type === 'item' && $isPreview && state.value.data.products.length === 0) {
+  if (state.value.data.category.type === 'item') {
     const fakeFacetCall = lang === 'de' ? fakeFacetCallDE.data : fakeFacetCallEN.data;
 
     state.value.data = {

--- a/apps/web/app/utils/handle-preview-products.ts
+++ b/apps/web/app/utils/handle-preview-products.ts
@@ -7,11 +7,18 @@ import type { UseProductsState } from '~/composables/useProducts/types';
 
 export const handlePreviewProducts = (state: Ref<UseProductsState>, lang: string) => {
   const { $isPreview } = useNuxtApp();
+  if (!$isPreview || state.value.data.products.length !== 0) return;
 
   if (state.value.data.category.type === 'item' && $isPreview && state.value.data.products.length === 0) {
     const fakeFacetCall = lang === 'de' ? fakeFacetCallDE.data : fakeFacetCallEN.data;
-    state.value.data = { ...state.value.data, facets: fakeFacetCall.facets };
 
+    state.value.data = {
+      ...state.value.data,
+      category: fakeFacetCall.category,
+      facets: fakeFacetCall.facets,
+      pagination: fakeFacetCall.pagination,
+      languageUrls: fakeFacetCall.languageUrls,
+    };
     const fakeProduct = lang === 'de' ? fakeProductDE : fakeProductEN;
     const exampleProductName = lang === 'de' ? 'Beispielprodukt ' : 'Example Product ';
 

--- a/apps/web/app/utils/handle-preview-products.ts
+++ b/apps/web/app/utils/handle-preview-products.ts
@@ -7,7 +7,7 @@ import type { UseProductsState } from '~/composables/useProducts/types';
 
 export const handlePreviewProducts = (state: Ref<UseProductsState>, lang: string) => {
   const { $isPreview } = useNuxtApp();
-  if (!$isPreview || state.value.data.products.length !== 0) return;
+  if (!$isPreview || state.value.data.products.length > 0) return;
 
   if (state.value.data.category.type === 'item') {
     const fakeFacetCall = lang === 'de' ? fakeFacetCallDE.data : fakeFacetCallEN.data;


### PR DESCRIPTION
## Issue:

Closes: [AB#181223](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/181223)

## Describe your changes

- category name will now be shown with the rest of fake data
- [Notable implementation decisions]
- [Known limitations]

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- NUXT_PUBLIC_IS_PREVIEW='1'
ENABLE_CATEGORY_EDITING='1'

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [x] Ran e2e tests relevant to my changes locally
- [x] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
