### PR TITLE
test: fix button instance selector

### DIFF
--- a/apps/web/__tests__/test/editor/textcardform.cy.ts
+++ b/apps/web/__tests__/test/editor/textcardform.cy.ts
@@ -5,7 +5,7 @@ describe('Text Card Block Form', () => {
   const openSettingsForTextCardBlock = () => {
     cy.get('[data-testid="TextCard-open-editor-button"]').should('have.length.at.least', 2);
 
-    cy.get('[data-testid="TextCard-open-editor-button"]').eq(1).should('exist').click({ force: true });
+    cy.get('[data-testid="TextCard-open-editor-button"]').first().should('exist').click({ force: true });
     cy.wait(1000);
 
     cy.get('[data-testid="text-card-form"]').should('exist');


### PR DESCRIPTION
## Issue:

https://github.com/plentymarkets/plentyshop-pwa/actions/runs/20708800615

## Describe your changes

- Updates selector of Text Card button to use the first instance for both editing and checking

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- None

### Functionality

- [x] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [x] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
