### PR TITLE
fix: update state from doSaveBlocks response

### DIFF
--- a/apps/web/app/composables/useCategoryTemplate/useCategoryTemplate.ts
+++ b/apps/web/app/composables/useCategoryTemplate/useCategoryTemplate.ts
@@ -135,13 +135,14 @@ export const useCategoryTemplate: UseCategoryTemplateReturn = (
     try {
       state.value.loading = true;
 
-      await useSdk().plentysystems.doSaveBlocks({
+      const response = await useSdk().plentysystems.doSaveBlocks({
         identifier,
         entityType: type,
         blocks: content,
       });
 
-      state.value.cleanData = markRaw(JSON.parse(JSON.stringify(state.value.data)));
+      state.value.data = response?.data ?? state.value.data;
+      state.value.cleanData = markRaw(JSON.parse(JSON.stringify(response?.data ?? state.value.data)));
 
       if (typeof content === 'string' && content.includes('"name":"Footer"')) {
         const {

--- a/apps/web/app/composables/useCategoryTemplate/useCategoryTemplate.ts
+++ b/apps/web/app/composables/useCategoryTemplate/useCategoryTemplate.ts
@@ -141,8 +141,9 @@ export const useCategoryTemplate: UseCategoryTemplateReturn = (
         blocks: content,
       });
 
-      state.value.data = response?.data ?? state.value.data;
-      state.value.cleanData = markRaw(JSON.parse(JSON.stringify(response?.data ?? state.value.data)));
+      const data = response?.data ?? state.value.data;
+
+      setupBlocks(data);
 
       if (typeof content === 'string' && content.includes('"name":"Footer"')) {
         const {


### PR DESCRIPTION
## Issue:

Closes: [AB#187750](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/187750) (part 2)

## Describe your changes

- The issue occurs when (1) saving blocks, (2) navigating to a page that's not blockified, (3) navigating back via the browser history. In this case, the original content from before saving was displayed until the user reloaded the page.
- This change aims to address the issue by updating state data from the saving response.

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
