### PR TITLE
ci: only run meta job on pull request

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   meta:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -49,7 +50,6 @@ jobs:
   fitness-compliance:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: meta
     steps:
       - uses: actions/checkout@v6
       - name: Dependency review


### PR DESCRIPTION
## Issue:

Follow-up: #2098 

## Describe your changes

- Only runs `meta` job for pull request event, not in merge groups
- Decouples `fitness-compliance` job from `meta` job

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
