### PR TITLE
chore: rename variant to variation

### DIFF
--- a/apps/web/app/components/settings/seo/item-URL-handling/2.item-URL-scheme/ItemUrlScheme.vue
+++ b/apps/web/app/components/settings/seo/item-URL-handling/2.item-URL-scheme/ItemUrlScheme.vue
@@ -102,47 +102,47 @@ const urlScheme = computed({
 {
   "en": {
     "label": "Item URL Scheme",
-    "tooltip": "Defines whether item variants get their own URL or share the same URL",
-    "button-modern-label": "Unique Variant URLs",
+    "tooltip": "Defines whether item variations get their own URL or share the same URL",
+    "button-modern-label": "Unique Variation URLs",
     "button-legacy-label": "Single Product URL",
 
-    "description-modern-code": "Example: /item-name_itemID_variantID",
-    "description-modern-body-one": "Recommended if you use price comparison platforms like Google Shopping or want variants to be individually discoverable.",
-    "description-modern-body-list-line-one": "Each variant gets its own URL",
-    "description-modern-body-list-line-two": "Enables direct linking to specific variants",
-    "description-modern-body-list-line-three": "Supports variant-level SEO potential",
-    "description-modern-body-list-line-four": "Safer when variants have different prices",
-    "description-modern-body-footer": "Price comparison platforms expect the landing page price to match the submitted feed price. With separate URLs, each variant links directly to the correct price — avoiding mismatches and potential product disapprovals. Best suited when variants differ meaningfully (e.g. price, features, texts, images) or when users and search engines should land on a preselected variant.",
+    "description-modern-code": "Example: /item-name_itemID_variationID",
+    "description-modern-body-one": "Recommended if you use price comparison platforms like Google Shopping or want variations to be individually discoverable.",
+    "description-modern-body-list-line-one": "Each variation gets its own URL",
+    "description-modern-body-list-line-two": "Enables direct linking to specific variations",
+    "description-modern-body-list-line-three": "Supports variation-level SEO potential",
+    "description-modern-body-list-line-four": "Safer when variations have different prices",
+    "description-modern-body-footer": "Price comparison platforms expect the landing page price to match the submitted feed price. With separate URLs, each variation links directly to the correct price — avoiding mismatches and potential product disapprovals. Best suited when variations differ meaningfully (e.g. price, features, texts, images) or when users and search engines should land on a preselected variation.",
 
     "description-legacy-code": "Example: /item-name/a-itemID",
-    "description-legacy-body-one": "Use with caution if variants have different prices.",
-    "description-legacy-body-list-line-one": "One shared URL for all variants",
+    "description-legacy-body-one": "Use with caution if variations have different prices.",
+    "description-legacy-body-list-line-one": "One shared URL for all variations",
     "description-legacy-body-list-line-two": "Prevents duplicate or near-identical pages",
     "description-legacy-body-list-line-three": "Consolidates SEO signals to a single product page",
     "description-legacy-body-list-line-four": "Simplifies analytics and maintenance",
-    "description-legacy-body-footer": "Since the page loads one default variant, price comparison platforms like Google Shopping may see a different price than the one submitted in your feed if variants differ. This can lead to price mismatch errors or product disapprovals. Best suited when variants are mostly cosmetic or share the same price."
+    "description-legacy-body-footer": "Since the page loads one default variation, price comparison platforms like Google Shopping may see a different price than the one submitted in your feed if variations differ. This can lead to price mismatch errors or product disapprovals. Best suited when variations are mostly cosmetic or share the same price."
   },
   "de": {
     "label": "Item URL Scheme",
-    "tooltip": "Defines whether item variants get their own URL or share the same URL",
-    "button-modern-label": "Unique Variant URLs",
+    "tooltip": "Defines whether item variations get their own URL or share the same URL",
+    "button-modern-label": "Unique Variation URLs",
     "button-legacy-label": "Single Product URL",
 
-    "description-modern-code": "Example: /item-name_itemID_variantID",
-    "description-modern-body-one": "Recommended if you use price comparison platforms like Google Shopping or want variants to be individually discoverable.",
-    "description-modern-body-list-line-one": "Each variant gets its own URL",
-    "description-modern-body-list-line-two": "Enables direct linking to specific variants",
-    "description-modern-body-list-line-three": "Supports variant-level SEO potential",
-    "description-modern-body-list-line-four": "Safer when variants have different prices",
-    "description-modern-body-footer": "Price comparison platforms expect the landing page price to match the submitted feed price. With separate URLs, each variant links directly to the correct price — avoiding mismatches and potential product disapprovals. Best suited when variants differ meaningfully (e.g. price, features, texts, images) or when users and search engines should land on a preselected variant.",
+    "description-modern-code": "Example: /item-name_itemID_variationID",
+    "description-modern-body-one": "Recommended if you use price comparison platforms like Google Shopping or want variations to be individually discoverable.",
+    "description-modern-body-list-line-one": "Each variation gets its own URL",
+    "description-modern-body-list-line-two": "Enables direct linking to specific variations",
+    "description-modern-body-list-line-three": "Supports variation-level SEO potential",
+    "description-modern-body-list-line-four": "Safer when variations have different prices",
+    "description-modern-body-footer": "Price comparison platforms expect the landing page price to match the submitted feed price. With separate URLs, each variation links directly to the correct price — avoiding mismatches and potential product disapprovals. Best suited when variations differ meaningfully (e.g. price, features, texts, images) or when users and search engines should land on a preselected variation.",
 
     "description-legacy-code": "Example: /item-name/a-itemID",
-    "description-legacy-body-one": "Use with caution if variants have different prices.",
-    "description-legacy-body-list-line-one": "One shared URL for all variants",
+    "description-legacy-body-one": "Use with caution if variations have different prices.",
+    "description-legacy-body-list-line-one": "One shared URL for all variations",
     "description-legacy-body-list-line-two": "Prevents duplicate or near-identical pages",
     "description-legacy-body-list-line-three": "Consolidates SEO signals to a single product page",
     "description-legacy-body-list-line-four": "Simplifies analytics and maintenance",
-    "description-legacy-body-footer": "Since the page loads one default variant, price comparison platforms like Google Shopping may see a different price than the one submitted in your feed if variants differ. This can lead to price mismatch errors or product disapprovals. Best suited when variants are mostly cosmetic or share the same price."
+    "description-legacy-body-footer": "Since the page loads one default variation, price comparison platforms like Google Shopping may see a different price than the one submitted in your feed if variations differ. This can lead to price mismatch errors or product disapprovals. Best suited when variations are mostly cosmetic or share the same price."
   }
 }
 </i18n>


### PR DESCRIPTION
## Link to ticket

- https://dev.azure.com/plentymarkets/plentymarkets/_workitems/edit/187709

## Changes

- In the UI and the manual, we use the term **variation** instead of **variant**. This PR renames the terms for the **Item UI Handling** within the **Item UI Scheme** to ensure consistency.
