### PR TITLE
fix: icons in editor toolbar in chrome dark mode

### DIFF
--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -163,6 +163,9 @@ export default defineNuxtConfig({
       icons: {
         defaultSet: 'mdi-svg',
       },
+      theme: {
+        defaultTheme: 'light',
+      },
     },
   },
   shopCore: {


### PR DESCRIPTION
## Issue:

Original: #2334 

When using Chrome's Dark Mode, some elements of the editor toolbar aren't displayed properly.

## Describe your changes

- Explicitly sets Vuetify to light mode instead of using the browser mode.

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
