### PR TITLE
fix: lazy load categories

### DIFF
--- a/apps/web/app/composables/useCategoriesSearch/types.ts
+++ b/apps/web/app/composables/useCategoriesSearch/types.ts
@@ -40,4 +40,3 @@ export interface UseCategoriesSearchMethods {
 }
 
 export type UseCategoriesSearchMethodsReturn = () => UseCategoriesSearchMethods;
-

--- a/apps/web/app/composables/useCategoriesSearch/types.ts
+++ b/apps/web/app/composables/useCategoriesSearch/types.ts
@@ -1,5 +1,7 @@
 import type { CategoryEntry, CategoryData, CategorySearchCriteria } from '@plentymarkets/shop-api';
 
+export type CategoryType = 'item' | 'content';
+
 export interface UseCategoriesSearchState {
   data: CategoryData;
   contentItems: CategoryEntry[];
@@ -28,7 +30,7 @@ export interface UseCategoriesSearchMethods {
   loadingItem: Readonly<Ref<boolean>>;
   hasMoreContent: Readonly<Ref<boolean>>;
   hasMoreItem: Readonly<Ref<boolean>>;
-  fetchCategories: (categoryType: 'item' | 'content') => Promise<void>;
+  fetchCategories: (categoryType: CategoryType) => Promise<void>;
   usePaginatedChildren: (category: CategoryEntry) => PaginatedChildren;
   addNewPageToTree: (newPage: CategoryEntry) => void;
   deletePageFromTree: (id: number) => void;
@@ -38,3 +40,4 @@ export interface UseCategoriesSearchMethods {
 }
 
 export type UseCategoriesSearchMethodsReturn = () => UseCategoriesSearchMethods;
+

--- a/apps/web/app/composables/useCategoriesSearch/useCategoriesSearch.ts
+++ b/apps/web/app/composables/useCategoriesSearch/useCategoriesSearch.ts
@@ -123,18 +123,6 @@ export const useCategoriesSearch: UseCategoriesSearchMethodsReturn = () => {
     with: 'details,clients',
   });
 
-  const { data: contentData, refresh: refreshContent } = useAsyncData(
-    'categories-search-content',
-    () => useSdk().plentysystems.getCategoriesSearch(buildSearchParams('content', state.value.contentPage)),
-    { immediate: false },
-  );
-
-  const { data: itemData, refresh: refreshItem } = useAsyncData(
-    'categories-search-item',
-    () => useSdk().plentysystems.getCategoriesSearch(buildSearchParams('item', state.value.itemPage)),
-    { immediate: false },
-  );
-
   const fetchCategories = async (categoryType: CategoryType) => {
     const loadingKey = categoryType === 'item' ? 'loadingItem' : 'loadingContent';
     const hasMoreKey = categoryType === 'item' ? 'hasMoreItem' : 'hasMoreContent';
@@ -148,14 +136,11 @@ export const useCategoriesSearch: UseCategoriesSearchMethodsReturn = () => {
     try {
       const currentPage = state.value[pageKey];
 
-      if (categoryType === 'content') {
-        await refreshContent();
-      } else {
-        await refreshItem();
-      }
+      const { data } = await useAsyncData(`categories-search-${categoryType}-${currentPage}`, () =>
+        useSdk().plentysystems.getCategoriesSearch(buildSearchParams(categoryType, currentPage)),
+      );
 
-      const response = categoryType === 'content' ? contentData.value : itemData.value;
-      const result: CategoryData = response?.data ?? createEmptyCategoryData();
+      const result: CategoryData = data.value?.data ?? createEmptyCategoryData();
       state.value[itemsKey].push(...filterNewlyAddedPages(result.entries));
       state.value[hasMoreKey] = !result.isLastPage;
       state.value[pageKey] = currentPage + 1;


### PR DESCRIPTION
## Issue:

Closes: [AB#187394](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/187394)

## Describe your changes

- Restored lazy load for pages menu
- Can be tested switching  ITEMS_PER_PAGE to a lesser number. Has to be at least 6 or the scroll logic won't trigger (that's another topic). For my tests I used 10. 

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- No flags 

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

Content pages 

There is a total of 20 pages for content pages on MEVO. We can see we have two network calls. 10 for page one and 9 for page 2 

<img width="1439" height="563" alt="Screenshot 2026-02-12 at 04 42 27" src="https://github.com/user-attachments/assets/02ead808-eb25-4607-94b6-525e646f4fe6" />


Then the items which are 50. We can see we have 5 pages 

<img width="1848" height="986" alt="Screenshot 2026-02-12 at 04 46 56" src="https://github.com/user-attachments/assets/ed506b90-6975-4809-b9e7-125ed166ec5f" />



Tested on Mevo system with 10 pages

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
