### PR TITLE
fix: use space better when only one language is selected

### DIFF
--- a/apps/web/app/components/editor/Localization/EditorLocalizationDrawer.vue
+++ b/apps/web/app/components/editor/Localization/EditorLocalizationDrawer.vue
@@ -53,7 +53,6 @@
                 :key="lang"
                 class="w-64 px-4 py-3 mr-3 font-semibold flex-shrink-0 last:mr-0"
                 :class="{
-                  '!w-[calc(100%-12px)]': selectedLocales.length === 1,
                   '!w-[calc(50%-12px)]': selectedLocales.length === 2,
                 }"
               >

--- a/apps/web/app/components/editor/Localization/EditorLocalizationDrawer.vue
+++ b/apps/web/app/components/editor/Localization/EditorLocalizationDrawer.vue
@@ -52,9 +52,7 @@
                 v-for="lang in languages"
                 :key="lang"
                 class="w-64 px-4 py-3 mr-3 font-semibold flex-shrink-0 last:mr-0"
-                :class="{
-                  '!w-[calc(50%-12px)]': selectedLocales.length === 2,
-                }"
+                :class="{ '!w-[calc(50%-12px)]': selectedLocales.length === 2 }"
               >
                 {{ lang }}
               </div>

--- a/apps/web/app/components/editor/Localization/EditorLocalizationDrawer.vue
+++ b/apps/web/app/components/editor/Localization/EditorLocalizationDrawer.vue
@@ -52,9 +52,9 @@
                 v-for="lang in languages"
                 :key="lang"
                 class="w-64 px-4 py-3 mr-3 font-semibold flex-shrink-0 last:mr-0"
-                :class="{ 
+                :class="{
                   '!w-[calc(100%-12px)]': selectedLocales.length === 1,
-                  '!w-[calc(50%-12px)]': selectedLocales.length === 2
+                  '!w-[calc(50%-12px)]': selectedLocales.length === 2,
                 }"
               >
                 {{ lang }}

--- a/apps/web/app/components/editor/Localization/EditorLocalizationDrawer.vue
+++ b/apps/web/app/components/editor/Localization/EditorLocalizationDrawer.vue
@@ -52,7 +52,10 @@
                 v-for="lang in languages"
                 :key="lang"
                 class="w-64 px-4 py-3 mr-3 font-semibold flex-shrink-0 last:mr-0"
-                :class="{ 'min-w-64 !w-[calc(50%-12px)]': selectedLocales.length === 2 }"
+                :class="{ 
+                  '!w-[calc(100%-12px)]': selectedLocales.length === 1
+                  '!w-[calc(50%-12px)]': selectedLocales.length === 2,
+                }"
               >
                 {{ lang }}
               </div>

--- a/apps/web/app/components/editor/Localization/EditorLocalizationDrawer.vue
+++ b/apps/web/app/components/editor/Localization/EditorLocalizationDrawer.vue
@@ -53,8 +53,8 @@
                 :key="lang"
                 class="w-64 px-4 py-3 mr-3 font-semibold flex-shrink-0 last:mr-0"
                 :class="{ 
-                  '!w-[calc(100%-12px)]': selectedLocales.length === 1
-                  '!w-[calc(50%-12px)]': selectedLocales.length === 2,
+                  '!w-[calc(100%-12px)]': selectedLocales.length === 1,
+                  '!w-[calc(50%-12px)]': selectedLocales.length === 2
                 }"
               >
                 {{ lang }}

--- a/apps/web/app/components/editor/Localization/EditorLocalizationDrawer.vue
+++ b/apps/web/app/components/editor/Localization/EditorLocalizationDrawer.vue
@@ -52,7 +52,7 @@
                 v-for="lang in languages"
                 :key="lang"
                 class="w-64 px-4 py-3 mr-3 font-semibold flex-shrink-0 last:mr-0"
-                :class="{ '!w-[calc(50%-12px)]': selectedLocales.length === 2 }"
+                :class="{ 'min-w-64 !w-[calc(50%-12px)]': selectedLocales.length === 2 }"
               >
                 {{ lang }}
               </div>

--- a/apps/web/app/components/editor/Localization/TranslationInput.vue
+++ b/apps/web/app/components/editor/Localization/TranslationInput.vue
@@ -1,7 +1,10 @@
 <template>
   <div
     class="w-64 flex-shrink-0 m-1 mr-2 group relative last:mr-0"
-    :class="{ 'min-w-64 !w-[calc(50%-12px)]': selectedLocales.length === 2 }"
+    :class="{
+      '!w-[calc(100%-12px)]': selectedLocales.length === 1,
+      '!w-[calc(50%-12px)]': selectedLocales.length === 2,
+    }"
   >
     <textarea
       v-if="translation?.input !== undefined"

--- a/apps/web/app/components/editor/Localization/TranslationInput.vue
+++ b/apps/web/app/components/editor/Localization/TranslationInput.vue
@@ -2,8 +2,8 @@
   <div
     class="w-64 flex-shrink-0 m-1 mr-2 group relative last:mr-0"
     :class="{
-      '!w-[calc(100%-12px)]': selectedLocales.length === 1,
-      '!w-[calc(50%-12px)]': selectedLocales.length === 2,
+      'min-w-64 !w-[calc(100%-12px)]': selectedLocales.length === 1,
+      'min-w-64 !w-[calc(50%-12px)]': selectedLocales.length === 2,
     }"
   >
     <textarea


### PR DESCRIPTION
## Issue:

Closes: AB#ID

## Describe your changes

- removed unnecessary min-w-64 class since the element already has w-64 class
- when only one language is selected (selectedLocales.length === 1) use the full available space

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
