### PR TITLE
chore: restrict usage of structuredClone in ESLint config

### DIFF
--- a/apps/web/__tests__/test/unit/i18n.spec.ts
+++ b/apps/web/__tests__/test/unit/i18n.spec.ts
@@ -33,7 +33,9 @@ const haveEqualStructure = (lang1: object, lang2: object) => {
 };
 
 const hasAllKeys = (obj1: object, obj2: object) => {
+  // eslint-disable-next-line no-restricted-globals
   const obj1WorkingCopy = structuredClone(obj1);
+  // eslint-disable-next-line no-restricted-globals
   const obj2WorkingCopy = structuredClone(obj2);
 
   const obj1Skeleton = setValuesToEmptyString(obj1WorkingCopy);

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -48,6 +48,13 @@ export default withNuxt(
       'jsonc/no-useless-escape': 'off', // incompatible with ESLint 9, affects postCodeMapper.json
       'no-console': ['error'],
       'no-constant-binary-expression': 'off',
+      "no-restricted-globals": [
+        "error",
+        {
+          name: "structuredClone",
+          message: "structuredClone isn't fully supported. Use JSON.parse(JSON.stringify(...)) instead."
+        }
+      ],
       'no-restricted-imports': ['error', {
         patterns: [
           {

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -51,7 +51,7 @@ export default withNuxt(
       "no-restricted-globals": [
         "error",
         {
-          name: 'structuredClone'
+          name: 'structuredClone',
           message: 'structuredClone strips Vue reactivity. Avoid cloning reactive state; use JSON.parse(JSON.stringify(...)) for plain data or toRaw() on reactive objects instead.'
         }
       ],

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -51,8 +51,8 @@ export default withNuxt(
       "no-restricted-globals": [
         "error",
         {
-          name: "structuredClone",
-          message: "structuredClone isn't fully supported. Use JSON.parse(JSON.stringify(...)) instead."
+          name: 'structuredClone'
+          message: 'structuredClone strips Vue reactivity. Avoid cloning reactive state; use JSON.parse(JSON.stringify(...)) for plain data or toRaw() on reactive objects instead.'
         }
       ],
       'no-restricted-imports': ['error', {


### PR DESCRIPTION
## Issue:

`structuredClone` breaks reactivity when handling blocks and possibly also in other parts of the application. We learned this lesson a long time ago already, but never codified it, which led to it re-emerging unnecessarily recently.

## Describe your changes

- Updates the ESLint configuration to restrict usage of `structuredClone`
- Disables the rule where usage is legitimate
- [Rule reference](https://eslint.org/docs/latest/rules/no-restricted-globals)

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
