### PR TITLE
fix: large space between arrow and language name

### DIFF
--- a/apps/web/app/components/ui/LanguageEditor/LanguageEditor.vue
+++ b/apps/web/app/components/ui/LanguageEditor/LanguageEditor.vue
@@ -2,10 +2,11 @@
   <SfTooltip :label="languageLabel" placement="bottom" :show-arrow="true">
     <div v-if="!loading" class="flex items-center space-x-1 md:space-x-2">
       <SfIconLanguage class="w-4 h-4 md:w-6 md:h-6" />
-      <div class="relative flex items-center">
+      <div class="relative flex items-center -space-x-2">
         <select
           :value="currentLocale"
-          class="form-select focus:outline-none focus:ring-0 focus:border-transparent text-sm md:text-base appearance-none cursor-pointer"
+          :style="{ width: selectWidth }"
+          class="form-select focus:outline-none focus:ring-0 focus:border-transparent text-sm md:text-base appearance-none cursor-pointer bg-transparent"
           data-testid="editor-language-select"
           @input="(ev: any) => switchLanguage(ev.target.value)"
         >
@@ -18,10 +19,11 @@
             {{ t(`lang.${locale}`) }}
           </option>
         </select>
-        <div class="flex items-center">
-          <SfIconExpandMore class="w-4 h-4 md:w-6 md:h-6" />
-        </div>
+        <SfIconExpandMore class="w-4 h-4 md:w-6 md:h-6 flex-shrink-0" />
       </div>
+    </div>
+    <div ref="measureRef" class="absolute invisible whitespace-nowrap font-medium text-sm md:text-base">
+      {{ t(`lang.${currentLocale}`) }}
     </div>
   </SfTooltip>
 </template>
@@ -32,16 +34,28 @@ import type { Locale } from 'vue-i18n';
 
 const languageLabel = 'Change the active language to manage multilingual content.';
 
-const { locale: currentLocale, availableLocales } = useI18n();
+const { locale: currentLocale, availableLocales, t } = useI18n();
 const { switchLocale } = useLocalization();
-const switchLanguage = async (locale: Locale) => {
-  await switchLocale(locale, false);
-};
 
 const loading = ref(true);
+const measureRef = ref<HTMLElement>();
+const selectWidth = ref('auto');
+
+const updateWidth = async () => {
+  await nextTick();
+  if (measureRef.value) {
+    selectWidth.value = `${measureRef.value.offsetWidth + 5}px`;
+  }
+};
+
+const switchLanguage = async (locale: Locale) => {
+  await switchLocale(locale, false);
+  await updateWidth();
+};
 
 onMounted(async () => {
   await nextTick();
   loading.value = false;
+  await updateWidth();
 });
 </script>

--- a/apps/web/app/components/ui/LanguageEditor/LanguageEditor.vue
+++ b/apps/web/app/components/ui/LanguageEditor/LanguageEditor.vue
@@ -44,6 +44,10 @@ const selectWidth = ref('auto');
 const updateWidth = async () => {
   await nextTick();
   if (measureRef.value) {
+    /**
+     * Add 5px to the measured width to provide extra space for the dropdown arrow
+     * and prevent text clipping.
+     */
     selectWidth.value = `${measureRef.value.offsetWidth + 5}px`;
   }
 };

--- a/apps/web/app/components/ui/LanguageEditor/LanguageEditor.vue
+++ b/apps/web/app/components/ui/LanguageEditor/LanguageEditor.vue
@@ -34,7 +34,7 @@ import type { Locale } from 'vue-i18n';
 
 const languageLabel = 'Change the active language to manage multilingual content.';
 
-const { locale: currentLocale, availableLocales, t } = useI18n();
+const { locale: currentLocale, availableLocales } = useI18n();
 const { switchLocale } = useLocalization();
 
 const loading = ref(true);

--- a/apps/web/app/components/ui/LanguageEditor/__tests__/LanguageEditor.spec.ts
+++ b/apps/web/app/components/ui/LanguageEditor/__tests__/LanguageEditor.spec.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import LanguageEditor from '../LanguageEditor.vue';
+
+interface LanguageEditorInstance {
+  measureRef: { offsetWidth: number } | null | undefined;
+  selectWidth: string;
+  updateWidth(): Promise<void>;
+}
+
+describe('LanguageEditor.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('updateWidth', () => {
+    it('should calculate select width based on measureRef offsetWidth plus 5px', async () => {
+      const mockSwitchLocale = vi.fn().mockResolvedValue(undefined);
+
+      const wrapper = mount(LanguageEditor, {
+        global: {
+          stubs: {
+            SfTooltip: true,
+            SfIconLanguage: true,
+            SfIconExpandMore: true,
+          },
+          mocks: {
+            useI18n: () => ({
+              locale: 'en',
+              availableLocales: ['en', 'de'],
+              t: (key: string) => key,
+            }),
+            useLocalization: () => ({
+              switchLocale: mockSwitchLocale,
+            }),
+          },
+        },
+      });
+
+      await flushPromises();
+      await nextTick();
+
+      const vm = wrapper.vm as unknown as LanguageEditorInstance;
+      vm.measureRef = { offsetWidth: 50 };
+
+      await vm.updateWidth();
+
+      expect(vm.selectWidth).toBe('55px');
+    });
+
+    it('should not update selectWidth when measureRef is null', async () => {
+      const wrapper = mount(LanguageEditor, {
+        global: {
+          stubs: {
+            SfTooltip: true,
+            SfIconLanguage: true,
+            SfIconExpandMore: true,
+          },
+          mocks: {
+            useI18n: () => ({
+              locale: 'en',
+              availableLocales: ['en', 'de'],
+              t: (key: string) => key,
+            }),
+            useLocalization: () => ({
+              switchLocale: vi.fn().mockResolvedValue(undefined),
+            }),
+          },
+        },
+      });
+
+      await flushPromises();
+      const vm = wrapper.vm as unknown as LanguageEditorInstance;
+      const initialWidth = vm.selectWidth;
+
+      vm.measureRef = null;
+      await vm.updateWidth();
+
+      expect(vm.selectWidth).toBe(initialWidth);
+    });
+
+    it('should not update selectWidth when measureRef is undefined', async () => {
+      const wrapper = mount(LanguageEditor, {
+        global: {
+          stubs: {
+            SfTooltip: true,
+            SfIconLanguage: true,
+            SfIconExpandMore: true,
+          },
+          mocks: {
+            useI18n: () => ({
+              locale: 'en',
+              availableLocales: ['en', 'de'],
+              t: (key: string) => key,
+            }),
+            useLocalization: () => ({
+              switchLocale: vi.fn().mockResolvedValue(undefined),
+            }),
+          },
+        },
+      });
+
+      await flushPromises();
+      const vm = wrapper.vm as unknown as LanguageEditorInstance;
+      const initialWidth = vm.selectWidth;
+
+      vm.measureRef = undefined;
+      await vm.updateWidth();
+
+      expect(vm.selectWidth).toBe(initialWidth);
+    });
+
+    it('should handle various offsetWidth values correctly', async () => {
+      const wrapper = mount(LanguageEditor, {
+        global: {
+          stubs: {
+            SfTooltip: true,
+            SfIconLanguage: true,
+            SfIconExpandMore: true,
+          },
+          mocks: {
+            useI18n: () => ({
+              locale: 'en',
+              availableLocales: ['en', 'de'],
+              t: (key: string) => key,
+            }),
+            useLocalization: () => ({
+              switchLocale: vi.fn().mockResolvedValue(undefined),
+            }),
+          },
+        },
+      });
+
+      await flushPromises();
+      const vm = wrapper.vm as unknown as LanguageEditorInstance;
+
+      const testCases = [0, 25, 100, 200];
+
+      for (const offsetWidth of testCases) {
+        vm.measureRef = { offsetWidth };
+        await vm.updateWidth();
+        expect(vm.selectWidth).toBe(`${offsetWidth + 5}px`);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Issue:

Closes: [AB#183235](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/183235)

## Describe your changes

- Fixed the large space between the arrow and lang name 
- Calculated dynamic width to have the same spacing no matter the language name length 

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

Tested in both 
**Feature flags**:

- No feature flag 

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

Before 

<img width="203" height="58" alt="Screenshot 2025-12-15 at 23 19 08" src="https://github.com/user-attachments/assets/f665ee51-3c4b-486f-9fc4-03814722810c" />


After
<img width="141" height="41" alt="Screenshot 2025-12-16 at 00 38 02" src="https://github.com/user-attachments/assets/e377f521-225a-45e1-b3e5-c70ee19f0a5c" />

