### PR TITLE
fix: old HTML is not converted correctly

### DIFF
--- a/apps/web/app/components/TextContent/TextContent.vue
+++ b/apps/web/app/components/TextContent/TextContent.vue
@@ -9,7 +9,7 @@
       v-if="config.enableRichTextEditorV2 && props.text?.htmlDescription"
       class="rte-prose rte-prose--render"
       :class="`rte-prose--${props.text?.textAlignment ?? 'left'}`"
-      v-html="props.text.htmlDescription"
+      v-html="renderedHtmlDescription"
     />
 
     <template v-else>
@@ -17,35 +17,35 @@
         v-if="props.text?.pretitle"
         data-testid="text-pretitle"
         class="text-xl font-bold mb-2"
-        v-html="props.text.pretitle"
+        v-html="renderedPretitle"
       />
 
       <h1
         v-if="props.text?.title && props.index === 0"
         data-testid="text-title"
         class="typography-display-3 md:typography-display-2 lg:typography-display-1 font-bold my-2 lg:leading-[4rem]"
-        v-html="props.text.title"
+        v-html="renderedTitle"
       />
 
       <h2
         v-else-if="props.text?.title"
         data-testid="text-title"
         class="text-2xl font-semibold mb-4"
-        v-html="props.text.title"
+        v-html="renderedTitle"
       />
 
       <div
         v-if="props.text?.subtitle"
         data-testid="text-subtitle"
         class="text-lg font-semibold"
-        v-html="props.text.subtitle"
+        v-html="renderedSubtitle"
       />
 
       <div
         v-if="props.text?.htmlDescription"
         data-testid="text-html"
         class="text-base"
-        v-html="props.text.htmlDescription"
+        v-html="renderedHtmlDescription"
       />
     </template>
 
@@ -66,6 +66,11 @@
 import type { TextContentProps } from '~/components/TextContent/types';
 
 const props = defineProps<TextContentProps>();
+
+const renderedHtmlDescription = computed(() => decodeHtmlEntities(props.text?.htmlDescription));
+const renderedPretitle = computed(() => decodeHtmlEntities(props.text?.pretitle));
+const renderedTitle = computed(() => decodeHtmlEntities(props.text?.title));
+const renderedSubtitle = computed(() => decodeHtmlEntities(props.text?.subtitle));
 
 const textAlignmentClass = computed(() => {
   switch (props.text?.textAlignment) {

--- a/apps/web/app/components/blocks/TextCard/TextCardForm.vue
+++ b/apps/web/app/components/blocks/TextCard/TextCardForm.vue
@@ -453,8 +453,8 @@ const textCardBlock = computed<TextCardContent>(() => {
 });
 
 const contentModel = computed<string>({
-  get: () => textCardBlock.value.text.htmlDescription ?? '',
-  set: (val) => {
+  get: () => decodeHtmlEntities(textCardBlock.value.text.htmlDescription ?? ''),
+  set: (val: string) => {
     textCardBlock.value.text.htmlDescription = val ?? '';
   },
 });

--- a/apps/web/app/composables/useRichTextEditor/useRichTextEditor.ts
+++ b/apps/web/app/composables/useRichTextEditor/useRichTextEditor.ts
@@ -8,6 +8,7 @@ import Color from '@tiptap/extension-color';
 import Highlight from '@tiptap/extension-highlight';
 import TextAlign from '@tiptap/extension-text-align';
 import type { UseRichTextEditorArgs, RteCommand } from '~/composables/useRichTextEditor/types';
+import { decodeHtmlEntities } from '~/utils/decodeHtmlEntities';
 import { setupRichTextEditorExpansion } from './helpers/expansion';
 import { setupRichTextEditorBlocks } from './helpers/blocks';
 import { setupRichTextEditorColors } from './helpers/colors';
@@ -44,7 +45,11 @@ export function useRichTextEditor(args: UseRichTextEditorArgs) {
     if (!editor.value) return;
     const wanted = next ?? '';
     const current = editor.value.getHTML();
-    if (current !== wanted) {
+
+    const normalizedWanted = decodeHtmlEntities(wanted);
+    const normalizedCurrent = decodeHtmlEntities(current);
+
+    if (normalizedCurrent !== normalizedWanted) {
       editor.value.commands.setContent(wanted, { emitUpdate: false });
     }
   });

--- a/apps/web/app/composables/useRichTextEditor/useRichTextEditor.ts
+++ b/apps/web/app/composables/useRichTextEditor/useRichTextEditor.ts
@@ -8,7 +8,6 @@ import Color from '@tiptap/extension-color';
 import Highlight from '@tiptap/extension-highlight';
 import TextAlign from '@tiptap/extension-text-align';
 import type { UseRichTextEditorArgs, RteCommand } from '~/composables/useRichTextEditor/types';
-import { decodeHtmlEntities } from '~/utils/decodeHtmlEntities';
 import { setupRichTextEditorExpansion } from './helpers/expansion';
 import { setupRichTextEditorBlocks } from './helpers/blocks';
 import { setupRichTextEditorColors } from './helpers/colors';

--- a/apps/web/app/utils/__tests__/decodeHtmlEntities.spec.ts
+++ b/apps/web/app/utils/__tests__/decodeHtmlEntities.spec.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect } from 'vitest';
 
 describe('decodeHtmlEntities', () => {
-  it('returns empty string for undefined or empty input', () => {
+  it('should return empty string for undefined or empty input', () => {
     expect(decodeHtmlEntities()).toBe('');
     expect(decodeHtmlEntities('')).toBe('');
   });
 
-  it('returns original string when there are no HTML entities', () => {
+  it('should return original string when there are no HTML entities', () => {
     const input = 'Plain text without entities';
     expect(decodeHtmlEntities(input)).toBe(input);
   });
 
-  it('decodes individual HTML entities', () => {
+  it('should decode individual HTML entities', () => {
     expect(decodeHtmlEntities('&lt;')).toBe('<');
     expect(decodeHtmlEntities('&gt;')).toBe('>');
     expect(decodeHtmlEntities('&amp;')).toBe('&');
@@ -19,7 +19,7 @@ describe('decodeHtmlEntities', () => {
     expect(decodeHtmlEntities('&#039;')).toBe("'");
   });
 
-  it('decodes a string with multiple entities mixed with text', () => {
+  it('should decode a string with multiple entities mixed with text', () => {
     const input = '&lt;span style="color:#88aa8a;"&gt;Example of a flexible text element&lt;/span&gt; &amp; more text';
     const output = '<span style="color:#88aa8a;">Example of a flexible text element</span> & more text';
 

--- a/apps/web/app/utils/__tests__/decodeHtmlEntities.spec.ts
+++ b/apps/web/app/utils/__tests__/decodeHtmlEntities.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+
+describe('decodeHtmlEntities', () => {
+  it('returns empty string for undefined or empty input', () => {
+    expect(decodeHtmlEntities()).toBe('');
+    expect(decodeHtmlEntities('')).toBe('');
+  });
+
+  it('returns original string when there are no HTML entities', () => {
+    const input = 'Plain text without entities';
+    expect(decodeHtmlEntities(input)).toBe(input);
+  });
+
+  it('decodes individual HTML entities', () => {
+    expect(decodeHtmlEntities('&lt;')).toBe('<');
+    expect(decodeHtmlEntities('&gt;')).toBe('>');
+    expect(decodeHtmlEntities('&amp;')).toBe('&');
+    expect(decodeHtmlEntities('&quot;')).toBe('"');
+    expect(decodeHtmlEntities('&#039;')).toBe("'");
+  });
+
+  it('decodes a string with multiple entities mixed with text', () => {
+    const input = '&lt;span style="color:#88aa8a;"&gt;Example of a flexible text element&lt;/span&gt; &amp; more text';
+    const output = '<span style="color:#88aa8a;">Example of a flexible text element</span> & more text';
+
+    expect(decodeHtmlEntities(input)).toBe(output);
+  });
+});

--- a/apps/web/app/utils/decodeHtmlEntities.ts
+++ b/apps/web/app/utils/decodeHtmlEntities.ts
@@ -1,0 +1,20 @@
+export const decodeHtmlEntities = (value?: string): string => {
+  if (!value) return '';
+
+  if (
+    !value.includes('&lt;') &&
+    !value.includes('&gt;') &&
+    !value.includes('&amp;') &&
+    !value.includes('&quot;') &&
+    !value.includes('&#039;')
+  ) {
+    return value;
+  }
+
+  return value
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#039;/g, "'")
+    .replace(/&amp;/g, '&');
+};


### PR DESCRIPTION
## Issue:

Closes: [AB#187834](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/187834)

## Describe your changes

- Added a decode method for html entities 
- Wrapped the method in the Rich Text Editor parts and where we use them 
- With this method, html is no longer allowed inside the RIch Text Editor if the mode is set to 'wysiwyg' mode 
- Html is only allowed in the 'html' mode 

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots
<img width="1870" height="1014" alt="Screenshot 2026-02-23 at 00 31 19" src="https://github.com/user-attachments/assets/158685c6-58ca-4055-969f-6b34da43f5a4" />

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
