### PR TITLE
fix: Retrieves the appropriate form component when override or extend an Editor's block and its Form from a module

### DIFF
--- a/apps/web/app/components/BlockEditView/BlockEditView.vue
+++ b/apps/web/app/components/BlockEditView/BlockEditView.vue
@@ -66,26 +66,26 @@ const handleBackClick = () => {
   clearCustomTitle();
 };
 
-const modules = import.meta.glob('@/components/**/blocks/**/*Form.vue') as Record<
-  string,
-  () => Promise<{ default: unknown }>
->;
-
 const componentCache = new Map<string, ReturnType<typeof defineAsyncComponent>>();
 
+/** NK
+ * Dynamically imports and returns the form component for the given block type name, utilizing a cache to optimize performance.
+ * @param name The name of the block type
+ */
 const getComponent = (name: string) => {
   if (!name) return null;
+  const formName = name + 'Form';
 
-  if (componentCache.has(name)) {
-    return componentCache.get(name);
+  if (componentCache.has(formName)) {
+    return componentCache.get(formName);
   }
 
-  const regex = new RegExp(`${name}Form\\.vue$`, 'i');
-  const matched = Object.keys(modules).find((path) => regex.test(path));
+  const loader = getBlockLoader(formName);
+  if (!loader) return null;
 
-  if (matched && modules[matched]) {
-    const component = defineAsyncComponent(modules[matched]);
-    componentCache.set(name, component);
+  if (loader) {
+    const component = defineAsyncComponent(loader);
+    componentCache.set(formName, component);
     return component;
   }
 


### PR DESCRIPTION
Retrieves the appropriate form component for a specified block type, taking into account any overrides defined in a module.

## Issue:

We need the ability to override or extend an Editor block and its Form from a module. Currently, when the folder structure is replicated inside a module, the editor continues to load the original Form file instead of the overridden version.

Line 69 of BlockEditView.vue always loads the original Form files and not the overridden ones


## Describe your changes

- Refactor getComponent in BlockEditView.vue (components/BlockEditView/BlockEditView.vue) to use getBlockLoader (from utils/blocks-imports.ts) for resolving the correct Form file path, ensuring overridden files are properly loaded.
- Form name does not need a RegExp to be created. The getBlockLoader function gets the name as a string.
- The componentCash searches and stores the correct Form name

