### PR TITLE
chore: update copilot instructions for nvm & i18n

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,6 +28,10 @@ npm run lint:fix     # Auto-fix linting issues
 - The middleware reads web app's `.env` file (see `middleware.config.ts`)
 - **Production caveat**: `apps/web/.env` is only available at build time, not runtime. You cannot use Nuxt's auto-substitution in `nuxt.config.ts` for production builds
 
+### Terminal Setup
+
+- Run `nvm install` once per new terminal session to ensure the correct Node.js version is active
+
 ## Key Patterns & Conventions
 
 ### Component Architecture
@@ -54,8 +58,10 @@ npm run lint:fix     # Auto-fix linting issues
 ### Routing & i18n
 
 - **File-based routing**: Pages in `pages/` directory
-- **Nuxt-i18n**: Multi-language support with configuration in `configuration/i18n.config.ts`
 - **Dynamic routes**: Product/category pages use PlentyONE item/category IDs
+- **Nuxt-i18n**: Multi-language support with configuration in `configuration/i18n.config.ts`
+- **Auto-import**: The `t` function is auto-imported from a custom wrapper composable in the `@plentymarkets/shop-core` package
+- **Admin views translations**: Components in `components/settings/` and `components/blocks/**/*Form.vue` use `getEditorTranslation()` for admin panel translations and are always in English, even if the shop frontend is in another language.
 
 ### Dynamic Component System
 


### PR DESCRIPTION
## Issue:

- False positives in Copilot reviews regarding i18n
- Copilot may use the wrong NodeJS version in terminal sessions depending on the globally installed version, potentially causing commands to fail

## Describe your changes

- Adds a note to run `nvm install` in each new terminal session for correct Node.js version
- Expands routing and i18n section with details on auto-imported `t` function and admin view translation conventions

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
