### PR TITLE
test: add blocks template assertions to smoke test

### DIFF
--- a/apps/web/__tests__/support/pageObjects/CartPageObject.ts
+++ b/apps/web/__tests__/support/pageObjects/CartPageObject.ts
@@ -111,6 +111,7 @@ export class CartPageObject extends PageObject {
   assertCartPreviewElements() {
     this.cartPreview.should('be.visible');
     this.totalPrice.should('be.visible');
+    this.footer.should('have.length', 1);
     return this;
   }
 

--- a/apps/web/__tests__/support/pageObjects/HomePageObject.ts
+++ b/apps/web/__tests__/support/pageObjects/HomePageObject.ts
@@ -45,6 +45,26 @@ export class HomePageObject extends PageObject {
     return cy.getByTestId('edit-block-actions');
   }
 
+  get bannerImages() {
+    return cy.get('[data-testid^="banner-image-"]');
+  }
+
+  get textCard() {
+    return cy.getByTestId('text-card');
+  }
+
+  get imageBlock() {
+    return cy.getByTestId('image-block');
+  }
+
+  get recommendedBlock() {
+    return cy.getByTestId('recommended-block');
+  }
+
+  get newsletterBlock() {
+    return cy.getByTestId('newsletter-block');
+  }
+
   get baseUrl() {
     return Cypress.config('baseUrl');
   }
@@ -96,6 +116,18 @@ export class HomePageObject extends PageObject {
     cy.getByTestId('category-button').first().click();
     cy.wait('@getFacet');
     cy.getByTestId('category-page-content').should('be.visible');
+    return this;
+  }
+
+  assertBlockTemplate() {
+    this.bannerImages.should('exist');
+    this.multiGridStructure.should('exist');
+    this.multiGridColumn.should('have.length', 2);
+    this.imageBlock.should('exist');
+    this.textCard.should('exist');
+    this.recommendedBlock.should('exist');
+    this.newsletterBlock.should('exist');
+    this.footer.should('have.length', 1);
     return this;
   }
 

--- a/apps/web/__tests__/support/pageObjects/PageObject.ts
+++ b/apps/web/__tests__/support/pageObjects/PageObject.ts
@@ -1,4 +1,16 @@
 export class PageObject {
+  get footer() {
+    return cy.getByTestId('footer');
+  }
+
+  get multiGridStructure() {
+    return cy.getByTestId('multi-grid-structure');
+  }
+
+  get multiGridColumn() {
+    return cy.getByTestId('multi-grid-column');
+  }
+
   waitFor(intercepts: string[]) {
     cy.wait(intercepts);
     return this;

--- a/apps/web/__tests__/support/pageObjects/ProductDetailPageObject.ts
+++ b/apps/web/__tests__/support/pageObjects/ProductDetailPageObject.ts
@@ -29,6 +29,22 @@ export class ProductDetailPageObject extends PageObject {
     return cy.getByTestId('product-image-0');
   }
 
+  get itemTextBlock() {
+    return cy.getByTestId('item-text-block');
+  }
+
+  get technicalDataBlock() {
+    return cy.getByTestId('technical-data-block');
+  }
+
+  get reviewArea() {
+    return cy.getByTestId('review-area');
+  }
+
+  get legalInformation() {
+    return cy.getByTestId('legal-information');
+  }
+
   displayCheck() {
     this.assertProductDetailPageElements();
     return this;
@@ -40,6 +56,16 @@ export class ProductDetailPageObject extends PageObject {
     this.productPriceValue.should('be.visible');
     this.quantitySelector.should('be.visible');
     this.addToCartButton.should('be.visible');
+    return this;
+  }
+
+  assertBlockTemplate() {
+    this.multiGridStructure.should('exist');
+    this.itemTextBlock.should('exist');
+    this.technicalDataBlock.should('exist');
+    this.reviewArea.should('exist');
+    this.legalInformation.should('exist');
+    this.footer.should('have.length', 1);
     return this;
   }
 

--- a/apps/web/__tests__/support/pageObjects/ProductListPageObject.ts
+++ b/apps/web/__tests__/support/pageObjects/ProductListPageObject.ts
@@ -25,6 +25,14 @@ export class ProductListPageObject extends PageObject {
     return cy.getByTestId('product-card-link').first();
   }
 
+  get categoryData() {
+    return cy.getByTestId('category-data');
+  }
+
+  get sortFilter() {
+    return cy.getByTestId('category-sort-filter');
+  }
+
   assertProductCardPath(expectedPathContent?: string) {
     const link = this.productLink;
 
@@ -62,6 +70,14 @@ export class ProductListPageObject extends PageObject {
             });
         });
     });
+    return this;
+  }
+
+  assertBlockTemplate() {
+    this.categoryData.should('exist');
+    this.sortFilter.should('exist');
+    this.categoryGrid.should('exist');
+    this.footer.should('have.length', 1);
     return this;
   }
 

--- a/apps/web/__tests__/test/smoke/smoke.cy.ts
+++ b/apps/web/__tests__/test/smoke/smoke.cy.ts
@@ -27,10 +27,12 @@ describe('Smoke Tests', () => {
       .topToolbarShouldNotExist()
       .sideToolbarShouldNotExist()
       .blockActionsShouldNotExist()
+      .assertBlockTemplate()
       .goToCategory();
 
     // prettier-ignore
     productListPage
+      .assertBlockTemplate()
       .assertGridView()
       .addToCart();
 
@@ -42,6 +44,7 @@ describe('Smoke Tests', () => {
     // prettier-ignore
     productDetailPage
       .assertProductDetailPageElements()
+      .assertBlockTemplate()
       .addToCart(2);
 
     // prettier-ignore


### PR DESCRIPTION
## Issue:

The integration gate currently doesn't check if a page contains the right blocks. This means we don't capture easy wins like seeing if a page is empty or has exactly one footer.

## Describe your changes

- Adds assertions to the homepage, item category, and product page.
- The assertions check the blocks on the page.

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [None]

### Functionality

- [x] Implemented all acceptance criteria from the issue
- [x] Encoded requirements in executable specifications (unit and/or e2e tests)
- [x] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
