### PR TITLE
fix: technical data and item text in preview

### DIFF
--- a/apps/web/app/components/PageBlock/PageBlock.vue
+++ b/apps/web/app/components/PageBlock/PageBlock.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="block.meta" :key="block.meta.uuid" :data-uuid="block.meta.uuid">
+  <div v-if= "shouldRenderBlock && block.meta" :key="block.meta.uuid" :data-uuid="block.meta.uuid">
     <UiBlockPlaceholder v-if="displayTopPlaceholder(block.meta.uuid)" />
     <div
       :id="`block-${index}`"
@@ -49,7 +49,8 @@
         />
       </ClientOnly>
 
-      <component :is="getBlockComponent" v-bind="contentProps" :index="index">
+      <component :is="getBlockComponent" v-bind="contentProps" :index="index"   @no-data="handleNoData"
+      >
         <template v-if="block.type === 'structure'" #content="slotProps">
           <PageBlock
             :index="index"
@@ -140,6 +141,24 @@ const shouldShowBottomAddInGrid = computed(() =>
 );
 const clientPreview = ref(false);
 const buttonLabel = 'Insert a new block at this position.';
+const hasRuntimeData = ref(true);
+
+const handleNoData = () => {
+  hasRuntimeData.value = false;
+};
+const shouldRenderBlock = computed(() => {
+  if (!props.block?.meta) return false;
+
+  if (!hasRuntimeData.value) {
+    return false;
+  }
+
+  if (props.blockHasData && !props.blockHasData(props.block)) {
+    return false;
+  }
+
+  return true;
+});
 
 const marginBottomClasses = computed(() => {
   if (props.block.name === 'MultiGrid') return '';
@@ -282,4 +301,5 @@ const getBlockActions = (block: Block) => {
   }
   return undefined;
 };
+
 </script>

--- a/apps/web/app/components/PageBlock/PageBlock.vue
+++ b/apps/web/app/components/PageBlock/PageBlock.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if= "shouldRenderBlock && block.meta" :key="block.meta.uuid" :data-uuid="block.meta.uuid">
+  <div v-if="shouldRenderBlock && block.meta" :key="block.meta.uuid" :data-uuid="block.meta.uuid">
     <UiBlockPlaceholder v-if="displayTopPlaceholder(block.meta.uuid)" />
     <div
       :id="`block-${index}`"
@@ -49,7 +49,12 @@
         />
       </ClientOnly>
 
-      <component :is="getBlockComponent" v-bind="contentProps" :index="index"   @no-data="handleNoData"
+      <component
+        :is="getBlockComponent"
+        v-bind="contentProps"
+        :index="index"
+        @no-data="handleNoData"
+        @has-data="handleHasData"
       >
         <template v-if="block.type === 'structure'" #content="slotProps">
           <PageBlock
@@ -146,8 +151,16 @@ const hasRuntimeData = ref(true);
 const handleNoData = () => {
   hasRuntimeData.value = false;
 };
+const handleHasData = () => {
+  hasRuntimeData.value = true;
+};
+
 const shouldRenderBlock = computed(() => {
   if (!props.block?.meta) return false;
+
+  if (props.enableActions) {
+    return true;
+  }
 
   if (!hasRuntimeData.value) {
     return false;
@@ -301,5 +314,4 @@ const getBlockActions = (block: Block) => {
   }
   return undefined;
 };
-
 </script>

--- a/apps/web/app/components/blocks/ItemText/ItemText.vue
+++ b/apps/web/app/components/blocks/ItemText/ItemText.vue
@@ -44,10 +44,10 @@ const inlineStyle = computed(() => {
   };
 });
 const emit = defineEmits<{
-  (e: 'no-data' | 'has-data'): void;
+  'no-data': [];
+  'has-data': [];
 }>();
-
-const hasRealData = computed(() => !!text.value && text.value.length > 0);
+const hasRealData = computed(() => text.value?.length > 0);
 
 watch(
   () => hasRealData.value,
@@ -58,6 +58,6 @@ watch(
       emit('no-data');
     }
   },
-  { immediate: true }
+  { immediate: true },
 );
 </script>

--- a/apps/web/app/components/blocks/ItemText/ItemText.vue
+++ b/apps/web/app/components/blocks/ItemText/ItemText.vue
@@ -43,4 +43,21 @@ const inlineStyle = computed(() => {
     paddingRight: layout.paddingRight ? `${layout.paddingRight}px` : 0,
   };
 });
+const emit = defineEmits<{
+  (e: 'no-data' | 'has-data'): void;
+}>();
+
+const hasRealData = computed(() => !!text.value && text.value.length > 0);
+
+watch(
+  () => hasRealData.value,
+  (hasData) => {
+    if (hasData) {
+      emit('has-data');
+    } else {
+      emit('no-data');
+    }
+  },
+  { immediate: true }
+);
 </script>

--- a/apps/web/app/components/blocks/TechnicalData/TechnicalData.vue
+++ b/apps/web/app/components/blocks/TechnicalData/TechnicalData.vue
@@ -46,8 +46,7 @@ const inlineStyle = computed(() => {
 
 
 const emit = defineEmits<{
-  (e: 'no-data'): void;
-  (e: 'has-data'): void;
+  (e: 'no-data' | 'has-data'): void;
 }>();
 
 const hasRealData = computed(() => !!text.value && text.value.length > 0);

--- a/apps/web/app/components/blocks/TechnicalData/TechnicalData.vue
+++ b/apps/web/app/components/blocks/TechnicalData/TechnicalData.vue
@@ -44,12 +44,12 @@ const inlineStyle = computed(() => {
   };
 });
 
-
 const emit = defineEmits<{
-  (e: 'no-data' | 'has-data'): void;
+  'no-data': [];
+  'has-data': [];
 }>();
 
-const hasRealData = computed(() => !!text.value && text.value.length > 0);
+const hasRealData = computed(() => text.value?.length > 0);
 
 watch(
   () => hasRealData.value,
@@ -60,6 +60,6 @@ watch(
       emit('no-data');
     }
   },
-  { immediate: true }
+  { immediate: true },
 );
 </script>

--- a/apps/web/app/components/blocks/TechnicalData/TechnicalData.vue
+++ b/apps/web/app/components/blocks/TechnicalData/TechnicalData.vue
@@ -43,4 +43,20 @@ const inlineStyle = computed(() => {
     paddingRight: layout.paddingRight ? `${layout.paddingRight}px` : 0,
   };
 });
+const emit = defineEmits<{
+  (e: 'no-data'): void;
+}>();
+const { $isPreview } = useNuxtApp();
+const hasRealData = computed(() => !!text.value && text.value.length > 0);
+
+watch(
+  () => hasRealData.value,
+  (hasData) => {
+    if ($isPreview && !hasData) {
+      emit('no-data');
+    }
+  },
+  { immediate: true }
+);
+
 </script>

--- a/apps/web/app/components/blocks/TechnicalData/TechnicalData.vue
+++ b/apps/web/app/components/blocks/TechnicalData/TechnicalData.vue
@@ -43,20 +43,24 @@ const inlineStyle = computed(() => {
     paddingRight: layout.paddingRight ? `${layout.paddingRight}px` : 0,
   };
 });
+
+
 const emit = defineEmits<{
   (e: 'no-data'): void;
+  (e: 'has-data'): void;
 }>();
-const { $isPreview } = useNuxtApp();
+
 const hasRealData = computed(() => !!text.value && text.value.length > 0);
 
 watch(
   () => hasRealData.value,
   (hasData) => {
-    if ($isPreview && !hasData) {
+    if (hasData) {
+      emit('has-data');
+    } else {
       emit('no-data');
     }
   },
   { immediate: true }
 );
-
 </script>


### PR DESCRIPTION
## Issue:

Closes: [AB#183349](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/183349)

## Describe your changes

- technical block and item details should not be visible in preview if they only have fake data. the issue was that even if the data was not visible, the block was still in the list and the little space for it was visible. fixed that by changing the rendering logic for the case of fake data


## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- NUXT_PUBLIC_IS_PREVIEW='1'
ENABLE_CATEGORY_EDITING='1'
ENABLE_PRODUCT_EDITING='1'

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [x] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
