### PR TITLE
chore: add eslint rule to restrict vue imports

### DIFF
--- a/apps/web/app/components/NotifyMe/NotifyMe.vue
+++ b/apps/web/app/components/NotifyMe/NotifyMe.vue
@@ -128,7 +128,6 @@ import {
   useDisclosure,
 } from '@storefront-ui/vue';
 import { offset } from '@floating-ui/vue';
-import { ref } from 'vue';
 import type { NotifyMeComponentProps } from './types';
 
 const props = defineProps<NotifyMeComponentProps>();

--- a/apps/web/app/components/blocks/CategoryData/FieldsOrder.vue
+++ b/apps/web/app/components/blocks/CategoryData/FieldsOrder.vue
@@ -32,7 +32,6 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
 import type {
   CategoryDataFieldKey,
   CategoryDataFieldsVisibility,

--- a/apps/web/app/composables/useBlockClasses/useBlockClasses.ts
+++ b/apps/web/app/composables/useBlockClasses/useBlockClasses.ts
@@ -1,4 +1,4 @@
-import { computed, type ComputedRef } from 'vue';
+import type { ComputedRef } from 'vue';
 import type { Block } from '@plentymarkets/shop-api';
 import { useSiteSettings } from '~/composables/useSiteSettings/useSiteSettings';
 import { resolveBlockLayoutRule } from '~/configuration/block-layout.config';

--- a/apps/web/app/composables/useResetProductPageModal/__tests__/useResetProductPageModal.spec.ts
+++ b/apps/web/app/composables/useResetProductPageModal/__tests__/useResetProductPageModal.spec.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
-import { nextTick } from 'vue';
 import { useResetProductPageModal } from '../useResetProductPageModal';
 
 const mockSend = vi.fn();

--- a/apps/web/app/utils/handle-preview-product.ts
+++ b/apps/web/app/utils/handle-preview-product.ts
@@ -1,7 +1,7 @@
 import { fakeProductDE } from './facets/fakeProductDE';
 import { fakeProductEN } from './facets/fakeProductEN';
 import type { Product } from '@plentymarkets/shop-api';
-import { toRaw, type Ref } from 'vue';
+import type { Ref } from 'vue';
 import type { UseProductState } from '~/composables/useProduct/types';
 import { variationAttributeMapEN } from './facets/variationAttributeMapEN';
 import { variationAttributeMapDE } from './facets/variationAttributeMapDE';

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -48,6 +48,15 @@ export default withNuxt(
       'jsonc/no-useless-escape': 'off', // incompatible with ESLint 9, affects postCodeMapper.json
       'no-console': ['error'],
       'no-constant-binary-expression': 'off',
+      'no-restricted-imports': ['error', {
+        patterns: [
+          {
+            regex: '^vue$',
+            message: 'Use Nuxt auto-imports instead of importing from vue directly.',
+            allowTypeImports: true
+          }
+        ]
+      }],
       '@typescript-eslint/no-unused-expressions': ['error', { allowTernary: true }],
       'vue/no-console': ['error'],
       'vue/no-multiple-template-root': ['off'],


### PR DESCRIPTION
## Issue:

We occasionally import from `vue` unnecessarily, which either needs to be covered by a reviewer or gets missed altogether. These imports are covered by Nuxt.

## Describe your changes

- Adds a rule to the ESLint config to prohibit imports from `vue`
- The rule doesn't cover `type` imports because types aren't covered by Nuxt
- Updates files with invalid imports

[Rules reference](https://eslint.org/docs/latest/rules/no-restricted-imports)

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
