### PR TITLE
fix: remove visibility toggle for utility bar items

### DIFF
--- a/apps/web/app/components/blocks/UtilityBar/UtilityBarForm.vue
+++ b/apps/web/app/components/blocks/UtilityBar/UtilityBarForm.vue
@@ -42,15 +42,13 @@ const { sections } = useUtilityBarConfiguration(props.uuid);
 const { elementsOpen, layoutOpen, editingSectionIndex, openSectionMenuIndex, currentEditingSectionIndex, sectionForm } =
   useUtilityBarForm(sections);
 
-const { getSectionLabel, editSection, exitEditMode } = useUtilityBarActions(
-  {
-    sections,
-    editingSectionIndex,
-    openSectionMenuIndex,
-    getEditorTranslation,
-    emit,
-  },
-);
+const { getSectionLabel, editSection, exitEditMode } = useUtilityBarActions({
+  sections,
+  editingSectionIndex,
+  openSectionMenuIndex,
+  getEditorTranslation,
+  emit,
+});
 
 defineExpose({
   exitEditMode,

--- a/apps/web/app/components/blocks/UtilityBar/UtilityBarForm.vue
+++ b/apps/web/app/components/blocks/UtilityBar/UtilityBarForm.vue
@@ -9,8 +9,6 @@
       :get-section-label="getSectionLabel"
       :get-editor-translation="getEditorTranslation"
       :edit-section="editSection"
-      :toggle-section-menu="toggleSectionMenu"
-      :toggle-section-visibility="toggleSectionVisibility"
     />
 
     <BlocksUtilityBarPartialsUtilityBarSectionEditor
@@ -44,7 +42,7 @@ const { sections } = useUtilityBarConfiguration(props.uuid);
 const { elementsOpen, layoutOpen, editingSectionIndex, openSectionMenuIndex, currentEditingSectionIndex, sectionForm } =
   useUtilityBarForm(sections);
 
-const { getSectionLabel, editSection, exitEditMode, toggleSectionMenu, toggleSectionVisibility } = useUtilityBarActions(
+const { getSectionLabel, editSection, exitEditMode } = useUtilityBarActions(
   {
     sections,
     editingSectionIndex,

--- a/apps/web/app/components/blocks/UtilityBar/partials/UtilityBarSectionsList.vue
+++ b/apps/web/app/components/blocks/UtilityBar/partials/UtilityBarSectionsList.vue
@@ -42,35 +42,6 @@
                   </svg>
                 </SfIconBase>
               </button>
-
-              <div :key="`menu-${index}`" class="relative">
-                <button
-                  :data-testid="`actions-menu-section-${index}`"
-                  class="text-gray-500 rounded-full no-drag"
-                  @click="toggleSectionMenu(index)"
-                >
-                  <SfIconMoreVert />
-                </button>
-
-                <div
-                  v-if="openSectionMenuIndex === index"
-                  class="absolute right-0 mt-1 w-48 bg-white rounded-lg shadow-lg border z-50"
-                  @click.stop
-                >
-                  <div class="px-4 py-3 border-b">
-                    <div class="flex items-center justify-between">
-                      <UiFormLabel class="mb-0">{{ getEditorTranslation('visibility-label') }}</UiFormLabel>
-                      <SfSwitch
-                        :model-value="sections[index]?.visible !== false"
-                        :data-testid="`actions-toggle-visibility-section-${index}`"
-                        :aria-label="getEditorTranslation('toggle-visibility-aria')"
-                        class="checked:bg-editor-button checked:before:hover:bg-editor-button checked:border-gray-500 checked:hover:border:bg-gray-700 hover:border-gray-700 hover:before:bg-gray-700 checked:hover:bg-gray-300 checked:hover:border-gray-400"
-                        @update:model-value="toggleSectionVisibility(index)"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
             </div>
           </div>
         </template>
@@ -91,8 +62,6 @@ defineProps<{
   getSectionLabel: (sectionId: SectionType) => string;
   getEditorTranslation: (key: string) => string;
   editSection: (index: number) => void;
-  toggleSectionMenu: (index: number) => void;
-  toggleSectionVisibility: (index: number) => void;
 }>();
 
 const isOpen = defineModel<boolean>('open', { default: true });

--- a/apps/web/app/components/blocks/UtilityBar/partials/UtilityBarSectionsList.vue
+++ b/apps/web/app/components/blocks/UtilityBar/partials/UtilityBarSectionsList.vue
@@ -51,7 +51,7 @@
 </template>
 
 <script setup lang="ts">
-import { SfIconMoreVert, SfIconBase, SfSwitch } from '@storefront-ui/vue';
+import { SfIconBase } from '@storefront-ui/vue';
 import { editPath } from '~/assets/icons/paths/edit';
 import type { UtilityBarSection, SectionType } from '../types';
 

--- a/apps/web/app/components/blocks/UtilityBar/partials/__tests__/UtilityBarSectionsList.spec.ts
+++ b/apps/web/app/components/blocks/UtilityBar/partials/__tests__/UtilityBarSectionsList.spec.ts
@@ -84,13 +84,4 @@ describe('UtilityBarSectionsList', () => {
     expect(editSection).toHaveBeenCalledWith(1);
     expect(toggleSectionMenu).toHaveBeenCalledWith(2);
   });
-
-  it('should render visibility menu for open section and toggle visibility handler', async () => {
-    const wrapper = mountComponent({ openSectionMenuIndex: 1 });
-
-    const visibilityToggle = wrapper.getByTestId('actions-toggle-visibility-section-1');
-    await visibilityToggle.trigger('click');
-
-    expect(toggleSectionVisibility).toHaveBeenCalledWith(1);
-  });
 });

--- a/apps/web/app/components/blocks/UtilityBar/partials/__tests__/UtilityBarSectionsList.spec.ts
+++ b/apps/web/app/components/blocks/UtilityBar/partials/__tests__/UtilityBarSectionsList.spec.ts
@@ -74,14 +74,4 @@ describe('UtilityBarSectionsList', () => {
     expect(labelTexts).toEqual(['logo-label', 'search-label', 'actions-label']);
     expect(getSectionLabel).toHaveBeenCalledTimes(3);
   });
-
-  it('should call editSection and toggleSectionMenu with matching indices', async () => {
-    const wrapper = mountComponent();
-
-    await wrapper.getByTestId('actions-edit-section-1').trigger('click');
-    await wrapper.getByTestId('actions-menu-section-2').trigger('click');
-
-    expect(editSection).toHaveBeenCalledWith(1);
-    expect(toggleSectionMenu).toHaveBeenCalledWith(2);
-  });
 });


### PR DESCRIPTION
we recently removed the possibility to reorder the items inside the utility bar because the new search doesn't work being ordered on the left or right of the utility bar. but this also does happen when toggling the logo invisible for example.

## Issue:

Closes: AB#ID

## Describe your changes

- [What changed]
- [Notable implementation decisions]
- [Known limitations]

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
