### PR TITLE
refactor: move editor logic to central composable

### DIFF
--- a/apps/web/app/app.vue
+++ b/apps/web/app/app.vue
@@ -58,16 +58,14 @@
 import { isCssUrl, isJsUrl } from '~/utils/assets';
 import { categoryGetters } from '@plentymarkets/shop-api';
 
-const { $isPreview } = useNuxtApp();
 const bodyClass = ref('');
 const route = useRoute();
 const { disableActions } = useEditor();
 const { drawerOpen, currentFont, placement } = useSiteConfiguration();
 const { setStaticPageMeta } = useCanonical();
+const { isInEditorClient } = useEditorState();
 
-const clientPreview = ref(false);
-
-onNuxtReady(() => (clientPreview.value = !!$isPreview));
+const clientPreview = computed(() => isInEditorClient.value);
 
 const { getSetting: getFavicon } = useSiteSettings('favicon');
 const { getSetting: getOgTitle } = useSiteSettings('ogTitle');

--- a/apps/web/app/components/EditablePage/EditablePage.vue
+++ b/apps/web/app/components/EditablePage/EditablePage.vue
@@ -45,7 +45,7 @@ import type { DragEvent, EditablePageProps } from './types';
 
 const NarrowContainer = resolveComponent('NarrowContainer');
 
-const { $isPreview } = useNuxtApp();
+const { isInEditor, shouldShowEditorUI } = useEditorState();
 const props = withDefaults(defineProps<EditablePageProps>(), {
   hasEnabledActions: true,
   preventBlocksRequest: false,
@@ -59,7 +59,7 @@ const { data, getBlocksServer, cleanData } = useCategoryTemplate(
 const dataIsEmpty = computed(() => data.value.length === 0);
 
 const isContentEmptyInEditor = computed(
-  () => dataIsEmpty.value || (data.value.length === 1 && data.value[0]?.name === 'Footer' && !!$isPreview),
+  () => dataIsEmpty.value || (data.value.length === 1 && data.value[0]?.name === 'Footer' && isInEditor.value),
 );
 
 const isContentEmptyInLive = computed(
@@ -111,19 +111,19 @@ const scrollToBlock = (evt: DragEvent) => {
 
 const { closeDrawer } = useSiteConfiguration();
 const { settingsIsDirty } = useSiteSettings();
-const { isEditingEnabled, disableActions } = useEditor();
+const { isEditingEnabled } = useEditor();
 const { drawerOpen: localizationDrawerOpen } = useEditorLocalizationKeys();
 const { shouldShowBlock, clearRegistry, isHydrationComplete } = useBlocksVisibility();
 
 const enabledActions = computed(
-  () => !!$isPreview && props.hasEnabledActions && disableActions.value && !localizationDrawerOpen.value,
+  () => shouldShowEditorUI.value && props.hasEnabledActions && !localizationDrawerOpen.value,
 );
 
 onMounted(async () => {
   isEditingEnabled.value = false;
   window.addEventListener('beforeunload', handleBeforeUnload);
 
-  if ($isPreview) {
+  if (isInEditor.value) {
     await import('./draggable.css');
   }
 

--- a/apps/web/app/components/Gallery/Gallery.vue
+++ b/apps/web/app/components/Gallery/Gallery.vue
@@ -22,7 +22,7 @@
             :index="index"
             :active-index="activeIndex"
             :is-first-image="index === 0"
-            :disable-zoom="(!!$isPreview && disableActions) || configuration.thumbnails.enableHoverZoom === false"
+            :disable-zoom="shouldEnableEditorFeatures || configuration.thumbnails.enableHoverZoom === false"
           />
         </SwiperSlide>
       </Swiper>
@@ -123,8 +123,7 @@ const props = withDefaults(defineProps<GalleryProps>(), {
   }),
 });
 
-const { $isPreview } = useNuxtApp();
-const { disableActions } = useEditor();
+const { shouldEnableEditorFeatures } = useEditorState();
 
 const configuration = computed(() => props.configuration);
 const { images } = toRefs(props);

--- a/apps/web/app/components/PageBlock/PageBlock.vue
+++ b/apps/web/app/components/PageBlock/PageBlock.vue
@@ -109,7 +109,7 @@ const props = withDefaults(defineProps<PageBlockProps>(), {
   enableActions: false,
 });
 
-const { $isPreview } = useNuxtApp();
+const { isInEditorClient } = useEditorState();
 const { locale, defaultLocale } = useI18n();
 const route = useRoute();
 const { drawerOpen, drawerView, openDrawerWithView } = useSiteConfiguration();
@@ -199,7 +199,7 @@ const observeLazyLoadSection = (blockName: string) => {
 };
 
 onNuxtReady(() => {
-  clientPreview.value = !!$isPreview;
+  clientPreview.value = isInEditorClient.value;
   if (shouldLazyLoad(props.block.name)) observeLazyLoadSection(props.block.name);
 });
 

--- a/apps/web/app/components/PreviewMode/PreviewMode.vue
+++ b/apps/web/app/components/PreviewMode/PreviewMode.vue
@@ -1,6 +1,6 @@
 <template>
   <client-only>
-    <div v-if="$isPreview">
+    <div v-if="isInEditor">
       <div
         v-if="!bannerIsHidden"
         class="fixed z-50 w-fit h-fit bottom-[7.3rem] md:bottom-14 left-2 xl:left-auto xl:right-2 shadow-2xl p-3 bg-white rounded overflow-auto"
@@ -58,7 +58,7 @@ import storeBlack from '/assets/icons/paths/store-black.svg';
 import { SfIconWarning } from '@storefront-ui/vue';
 import type { RemoveLookupCookie } from './types';
 
-const { $isPreview } = useNuxtApp();
+const { isInEditor } = useEditorState();
 
 const { isEditingEnabled } = useEditor();
 const { settingsIsDirty } = useSiteSettings();

--- a/apps/web/app/components/blocks/CategoryData/CategoryData.vue
+++ b/apps/web/app/components/blocks/CategoryData/CategoryData.vue
@@ -113,10 +113,7 @@ const enabledText = computed(
 const showNoTextMessage = computed(() => !enabledText.value);
 const { isEditMode, isPreviewMode, isLiveMode } = useEditorState();
 const shouldShowTextBlock = computed(
-  () =>
-    isEditMode.value ||
-    (isPreviewMode.value && !showNoTextMessage.value) ||
-    (isLiveMode.value && !showNoTextMessage.value),
+  () => isEditMode.value || ((isPreviewMode.value || isLiveMode.value) && !showNoTextMessage.value),
 );
 
 const details = computed(() => categoryGetters.getCategoryDetails(category.value) || ({} as CategoryDetails));

--- a/apps/web/app/components/blocks/CategoryData/CategoryData.vue
+++ b/apps/web/app/components/blocks/CategoryData/CategoryData.vue
@@ -102,7 +102,6 @@ const runtimeConfig = useRuntimeConfig();
 const props = defineProps<CategoryDataProps>();
 const { hexToRgba, getTextAlignment, getContentPosition, isMobile } = useBlockContentHelper();
 const { data: productsCatalog } = useProducts();
-const { disableActions } = useEditor();
 const category = computed(() => productsCatalog.value.category || ({} as Category));
 const enabledText = computed(
   () =>
@@ -112,12 +111,12 @@ const enabledText = computed(
     (props.content.fields.shortDescription && details.value.shortDescription),
 );
 const showNoTextMessage = computed(() => !enabledText.value);
-const { $isPreview } = useNuxtApp();
+const { isEditMode, isPreviewMode, isLiveMode } = useEditorState();
 const shouldShowTextBlock = computed(
   () =>
-    (!!$isPreview && disableActions.value) ||
-    (!disableActions.value && !showNoTextMessage.value) ||
-    (!$isPreview && disableActions.value && !showNoTextMessage.value),
+    isEditMode.value ||
+    (isPreviewMode.value && !showNoTextMessage.value) ||
+    (isLiveMode.value && !showNoTextMessage.value),
 );
 
 const details = computed(() => categoryGetters.getCategoryDetails(category.value) || ({} as CategoryDetails));

--- a/apps/web/app/components/blocks/ItemData/ItemData.vue
+++ b/apps/web/app/components/blocks/ItemData/ItemData.vue
@@ -65,9 +65,7 @@ const props = defineProps<{
 const { t } = useI18n();
 const { currentProduct } = useProducts();
 
-const { $isPreview } = useNuxtApp();
-
-const { disableActions } = useEditor();
+const { isEditMode } = useEditorState();
 
 const { fieldValues } = useItemDataTable(currentProduct as Ref<Product | null>, {
   t,
@@ -107,9 +105,7 @@ const noFieldsSelected = computed(() => {
   return values.every((v) => !v);
 });
 
-const showNoDataMessage = computed(
-  () => !!$isPreview && disableActions.value && !hasTitle.value && noFieldsSelected.value,
-);
+const showNoDataMessage = computed(() => isEditMode.value && !hasTitle.value && noFieldsSelected.value);
 
 const visibleRows = computed(() => {
   const order =

--- a/apps/web/app/components/blocks/SortFilter/SortFilter.vue
+++ b/apps/web/app/components/blocks/SortFilter/SortFilter.vue
@@ -93,12 +93,10 @@ const props = defineProps<SortFilterProps>();
 const showSortAndFilter = ref(false);
 const { isOpen, open, close } = useDisclosure();
 const { t } = useI18n({ useScope: 'global' });
-const clientPreview = ref(false);
 
-const { $isPreview } = useNuxtApp();
-onNuxtReady(() => {
-  clientPreview.value = !!$isPreview;
-});
+const { isInEditorClient } = useEditorState();
+const clientPreview = computed(() => isInEditorClient.value);
+
 const showAllFiltersImmediately = computed(() => props.content?.showAllFiltersImmediately ?? true);
 const numberOfFiltersToShowInitially = computed(() => props.content?.numberOfFiltersToShowInitially ?? 0);
 

--- a/apps/web/app/components/blocks/structure/MultiGrid/EmptyGridBlock.vue
+++ b/apps/web/app/components/blocks/structure/MultiGrid/EmptyGridBlock.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="!!$isPreview && disableActions" class="flex w-full">
+  <div v-if="isEditMode" class="flex w-full">
     <div
       v-if="drawerOpen && isActiveColumn"
       data-testid="active-empty-multicolumn"
@@ -24,9 +24,8 @@
 import { SfIconAdd } from '@storefront-ui/vue';
 import type { EmptyGridBlockProps } from '~/components/blocks/structure/MultiGrid/types';
 
-const { $isPreview } = useNuxtApp();
-const { disableActions } = useEditor();
 const props = defineProps<EmptyGridBlockProps>();
+const { isEditMode } = useEditorState();
 const { multigridColumnUuid, updateMultigridColumnUuid, visiblePlaceholder } = useBlockManager();
 const { openDrawerWithView, drawerOpen } = useSiteConfiguration();
 

--- a/apps/web/app/components/blocks/structure/MultiGrid/MultiGrid.vue
+++ b/apps/web/app/components/blocks/structure/MultiGrid/MultiGrid.vue
@@ -66,7 +66,7 @@ const onRowLeave = () => {
 };
 const isRowHovered = (row: Block) => hoveredRowUuid.value === row.meta.uuid;
 
-const { $isPreview } = useNuxtApp();
+const { shouldEnableEditorFeatures } = useEditorState();
 const { isDragging } = useBlockManager();
 const attrs = useAttrs() as { enableActions?: boolean; root?: boolean };
 const { getSetting: getBlockSize } = useSiteSettings('verticalBlockSize');
@@ -121,7 +121,8 @@ const enableActions = computed(() => attrs.enableActions === true);
 const blockHasData = (block: Block): boolean => !!block.content && Object.keys(block.content).length > 0;
 
 const showOverlay = computed(
-  () => (block: Block) => enableActions.value && !!$isPreview && !isDragging.value && blockHasData(block),
+  () => (block: Block) =>
+    enableActions.value && shouldEnableEditorFeatures.value && !isDragging.value && blockHasData(block),
 );
 
 const isAlignable = (b: Block): b is AlignableBlock =>

--- a/apps/web/app/composables/index.ts
+++ b/apps/web/app/composables/index.ts
@@ -44,6 +44,7 @@ export * from './useCustomerOrders';
 export * from './useCustomerReturns';
 export * from './useDrawerState';
 export * from './useEditor';
+export * from './useEditorState';
 export * from './useGooglePay';
 export * from './useInitialSetup';
 export * from './useImageZoom';

--- a/apps/web/app/composables/useEditorState/__tests__/useEditorState.spec.ts
+++ b/apps/web/app/composables/useEditorState/__tests__/useEditorState.spec.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
+import { ref } from 'vue';
+import { useEditorState } from '../useEditorState';
+
+const $isPreview = ref(false);
+const disableActions = ref(true);
+
+mockNuxtImport('useNuxtApp', () => () => ({
+  $isPreview: $isPreview.value,
+}));
+
+mockNuxtImport('useEditor', () => () => ({
+  disableActions,
+}));
+
+describe('useEditorState', () => {
+  describe('when in live mode', () => {
+    beforeEach(() => {
+      $isPreview.value = false;
+      disableActions.value = true;
+    });
+
+    it('should return correct live mode state', () => {
+      const state = useEditorState();
+      expect(state.isInEditor.value).toBe(false);
+      expect(state.isLiveMode.value).toBe(true);
+      expect(state.isEditMode.value).toBe(false);
+      expect(state.isPreviewMode.value).toBe(false);
+    });
+
+    it('should not show editor UI', () => {
+      const state = useEditorState();
+      expect(state.shouldShowEditorUI.value).toBe(false);
+    });
+
+    it('should not use fake data', () => {
+      const state = useEditorState();
+      expect(state.shouldUseFakeData.value).toBe(false);
+    });
+
+    it('should hide zero values', () => {
+      const state = useEditorState();
+      expect(state.shouldHideZeroValues.value).toBe(true);
+    });
+
+    it('should not enable editor features', () => {
+      const state = useEditorState();
+      expect(state.shouldEnableEditorFeatures.value).toBe(false);
+    });
+  });
+
+  describe('when in edit mode', () => {
+    beforeEach(() => {
+      $isPreview.value = true;
+      disableActions.value = true;
+    });
+
+    it('should return correct edit mode state', () => {
+      const state = useEditorState();
+      expect(state.isInEditor.value).toBe(true);
+      expect(state.isEditMode.value).toBe(true);
+      expect(state.isPreviewMode.value).toBe(false);
+      expect(state.isLiveMode.value).toBe(false);
+    });
+
+    it('should show editor UI', () => {
+      const state = useEditorState();
+      expect(state.shouldShowEditorUI.value).toBe(true);
+    });
+
+    it('should use fake data', () => {
+      const state = useEditorState();
+      expect(state.shouldUseFakeData.value).toBe(true);
+    });
+
+    it('should not hide zero values', () => {
+      const state = useEditorState();
+      expect(state.shouldHideZeroValues.value).toBe(false);
+    });
+
+    it('should enable editor features', () => {
+      const state = useEditorState();
+      expect(state.shouldEnableEditorFeatures.value).toBe(true);
+    });
+  });
+
+  describe('when in preview mode', () => {
+    beforeEach(() => {
+      $isPreview.value = true;
+      disableActions.value = false;
+    });
+
+    it('should return correct preview mode state', () => {
+      const state = useEditorState();
+      expect(state.isInEditor.value).toBe(true);
+      expect(state.isPreviewMode.value).toBe(true);
+      expect(state.isEditMode.value).toBe(false);
+      expect(state.isLiveMode.value).toBe(false);
+    });
+
+    it('should not show editor UI', () => {
+      const state = useEditorState();
+      expect(state.shouldShowEditorUI.value).toBe(false);
+    });
+
+    it('should not use fake data', () => {
+      const state = useEditorState();
+      expect(state.shouldUseFakeData.value).toBe(false);
+    });
+
+    it('should hide zero values', () => {
+      const state = useEditorState();
+      expect(state.shouldHideZeroValues.value).toBe(true);
+    });
+
+    it('should not enable editor features', () => {
+      const state = useEditorState();
+      expect(state.shouldEnableEditorFeatures.value).toBe(false);
+    });
+  });
+
+  describe('client-side hydration support', () => {
+    beforeEach(() => {
+      $isPreview.value = true;
+      disableActions.value = true;
+    });
+
+    it('should initialize isInEditorClient as false', () => {
+      const state = useEditorState();
+      expect(state.isInEditorClient.value).toBe(false);
+    });
+  });
+});

--- a/apps/web/app/composables/useEditorState/__tests__/useEditorState.spec.ts
+++ b/apps/web/app/composables/useEditorState/__tests__/useEditorState.spec.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
-import { ref } from 'vue';
 import { useEditorState } from '../useEditorState';
 
 const $isPreview = ref(false);

--- a/apps/web/app/composables/useEditorState/index.ts
+++ b/apps/web/app/composables/useEditorState/index.ts
@@ -1,0 +1,2 @@
+export * from './useEditorState';
+export * from './types';

--- a/apps/web/app/composables/useEditorState/types.ts
+++ b/apps/web/app/composables/useEditorState/types.ts
@@ -1,0 +1,31 @@
+import type { ComputedRef, Ref } from 'vue';
+
+/**
+ * @description Return type for useEditorState composable
+ * Provides semantic state checks and feature flags for editor functionality
+ */
+export interface UseEditorStateReturn {
+  // Core states
+  /** Whether we are in the editor environment (true in both edit and preview modes) */
+  isInEditor: ComputedRef<boolean>;
+  /** Whether we are in edit mode (can modify blocks, shows editor UI, uses fake data) */
+  isEditMode: ComputedRef<boolean>;
+  /** Whether we are in preview mode (viewing changes without editing) */
+  isPreviewMode: ComputedRef<boolean>;
+  /** Whether we are in live/production mode (no editor features) */
+  isLiveMode: ComputedRef<boolean>;
+
+  // Feature flags
+  /** Whether to show editor UI elements (toolbars, overlays, etc.) */
+  shouldShowEditorUI: ComputedRef<boolean>;
+  /** Whether to use fake/example data instead of real API data */
+  shouldUseFakeData: ComputedRef<boolean>;
+  /** Whether to hide zero/empty values in displays */
+  shouldHideZeroValues: ComputedRef<boolean>;
+  /** Whether to enable editor features (drag-drop, zoom controls, etc.) */
+  shouldEnableEditorFeatures: ComputedRef<boolean>;
+
+  // Client-side
+  /** Client-side only editor check (guaranteed to be set post-hydration) */
+  isInEditorClient: Ref<boolean>;
+}

--- a/apps/web/app/composables/useEditorState/types.ts
+++ b/apps/web/app/composables/useEditorState/types.ts
@@ -1,5 +1,3 @@
-import type { ComputedRef, Ref } from 'vue';
-
 /**
  * @description Return type for useEditorState composable
  * Provides semantic state checks and feature flags for editor functionality

--- a/apps/web/app/composables/useEditorState/useEditorState.ts
+++ b/apps/web/app/composables/useEditorState/useEditorState.ts
@@ -1,0 +1,62 @@
+import type { UseEditorStateReturn } from './types';
+
+/**
+ * @description Composable for managing editor state conditions
+ * Centralizes all `$isPreview` logic into semantic, well-named computed properties
+ * @returns UseEditorStateReturn - Editor state properties and feature flags
+ * @example
+ * ``` ts
+ * const { isEditMode, shouldUseFakeData } = useEditorState();
+ * if (shouldUseFakeData.value) {
+ *   // Use fake data for editor
+ * }
+ * ```
+ */
+export const useEditorState = (): UseEditorStateReturn => {
+  const { $isPreview } = useNuxtApp();
+  const { disableActions } = useEditor();
+
+  /** @description Whether we are in the editor environment (true in both edit and preview modes) */
+  const isInEditor = computed(() => !!$isPreview);
+
+  /** @description Whether we are in edit mode (can modify blocks, shows editor UI, uses fake data) */
+  const isEditMode = computed(() => !!$isPreview && disableActions.value);
+
+  /** @description Whether we are in preview mode (viewing changes without editing) */
+  const isPreviewMode = computed(() => !!$isPreview && !disableActions.value);
+
+  /** @description Whether we are in live/production mode (no editor features) */
+  const isLiveMode = computed(() => !$isPreview);
+
+  /** @description Whether to show editor UI elements (toolbars, overlays, etc.) */
+  const shouldShowEditorUI = computed(() => isEditMode.value);
+
+  /** @description Whether to enable editor features (drag-drop, zoom controls, etc.) */
+  const shouldEnableEditorFeatures = computed(() => isEditMode.value);
+
+  /** @description Whether to use fake/example data instead of real API data */
+  const shouldUseFakeData = computed(() => isEditMode.value);
+
+  /** @description Whether to hide zero/empty values in displays */
+  const shouldHideZeroValues = computed(() => isPreviewMode.value || isLiveMode.value);
+
+  /** @description Client-side only editor check (guaranteed to be set post-hydration) */
+  const isInEditorClient = ref(false);
+  onNuxtReady(() => {
+    isInEditorClient.value = !!$isPreview;
+  });
+
+  return {
+    isInEditor,
+    isEditMode,
+    isPreviewMode,
+    isLiveMode,
+
+    shouldShowEditorUI,
+    shouldUseFakeData,
+    shouldHideZeroValues,
+    shouldEnableEditorFeatures,
+
+    isInEditorClient,
+  };
+};

--- a/apps/web/app/composables/useItemDataTable/useItemDataTable.ts
+++ b/apps/web/app/composables/useItemDataTable/useItemDataTable.ts
@@ -14,8 +14,7 @@ import {
 import type { TranslateFn } from '~/composables/useItemDataTable/types';
 
 export function useItemDataTable(productRef: Ref<Product | null>, options?: { t?: TranslateFn }) {
-  const { $isPreview } = useNuxtApp();
-  const { disableActions } = useEditor();
+  const { shouldHideZeroValues } = useEditorState();
 
   const fieldValues = computed<ItemDataFieldValues>(() => {
     const product = productRef.value as Product | null;
@@ -45,7 +44,7 @@ export function useItemDataTable(productRef: Ref<Product | null>, options?: { t?
     const widthMM = variation.widthMM ?? null;
     const heightMM = variation.heightMM ?? null;
 
-    const hideZeroInPreview = ($isPreview && !disableActions.value) || !$isPreview;
+    const hideZeroInPreview = shouldHideZeroValues.value;
 
     const shouldHideWeightG = hideZeroInPreview && weightG === 0;
     const shouldHideWeightNetG = hideZeroInPreview && weightNetG === 0;

--- a/apps/web/app/composables/useProduct/useProduct.ts
+++ b/apps/web/app/composables/useProduct/useProduct.ts
@@ -55,7 +55,8 @@ export const useProduct: UseProductReturn = (slug) => {
 
   const fetchProduct: FetchProduct = async (params: ProductParams) => {
     const route = useRoute();
-    const { $i18n, $isPreview } = useNuxtApp();
+    const { $i18n } = useNuxtApp();
+    const { isInEditor } = useEditorState();
     const {
       data: blockData,
       setupBlocks,
@@ -68,7 +69,7 @@ export const useProduct: UseProductReturn = (slug) => {
 
     state.value.loading = true;
 
-    if (isGlobalProductDetailsTemplate.value && $isPreview) {
+    if (isGlobalProductDetailsTemplate.value && isInEditor.value) {
       const fakeProduct = $i18n.locale.value === 'en' ? fakeProductEN : fakeProductDE;
 
       await getBlocksServer(route.meta.identifier as string, route.meta.type as string);
@@ -137,12 +138,10 @@ export const useProduct: UseProductReturn = (slug) => {
       ],
     });
   };
-  const { disableActions } = useEditor();
-  const { $isPreview } = useNuxtApp();
 
-  const productForEditor = computed(() =>
-    $isPreview && disableActions.value ? state.value.fakeData : state.value.data,
-  );
+  const { shouldUseFakeData } = useEditorState();
+
+  const productForEditor = computed(() => (shouldUseFakeData.value ? state.value.fakeData : state.value.data));
 
   return {
     setProductMeta,

--- a/apps/web/app/composables/useProducts/useProducts.ts
+++ b/apps/web/app/composables/useProducts/useProducts.ts
@@ -52,7 +52,8 @@ export const useProducts: UseProductsReturn = (category = '') => {
    */
   const fetchProducts: FetchProducts = async (params: FacetSearchCriteria) => {
     const route = useRoute();
-    const { $i18n, $isPreview } = useNuxtApp();
+    const { $i18n } = useNuxtApp();
+    const { isInEditor } = useEditorState();
     const {
       data: blockData,
       setupBlocks,
@@ -63,7 +64,7 @@ export const useProducts: UseProductsReturn = (category = '') => {
 
     if (params.categoryUrlPath?.endsWith('.js')) return state.value.data;
 
-    if (isGlobalProductCategoryTemplate.value && $isPreview) {
+    if (isGlobalProductCategoryTemplate.value && isInEditor.value) {
       const fakeFacet = $i18n.locale.value === 'en' ? fakeFacetCallEN : fakeFacetCallDE;
 
       await getBlocksServer(route.meta.identifier as string, route.meta.type as string);

--- a/apps/web/app/utils/handle-preview-product.ts
+++ b/apps/web/app/utils/handle-preview-product.ts
@@ -42,8 +42,8 @@ const getFakeProductForLanguage = (lang: string, variationId?: number): Product 
 };
 
 export const handlePreviewProduct = (state: Ref<UseProductState>, lang: string, shouldComplement: boolean) => {
-  const { $isPreview } = useNuxtApp();
-  if (!$isPreview) return;
+  const { isInEditor } = useEditorState();
+  if (!isInEditor.value) return;
 
   const variationId = state.value.data?.variation?.id;
   const fakeProduct = getFakeProductForLanguage(lang, variationId ? Number(variationId) : undefined);

--- a/apps/web/app/utils/handle-preview-products.ts
+++ b/apps/web/app/utils/handle-preview-products.ts
@@ -6,8 +6,8 @@ import { fakeProductDE } from './facets/fakeProductDE';
 import type { UseProductsState } from '~/composables/useProducts/types';
 
 export const handlePreviewProducts = (state: Ref<UseProductsState>, lang: string) => {
-  const { $isPreview } = useNuxtApp();
-  if (!$isPreview || state.value.data.products.length > 0) return;
+  const { isInEditor } = useEditorState();
+  if (!isInEditor.value || state.value.data.products.length > 0) return;
 
   if (state.value.data.category.type === 'item') {
     const fakeFacetCall = lang === 'de' ? fakeFacetCallDE.data : fakeFacetCallEN.data;

--- a/apps/web/app/utils/sendFakeDataNotification.ts
+++ b/apps/web/app/utils/sendFakeDataNotification.ts
@@ -2,7 +2,7 @@
  * Sends a notification to inform users about example data in editor preview mode.
  *
  * This notification only appears when the application is running in PlentyONE editor
- * preview mode ($isPreview is true). It informs users that fields without product data
+ * preview mode (isInEditor is true). It informs users that fields without product data
  * are displaying example data for editing purposes, and suggests switching to preview
  * mode to view only real data.
  *
@@ -13,8 +13,8 @@
  * ```
  */
 export const sendFakeDataNotification = () => {
-  const { $isPreview } = useNuxtApp();
-  if (!$isPreview) return;
+  const { isInEditor } = useEditorState();
+  if (!isInEditor.value) return;
 
   const { send } = useNotification();
   send({

--- a/package-lock.json
+++ b/package-lock.json
@@ -463,6 +463,7 @@
       "integrity": "sha512-KL1zWTzrlN4MSiaK1ea560iCA/UewMbS4ZsLQRPoDTWyrbDKVbztkPwwv764LAqgXk0fvkNZvJ3IelcK7DqhjQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.20.0",
         "@algolia/requester-browser-xhr": "5.20.0",
@@ -672,6 +673,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -2892,7 +2894,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.1.0",
         "tslib": "^2.4.0"
@@ -2905,7 +2906,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -6513,6 +6513,7 @@
       "integrity": "sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "eslint-scope": "^8.2.0",
@@ -7582,7 +7583,6 @@
       "integrity": "sha512-8es3Mt8TxM+77icxI+Gelds0txaYR0ZfLORB9I2bgUC6p6ID0n3F+7aoEhCWiyVKgVd2cI17yCJwXSPABN5xTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/kit": "^4.0.3",
         "@vueuse/core": "^13.7.0",
@@ -7629,7 +7629,6 @@
       "integrity": "sha512-WK0yPIqcb3GQ8r4GutF6p/2fsyXnmmmkuwVLzN4YaJHrpA2tjEagjbxdjkWYeHW8o4XIKJ4micah4wPOVK49Mg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "c12": "^3.3.0",
         "consola": "^3.4.2",
@@ -7663,8 +7662,7 @@
       "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
       "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@nuxt/scripts/node_modules/@vueuse/core": {
       "version": "13.9.0",
@@ -7672,7 +7670,6 @@
       "integrity": "sha512-ts3regBQyURfCE2BcytLqzm8+MmLlo5Ln/KLoxDVcsZ2gzIwVNnQpQOL/UKV8alUqjSZOlpFZcRNsLRqj+OzyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/web-bluetooth": "^0.0.21",
         "@vueuse/metadata": "13.9.0",
@@ -7691,7 +7688,6 @@
       "integrity": "sha512-1AFRvuiGphfF7yWixZa0KwjYH8ulyjDCC0aFgrGRz8+P4kvDFSdXLVfTk5xAN9wEuD1J6z4/myMoYbnHoX07zg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
@@ -7702,7 +7698,6 @@
       "integrity": "sha512-e89uuTLMh0U5cZ9iDpEI2senqPGfbPRTHM/0AaQkcxnpqjkZqDYP8rpfm7edOz8s+pOCOROEy1PIveSW8+fL5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       },
@@ -7715,8 +7710,7 @@
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
       "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@nuxt/scripts/node_modules/ignore": {
       "version": "7.0.5",
@@ -7724,7 +7718,6 @@
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -7734,16 +7727,14 @@
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@nuxt/scripts/node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@nuxt/scripts/node_modules/pkg-types": {
       "version": "2.3.0",
@@ -7751,7 +7742,6 @@
       "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
@@ -7764,7 +7754,6 @@
       "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@polka/url": "^1.0.0-next.24",
         "mrmime": "^2.0.0",
@@ -7780,7 +7769,6 @@
       "integrity": "sha512-nwNCjxJTjNuLCgFr42fEak5OcLuB3ecca+9ksPFNvtfYSLpjf+iJqSIaSnIile6ZPbKYxI5k2AfXqeopGudK/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "citty": "^0.1.6",
         "defu": "^6.1.4",
@@ -8084,21 +8072,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/@nuxt/vite-builder/node_modules/meow": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
-      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@nuxt/vite-builder/node_modules/npm-run-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
@@ -8178,6 +8151,7 @@
       "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -9160,6 +9134,7 @@
       "integrity": "sha512-ARBedLm9YlbvQomnmq91Os7ck6efydTSpRP3nuOKCvgJOHNrhRoJDSKtee8kcL1Vf7nz6U+PMBL+hTvR3bTVQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^6.6.4"
       },
@@ -12081,7 +12056,8 @@
       "version": "3.58.1",
       "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.58.1.tgz",
       "integrity": "sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/googlepay": {
       "version": "0.7.10",
@@ -12133,7 +12109,8 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -12175,6 +12152,7 @@
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -12234,6 +12212,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.1.tgz",
       "integrity": "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -12447,6 +12426,7 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -12854,6 +12834,7 @@
       "integrity": "sha512-Ym9f+Kd2Afqek2FtUHvYvK+j2uZ2vbZ6Rr9NCnNGGBMdmafAuiZpT117YGyh0ARcueL6Znia0U8ySqPsnHOZIg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hookable": "^5.5.3",
         "unhead": "2.0.14"
@@ -12877,8 +12858,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-android-arm64": {
       "version": "1.11.1",
@@ -12892,8 +12872,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
       "version": "1.11.1",
@@ -12907,8 +12886,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
       "version": "1.11.1",
@@ -12922,8 +12900,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
       "version": "1.11.1",
@@ -12937,8 +12914,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
       "version": "1.11.1",
@@ -12952,8 +12928,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
       "version": "1.11.1",
@@ -12967,8 +12942,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
       "version": "1.11.1",
@@ -12982,8 +12956,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
       "version": "1.11.1",
@@ -12997,8 +12970,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
       "version": "1.11.1",
@@ -13012,8 +12984,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
       "version": "1.11.1",
@@ -13027,8 +12998,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
       "version": "1.11.1",
@@ -13042,8 +13012,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
       "version": "1.11.1",
@@ -13057,8 +13026,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
       "version": "1.11.1",
@@ -13072,8 +13040,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
       "version": "1.11.1",
@@ -13087,8 +13054,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
       "version": "1.11.1",
@@ -13100,7 +13066,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "^0.2.11"
       },
@@ -13115,7 +13080,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
@@ -13134,8 +13098,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
       "version": "1.11.1",
@@ -13149,8 +13112,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
       "version": "1.11.1",
@@ -13164,8 +13126,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@vee-validate/nuxt": {
       "version": "4.15.1",
@@ -13730,6 +13691,7 @@
       "integrity": "sha512-jV7AbNoFPAY1EkFYpLq5bslU9NLNO8xnEeQXwErNibVryjk67wHVmddTBilc5srIttJDBrB0eMHKZBFbSIABCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -14204,6 +14166,7 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.26.tgz",
       "integrity": "sha512-egp69qDTSEZcf4bGOSsprUr4xI73wfrY5oRs6GSgXFTiHrWj4Y3X5Ydtip9QMqiCMCPVwLglB9GBxXtTadJ3mA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.28.5",
         "@vue/compiler-core": "3.5.26",
@@ -14781,6 +14744,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -14851,6 +14815,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -14875,6 +14840,7 @@
       "integrity": "sha512-groO71Fvi5SWpxjI9Ia+chy0QBwT61mg6yxJV27f5YFf+Mw+STT75K6SHySpP8Co5LsCrtsbCH5dJZSRtkSKaQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-abtesting": "5.20.0",
         "@algolia/client-analytics": "5.20.0",
@@ -15647,6 +15613,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "browserslist": "^4.24.4",
         "caniuse-lite": "^1.0.30001702",
@@ -15713,6 +15680,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
       "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -15789,22 +15757,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
-    },
-    "node_modules/bare-events": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
-      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peerDependencies": {
-        "bare-abort-controller": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        }
-      }
     },
     "node_modules/bare-fs": {
       "version": "4.0.1",
@@ -16146,6 +16098,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -16999,7 +16952,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.1.90"
       }
@@ -18130,6 +18082,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cypress/request": "^3.0.9",
         "@cypress/xvfb": "^1.2.4",
@@ -18534,6 +18487,7 @@
       "resolved": "https://registry.npmjs.org/db0/-/db0-0.3.2.tgz",
       "integrity": "sha512-xzWNQ6jk/+NtdfLyXEipbX55dmDSeteLFt/ayF+wZUU5bzKgmrDOxmInUTbyVRp46YwnJdkDA1KhB7WIXFofJw==",
       "devOptional": true,
+      "peer": true,
       "peerDependencies": {
         "@electric-sql/pglite": "*",
         "@libsql/client": "*",
@@ -18903,7 +18857,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1467305.tgz",
       "integrity": "sha512-LxwMLqBoPPGpMdRL4NkLFRNy3QLp6Uqa7GNp1v6JaBheop2QrB9Q7q0A/q/CYYP9sBfZdHOyszVx4gc9zyk7ow==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/dfa": {
       "version": "1.2.0",
@@ -19507,6 +19462,7 @@
       "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -19598,6 +19554,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -19741,6 +19698,7 @@
       "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^3.2.7",
         "is-core-module": "^2.13.0",
@@ -19870,6 +19828,7 @@
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -21586,6 +21545,7 @@
       "integrity": "sha512-xx560wGBk7seZ6y933idtjJQc1l+ck+pI3sKvhKozdBV1dRZoKhkW5xoCaFv9tQiX5RH1xfSxjuNu6g+lmN/gw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -22412,6 +22372,7 @@
       "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -22952,6 +22913,7 @@
       "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.5.tgz",
       "integrity": "sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cookie-es": "^1.2.2",
         "crossws": "^0.3.5",
@@ -23920,6 +23882,7 @@
       "integrity": "sha512-AUXbKn9gvo9hHKvk6LbZJQSKn/qIfkWXrnsyL9Yrf+oeXmla9Nmf6XEumOddyhM8neynpK5oAV6r9r99KBuwzA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.4.0",
         "cluster-key-slot": "^1.1.0",
@@ -26978,6 +26941,7 @@
       "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -29617,6 +29581,7 @@
       "integrity": "sha512-refms9HQoAlTYIazONYkuX5A3rFGPddbD6Otyc+A0/pj1WTttR8TsZRlMzQxCfhexxfrbinqd7ebkEoYNuCmLQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "^0.94.0"
       },
@@ -30131,6 +30096,7 @@
       "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -30234,6 +30200,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -30699,6 +30666,7 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -31146,6 +31114,7 @@
       "integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -32333,6 +32302,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.1.tgz",
       "integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -32597,6 +32567,7 @@
       "integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -34169,6 +34140,7 @@
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -34404,6 +34376,7 @@
       "integrity": "sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==",
       "devOptional": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -35656,6 +35629,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -35682,7 +35656,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -35699,7 +35672,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -35716,7 +35688,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -35733,7 +35704,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -35750,7 +35720,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -35767,7 +35736,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -35784,7 +35752,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -35801,7 +35768,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -35818,7 +35784,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -35835,7 +35800,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -35852,7 +35816,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -35869,7 +35832,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -35886,7 +35848,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -35903,7 +35864,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -35920,7 +35880,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -35937,7 +35896,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -35954,7 +35912,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -35971,7 +35928,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -35988,7 +35944,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36005,7 +35960,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36022,7 +35976,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36039,7 +35992,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36056,7 +36008,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36073,7 +36024,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36090,7 +36040,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36107,7 +36056,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36452,6 +36400,7 @@
       "integrity": "sha512-9Uu4WR9L7ZBgAl60N/h+jqmPxxvnC9nQAlnnO/OujtG2ubjnKTVUFY1XDhcMY+pCqlX3N2HsQM2QTYZIU9tJuw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 18"
       },
@@ -36500,6 +36449,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -36575,6 +36525,7 @@
       "integrity": "sha512-D7DbgGFtsqIPIFMPJwCad9Gfi/hC0PWErRRHFnaCWoEDYi5tQUDiJCTmGUbBiLzjqAck4KcXt9Ayj0CNlIrF+w==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.16.0",
         "@typescript-eslint/types": "8.16.0",
@@ -37401,6 +37352,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },
@@ -37728,7 +37680,6 @@
       "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "typescript": ">=5"
       },
@@ -37844,6 +37795,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -38154,6 +38106,7 @@
       "integrity": "sha512-Q4SC/4TqbNvaZIFb9YsfBqkGlYHbJJJ6uU3CnRBZqLUF3s5eCMVZAaV4GkTbehIH/bhSj42lMXztOwc71u6rVw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vuetify/loader-shared": "^2.1.2",
         "debug": "^4.3.3",
@@ -38763,6 +38716,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -38880,6 +38834,7 @@
       "integrity": "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -38960,6 +38915,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.26.tgz",
       "integrity": "sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.26",
         "@vue/compiler-sfc": "3.5.26",
@@ -39057,6 +39013,7 @@
       "integrity": "sha512-ULIKZyRluUPRCZmihVgUvpq8hJTtOqnbGZuv4Lz+byEKZq4mU0g92og414l6f/4ju+L5mORsiUuEPYrAuX2NJg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@intlify/core-base": "11.2.2",
         "@intlify/shared": "11.2.2",
@@ -39126,6 +39083,7 @@
       "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.1.0.tgz",
       "integrity": "sha512-fbMynMG7kXSnqZTRBSCh9ROYaVpXfCZbEO0gY3lqOjLbp361uuS88n6BDajiUriDIF+SGLWoinjvf6stS2J3Gg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@volar/typescript": "2.4.23",
         "@vue/language-core": "3.1.0"
@@ -39210,6 +39168,7 @@
       "integrity": "sha512-vaWvEpDSeldRoib1tCKNVBp60paTD2/n0a0TmrVLF9BN4CJJn6/A4VKG2Sg+DE8Yc+SNOtFtipChxSlQxjcUvw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/johnleider"
@@ -39657,6 +39616,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -40208,6 +40168,7 @@
       "resolved": "https://registry.npmjs.org/yup/-/yup-1.7.1.tgz",
       "integrity": "sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "property-expr": "^2.0.5",
         "tiny-case": "^1.0.3",


### PR DESCRIPTION
## Issue:

Logic for when to display which parts of the editor was all over the place and often without proper naming, making it difficult to understand.

## Describe your changes

- Adds a new composable `useEditorState`
- Moves all calculations for the different editor states to the new composable
- Updates affected components and composables

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- None

### Functionality

- [x] Implemented all acceptance criteria from the issue
- [x] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [x] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
