### PR TITLE
chore: add script for creating worktrees

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@plentymarkets/plentyshop-pwa",
       "version": "1.15.0",
+      "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "packages/*"
   ],
   "scripts": {
+    "postinstall": "node ./scripts/postinstall.js",
     "update:core": "npm update @plentymarkets/shop-core",
     "update:sdk": "npm update @plentymarkets/shop-api",
     "turbo:disable-telemetry": "turbo telemetry disable",
@@ -36,7 +37,8 @@
     "test:cypress": "concurrently -k -s=first --names \"cypress,server\" \"npx wait-on http-get://localhost:3000 && npm run turbo:disable-telemetry && turbo run test:cypress\" \"npm run start\"",
     "test:cypress-dev": "concurrently -k -s=first --names \"cypress,server\" \"npx wait-on http-get://localhost:3000 && npm run turbo:disable-telemetry && turbo run test:cypress-dev\" \"npm run start\"",
     "lhci:mobile": "lhci collect --config=lighthouserc.mobile.json && lhci assert",
-    "lhci:desktop": "lhci collect --config=lighthouserc.desktop.json && lhci assert"
+    "lhci:desktop": "lhci collect --config=lighthouserc.desktop.json && lhci assert",
+    "worktree:spawn": "./scripts/spawn-worktree.sh"
   },
   "dependencies": {
     "@plentymarkets/shop-core": "^1.16.1",

--- a/packages/shop-cli/src/core/path/PathResolver.ts
+++ b/packages/shop-cli/src/core/path/PathResolver.ts
@@ -19,7 +19,7 @@ class DefaultPathConfig implements PathConfig {
   }
 
   get webAppRoot(): string {
-    return join(this.projectRoot, '/apps/web/app');
+    return join(this.projectRoot, 'apps/web/app');
   }
 
   get templatesRoot(): string {

--- a/packages/shop-cli/src/core/path/__tests__/PathResolver.test.ts
+++ b/packages/shop-cli/src/core/path/__tests__/PathResolver.test.ts
@@ -3,14 +3,22 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { PathResolver, pathResolver } from '../index';
 import type { PathConfig, PathOptions } from '../types';
 
 describe('PathResolver', () => {
   describe('Default Configuration', () => {
     it('should provide correct default paths', () => {
-      expect(pathResolver.getProjectRoot()).toMatch(/.*plentyshop-pwa$/);
-      expect(pathResolver.getWebAppPath()).toMatch(/.*plentyshop-pwa\/apps\/web\/app$/);
+      const projectRoot = pathResolver.getProjectRoot();
+      const rootPackageJsonPath = join(projectRoot, 'package.json');
+      expect(existsSync(rootPackageJsonPath)).toBe(true);
+
+      const rootPackageJson = JSON.parse(readFileSync(rootPackageJsonPath, 'utf8')) as { name?: string };
+      expect(rootPackageJson.name).toBe('@plentymarkets/plentyshop-pwa');
+
+      expect(pathResolver.getWebAppPath()).toBe(join(projectRoot, 'apps/web/app'));
       expect(pathResolver.getTemplatePath('component')).toMatch(/.*templates\/component$/);
     });
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,40 @@
+# Scripts
+
+## `spawn-worktree.sh`
+Creates one or more Git worktrees under `../pwa-worktree/` (folder name = branch name with `/` replaced by `-`), then bootstraps each worktree:
+
+- loads `nvm` and runs `nvm use` (falls back to `nvm install`)
+- installs dependencies (`npm ci` if `package-lock.json` exists, otherwise `npm install`)
+- runs `npm run lint` and `npm run test`
+
+Usage:
+
+```bash
+./scripts/spawn-worktree.sh <branch> [<branch> ...] [--base <base-ref> | --head] [--worktree-jobs [<n>]]
+```
+
+Examples:
+
+```bash
+# Single worktree
+npm run worktree:spawn -- feat/awesome-feature
+
+# Multiple worktrees
+npm run worktree:spawn -- feat/a feat/b feat/c
+
+# Create worktrees in parallel (bootstrap runs in parallel, "all" when no number is provided)
+npm run worktree:spawn -- feat/a feat/b --worktree-jobs
+
+# Create from a specific base ref
+npm run worktree:spawn -- feat/a feat/b --base release/1.15
+
+# Create from the default branch on origin (origin/HEAD)
+npm run worktree:spawn -- feat/a --head
+```
+
+Notes:
+- If a target folder already exists but is not a registered worktree, the script errors; `git worktree prune` (and/or removing the folder) usually fixes this.
+- Designed for POSIX environments (macOS/Linux). Windows typically requires WSL or Git Bash.
+
+## `postinstall.js`
+`chmod +x` for `scripts/spawn-worktree.sh` during `npm install`, so `npm run worktree:spawn` works reliably on fresh checkouts.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,7 @@
 # Scripts
 
 ## `spawn-worktree.sh`
+
 Creates one or more Git worktrees under `../pwa-worktree/` (folder name = branch name with `/` replaced by `-`), then bootstraps each worktree:
 
 - loads `nvm` and runs `nvm use` (falls back to `nvm install`)
@@ -33,8 +34,10 @@ npm run worktree:spawn -- feat/a --head
 ```
 
 Notes:
+
 - If a target folder already exists but is not a registered worktree, the script errors; `git worktree prune` (and/or removing the folder) usually fixes this.
 - Designed for POSIX environments (macOS/Linux). Windows typically requires WSL or Git Bash.
 
 ## `postinstall.js`
+
 `chmod +x` for `scripts/spawn-worktree.sh` during `npm install`, so `npm run worktree:spawn` works reliably on fresh checkouts.

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,10 @@
+const fs = require('node:fs');
+
+const scriptPath = `${__dirname}/spawn-worktree.sh`;
+
+try {
+  fs.chmodSync(scriptPath, 0o755);
+} catch (error) {
+  // eslint-disable-next-line no-console
+  console.warn(`[postinstall] Skipped chmod for ${scriptPath}: ${String(error?.message ?? error)}`);
+}

--- a/scripts/spawn-worktree.sh
+++ b/scripts/spawn-worktree.sh
@@ -1,0 +1,382 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/spawn-worktree.sh <branch> [<branch> ...] [--base <base-ref> | --head] [--worktree-jobs [<n>]]
+
+Example:
+  scripts/spawn-worktree.sh feat/awesome-feature
+  scripts/spawn-worktree.sh feat/one feat/two feat/three
+  scripts/spawn-worktree.sh feat/awesome-feature --base release/1.15
+  scripts/spawn-worktree.sh feat/awesome-feature --head
+  scripts/spawn-worktree.sh feat/one feat/two --worktree-jobs 4
+  scripts/spawn-worktree.sh feat/one feat/two feat/three --worktree-jobs
+
+This will create a git worktree under ../pwa-worktree/<branch-with-slashes-replaced>.
+EOF
+}
+
+branches=()
+base_ref_override=""
+use_origin_head=false
+worktree_jobs=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      base_ref_override="${2:-}"
+      if [[ -z "$base_ref_override" ]]; then
+        echo "Error: --base requires a value." >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    --head)
+      use_origin_head=true
+      shift
+      ;;
+    --worktree-jobs)
+      worktree_jobs="auto"
+      shift
+      if [[ ${1:-} =~ ^[0-9]+$ ]]; then
+        worktree_jobs="$1"
+        if [[ "$worktree_jobs" -lt 1 ]]; then
+          echo "Error: --worktree-jobs must be a positive integer." >&2
+          exit 1
+        fi
+        shift
+      fi
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      branches+=("$@")
+      break
+      ;;
+    *)
+      branches+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ -n "$base_ref_override" ]] && [[ "$use_origin_head" == true ]]; then
+  echo "Error: use either --base or --head, not both." >&2
+  exit 1
+fi
+
+if [[ ${#branches[@]} -eq 0 ]]; then
+  usage
+  exit 1
+fi
+
+if [[ "$worktree_jobs" == "auto" ]]; then
+  worktree_jobs="${#branches[@]}"
+fi
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"
+if [[ -z "$repo_root" ]]; then
+  echo "Error: not inside a git repository." >&2
+  exit 1
+fi
+
+cd "$repo_root"
+
+base_dir="$repo_root/../pwa-worktree"
+mkdir -p "$base_dir"
+
+git fetch --prune --quiet origin || true
+
+prefetch_remote_branches() {
+  local target_branch
+  for target_branch in "${branches[@]}"; do
+    if git show-ref --verify --quiet "refs/heads/$target_branch"; then
+      continue
+    fi
+
+    if git show-ref --verify --quiet "refs/remotes/origin/$target_branch"; then
+      continue
+    fi
+
+    # Handle non-standard fetch refspecs: if the branch exists on origin but
+    # isn't present locally, fetch it explicitly before starting parallel work.
+    if git ls-remote --exit-code --heads origin "$target_branch" >/dev/null 2>&1; then
+      git fetch --quiet origin "$target_branch":"refs/remotes/origin/$target_branch" || true
+    fi
+  done
+}
+
+prefetch_remote_branches
+
+ensure_branch_ref() {
+  local target_branch="$1"
+
+  if git show-ref --verify --quiet "refs/heads/$target_branch"; then
+    return 0
+  fi
+
+  if git show-ref --verify --quiet "refs/remotes/origin/$target_branch"; then
+    return 0
+  fi
+
+  return 1
+}
+
+worktree_exists() {
+  local target_path="$1"
+  git worktree list --porcelain | grep -Fqx "worktree $target_path"
+}
+
+git_worktree_add_with_retry() {
+  local max_attempts=8
+  local attempt=1
+
+  while true; do
+    local output
+    if output="$(git "$@" 2>&1)"; then
+      return 0
+    fi
+
+    local status=$?
+    if echo "$output" | grep -Eqi 'index\.lock|worktree.*lock|another git process|could not lock|unable to create.*lock'; then
+      if [[ "$attempt" -ge "$max_attempts" ]]; then
+        echo "$output" >&2
+        return "$status"
+      fi
+
+      attempt=$((attempt + 1))
+      sleep 0.2
+      continue
+    fi
+
+    echo "$output" >&2
+    return "$status"
+  done
+}
+
+create_worktree() {
+  local target_branch="$1"
+  local target_path="$2"
+
+  if worktree_exists "$target_path"; then
+    return 0
+  fi
+
+  if [[ -d "$target_path" ]]; then
+    echo "[$target_branch] Error: $target_path exists but is not a registered worktree." >&2
+    echo "[$target_branch] Hint: remove it or run: git worktree prune" >&2
+    return 1
+  fi
+
+  if ensure_branch_ref "$target_branch"; then
+    if git show-ref --verify --quiet "refs/heads/$target_branch"; then
+      git_worktree_add_with_retry worktree add "$target_path" "$target_branch"
+    else
+      git_worktree_add_with_retry worktree add -b "$target_branch" "$target_path" "origin/$target_branch"
+    fi
+  else
+    git_worktree_add_with_retry worktree add -b "$target_branch" "$target_path" "$base_ref"
+  fi
+}
+
+load_nvm() {
+  if command -v nvm >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if [[ -n "${NVM_DIR:-}" ]] && [[ -s "$NVM_DIR/nvm.sh" ]]; then
+    # shellcheck disable=SC1090
+    . "$NVM_DIR/nvm.sh"
+    return 0
+  fi
+
+  if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
+    # shellcheck disable=SC1090
+    . "$HOME/.nvm/nvm.sh"
+    return 0
+  fi
+
+  return 1
+}
+
+bootstrap_worktree() {
+  local target_branch="$1"
+  local target_path="$2"
+
+  cd "$target_path"
+
+  if ! load_nvm; then
+    echo "[$target_branch] Error: nvm not found in this shell (expected 'nvm' or \$NVM_DIR/nvm.sh)." >&2
+    return 1
+  fi
+
+  if ! nvm use; then
+    nvm install
+    nvm use
+  fi
+
+  if [[ -f package-lock.json ]]; then
+    npm ci
+  else
+    npm install
+  fi
+
+  npm run lint
+  npm run test
+}
+
+default_base_ref() {
+  local origin_head
+  origin_head="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+  if [[ -n "$origin_head" ]]; then
+    printf '%s' "${origin_head#origin/}"
+  else
+    printf '%s' "main"
+  fi
+}
+
+current_branch_ref() {
+  git symbolic-ref --quiet --short HEAD 2>/dev/null || true
+}
+
+normalize_base_ref() {
+  local base="$1"
+  if [[ "$base" == refs/* ]] || [[ "$base" == origin/* ]]; then
+    printf '%s' "$base"
+    return 0
+  fi
+
+  if git show-ref --verify --quiet "refs/heads/$base"; then
+    printf '%s' "$base"
+    return 0
+  fi
+
+  if git show-ref --verify --quiet "refs/remotes/origin/$base"; then
+    printf '%s' "origin/$base"
+    return 0
+  fi
+
+  printf '%s' "$base"
+}
+
+if [[ -n "$base_ref_override" ]]; then
+  base_ref="$base_ref_override"
+elif [[ "$use_origin_head" == true ]]; then
+  base_ref="$(default_base_ref)"
+else
+  base_ref="$(current_branch_ref)"
+  if [[ -z "$base_ref" ]]; then
+    base_ref="$(default_base_ref)"
+  fi
+fi
+base_ref="$(normalize_base_ref "$base_ref")"
+
+pids=()
+pid_indices=()
+
+worktree_paths=()
+for branch in "${branches[@]}"; do
+  worktree_name="${branch//\//-}"
+  worktree_paths+=("$base_dir/$worktree_name")
+done
+
+create_pids=()
+create_pid_indices=()
+create_failures=0
+
+reap_finished_creates() {
+  local next_pids=()
+  local next_indices=()
+
+  for i in "${!create_pids[@]}"; do
+    local pid="${create_pids[$i]}"
+    local idx="${create_pid_indices[$i]}"
+    local b="${branches[$idx]}"
+
+    if kill -0 "$pid" 2>/dev/null; then
+      next_pids+=("$pid")
+      next_indices+=("$idx")
+      continue
+    fi
+
+    if ! wait "$pid"; then
+      echo "[$b] Failed to create worktree." >&2
+      create_failures=$((create_failures + 1))
+    fi
+  done
+
+  create_pids=()
+  create_pid_indices=()
+
+  # Bash 3.2 + `set -u` treats `${empty_array[@]}` as "unbound".
+  if [[ ${#next_pids[@]} -gt 0 ]]; then
+    create_pids=("${next_pids[@]}")
+    create_pid_indices=("${next_indices[@]}")
+  fi
+}
+
+wait_for_create_slot() {
+  while [[ "${#create_pids[@]}" -ge "$worktree_jobs" ]]; do
+    reap_finished_creates
+    if [[ "${#create_pids[@]}" -ge "$worktree_jobs" ]]; then
+      sleep 0.1
+    fi
+  done
+}
+
+for i in "${!branches[@]}"; do
+  branch="${branches[$i]}"
+  worktree_path="${worktree_paths[$i]}"
+
+  wait_for_create_slot
+  (
+    create_worktree "$branch" "$worktree_path"
+  ) &
+  create_pids+=("$!")
+  create_pid_indices+=("$i")
+done
+
+while [[ ${#create_pids[@]} -gt 0 ]]; do
+  reap_finished_creates
+  if [[ ${#create_pids[@]} -gt 0 ]]; then
+    sleep 0.1
+  fi
+done
+
+if [[ "$create_failures" -ne 0 ]]; then
+  echo "Error: $create_failures worktree(s) failed to create." >&2
+  exit 1
+fi
+
+for i in "${!branches[@]}"; do
+  branch="${branches[$i]}"
+  worktree_path="${worktree_paths[$i]}"
+
+  (
+    bootstrap_worktree "$branch" "$worktree_path"
+  ) &
+  pids+=("$!")
+  pid_indices+=("$i")
+done
+
+failures=0
+for j in "${!pids[@]}"; do
+  pid="${pids[$j]}"
+  idx="${pid_indices[$j]}"
+  b="${branches[$idx]}"
+  if ! wait "$pid"; then
+    echo "[$b] Failed" >&2
+    failures=$((failures + 1))
+  fi
+done
+
+if [[ "$failures" -ne 0 ]]; then
+  echo "Error: $failures worktree(s) failed to bootstrap." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Issue:

[git - worktree documentation](https://git-scm.com/docs/git-worktree)

A worktree lets you checkout multiple branches of the same repository at the same time. However, for this repository to be in a working state, several additional scripts have to run. Running all scripts manually is time-consuming and error prone.

## Describe your changes

- Adds a bash script to set up worktrees in a pre-defined location (`../pwa-worktree/`) and run all required Node scripts to set up the repository.
- The script contains various options, e.g. creating multiple worktrees at once, or creating them from different bases.
- Updates `PathResolver` tests, so that the tests still pass in the worktree folders, which have different names.
- Doesn't include a Windows version. We can add one later if anyone needs it.

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- None

### Functionality

- [x] Implemented all acceptance criteria from the issue
- [x] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [x] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
