### PR TITLE
fix: name not displaying for non saleable products

### DIFF
--- a/apps/web/app/components/BundleOrderItems/BundleOrderItems.vue
+++ b/apps/web/app/components/BundleOrderItems/BundleOrderItems.vue
@@ -60,7 +60,6 @@ const { addModernImageExtension } = useModernImage();
 
 const isLinkable = (item: ProductBundleComponent): boolean => {
   return (
-    productBundleGetters.isItemBundleSalable(item) &&
     !productBundleGetters.getBundleItemUrl(item).includes('null') &&
     productBundleGetters.getBundleItemName(item).length > 0
   );

--- a/apps/web/app/components/BundleOrderItems/BundleOrderItems.vue
+++ b/apps/web/app/components/BundleOrderItems/BundleOrderItems.vue
@@ -25,24 +25,20 @@
         loading="lazy"
       />
 
-      <div v-if="isLinkable(item)" class="h-24 self-center">
+      <div class="h-24 self-center">
         <div class="inline-flex font-medium typography-text-sm">
           <div class="mr-1">{{ productBundleGetters.getBundleItemQuantity(item) }} x</div>
-          <SfLink :tag="NuxtLink" :to="localePath(productBundleGetters.getBundleItemUrl(item))" variant="secondary">
+          <SfLink v-if="isLinkable(item)" :tag="NuxtLink" :to="localePath(productBundleGetters.getBundleItemUrl(item))" variant="secondary">
             {{ productBundleGetters.getBundleItemName(item) }}
           </SfLink>
+          <span v-else>{{ productBundleGetters.getBundleItemName(item) }}</span>
         </div>
 
         <div
+          v-if="productBundleGetters.getBundleItemShortDescription(item)"
           class="h-auto line-clamp-3 mt-1 font-normal typography-text-sm no-preflight"
           v-html="productBundleGetters.getBundleItemShortDescription(item)"
         />
-      </div>
-      <div v-else>
-        <p class="font-medium text-sm">
-          {{ productBundleGetters.getBundleItemQuantity(item) }} x
-          <span class="h-auto">[{{ t('product.attributes.productNameMissing') }}]</span>
-        </p>
       </div>
     </div>
   </div>
@@ -60,6 +56,7 @@ const { addModernImageExtension } = useModernImage();
 
 const isLinkable = (item: ProductBundleComponent): boolean => {
   return (
+    productBundleGetters.isItemBundleSalable(item) &&
     !productBundleGetters.getBundleItemUrl(item).includes('null') &&
     productBundleGetters.getBundleItemName(item).length > 0
   );

--- a/apps/web/app/components/BundleOrderItems/BundleOrderItems.vue
+++ b/apps/web/app/components/BundleOrderItems/BundleOrderItems.vue
@@ -28,7 +28,12 @@
       <div class="h-24 self-center">
         <div class="inline-flex font-medium typography-text-sm">
           <div class="mr-1">{{ productBundleGetters.getBundleItemQuantity(item) }} x</div>
-          <SfLink v-if="isLinkable(item)" :tag="NuxtLink" :to="localePath(productBundleGetters.getBundleItemUrl(item))" variant="secondary">
+          <SfLink
+            v-if="isLinkable(item)"
+            :tag="NuxtLink"
+            :to="localePath(productBundleGetters.getBundleItemUrl(item))"
+            variant="secondary"
+          >
             {{ productBundleGetters.getBundleItemName(item) }}
           </SfLink>
           <span v-else>{{ productBundleGetters.getBundleItemName(item) }}</span>


### PR DESCRIPTION
## Issue:

Closes: [AB#187671](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/187671)

## Describe your changes

- Removed the check the watches out if a bundle is saleable or not. 

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

With the  check 

<img width="1667" height="1016" alt="Screenshot 2026-03-03 at 04 30 51" src="https://github.com/user-attachments/assets/8622661b-02fe-402c-a02e-349a5cb0be14" />

Without the check 

<img width="1378" height="879" alt="Screenshot 2026-03-03 at 04 32 09" src="https://github.com/user-attachments/assets/5952e7c9-35fc-4f1b-9cd4-c2950b2ab853" />

