### PR TITLE
refactor: move watcher to close block configurations into component

### DIFF
--- a/apps/web/app/components/BlockEditView/BlockEditView.vue
+++ b/apps/web/app/components/BlockEditView/BlockEditView.vue
@@ -48,12 +48,14 @@ const { data } = useBlockTemplates(
   useNuxtApp().$i18n.locale.value,
 );
 
-const { closeBlocksConfigurationDrawer, blockType, blockUuid } = useSiteConfiguration();
+const { closeBlocksConfigurationDrawer, blocksConfigurationDrawerView, blockType, blockUuid } = useSiteConfiguration();
 
 watch(
   () => route.fullPath,
   () => {
-    closeBlocksConfigurationDrawer();
+    if (blocksConfigurationDrawerView.value === 'blocksSettings') {
+      closeBlocksConfigurationDrawer();
+    }
   },
 );
 const { deleteBlock } = useBlockManager();

--- a/apps/web/app/components/BlockEditView/BlockEditView.vue
+++ b/apps/web/app/components/BlockEditView/BlockEditView.vue
@@ -49,6 +49,13 @@ const { data } = useBlockTemplates(
 );
 
 const { closeBlocksConfigurationDrawer, blockType, blockUuid } = useSiteConfiguration();
+
+watch(
+  () => route.fullPath,
+  () => {
+    closeBlocksConfigurationDrawer();
+  },
+);
 const { deleteBlock } = useBlockManager();
 
 const customTitle = ref<string | null>(null);

--- a/apps/web/app/components/PageBlock/PageBlock.vue
+++ b/apps/web/app/components/PageBlock/PageBlock.vue
@@ -109,6 +109,7 @@ const props = withDefaults(defineProps<PageBlockProps>(), {
   enableActions: false,
 });
 
+const route = useRoute();
 const { isInEditorClient } = useEditorState();
 const { locale, defaultLocale } = useI18n();
 const { openDrawerWithView } = useSiteConfiguration();
@@ -221,7 +222,6 @@ const addNewBlock = (block: Block, position: BlockPosition) => {
 const getHomePath = (localeCode: string) => (localeCode === defaultLocale ? '/' : `/${localeCode}`);
 
 const isEditDisabled = () => {
-  const route = useRoute();
   return route.fullPath !== getHomePath(locale.value);
 };
 

--- a/apps/web/app/components/PageBlock/PageBlock.vue
+++ b/apps/web/app/components/PageBlock/PageBlock.vue
@@ -111,7 +111,6 @@ const props = withDefaults(defineProps<PageBlockProps>(), {
 
 const { isInEditorClient } = useEditorState();
 const { locale, defaultLocale } = useI18n();
-const route = useRoute();
 const { openDrawerWithView } = useSiteConfiguration();
 const attrs = useAttrs();
 const {
@@ -221,10 +220,10 @@ const addNewBlock = (block: Block, position: BlockPosition) => {
 
 const getHomePath = (localeCode: string) => (localeCode === defaultLocale ? '/' : `/${localeCode}`);
 
-const isEditDisabled = computed(() => {
-  const homePath = getHomePath(locale.value);
-  return route.fullPath !== homePath;
-});
+const isEditDisabled = () => {
+  const route = useRoute();
+  return route.fullPath !== getHomePath(locale.value);
+};
 
 const showTopAddBlockButton = computed(
   () =>
@@ -247,7 +246,7 @@ const showBottomAddBlockButton = computed(
 const getBlockActions = (block: Block) => {
   if (isGlobalBlock(block)) {
     return {
-      isEditable: !isEditDisabled.value,
+      isEditable: !isEditDisabled(),
       isMovable: false,
       isDeletable: false,
       classes: ['flex', 'items-center', 'right-0', 'top-0', 'border', 'border-[#538AEA]', 'bg-white'],

--- a/apps/web/app/composables/useSiteConfiguration/useSiteConfiguration.ts
+++ b/apps/web/app/composables/useSiteConfiguration/useSiteConfiguration.ts
@@ -117,17 +117,6 @@ export const useSiteConfiguration: UseSiteConfigurationReturn = () => {
     state.value.siteConfigurationDrawerOpen = true;
     state.value.siteConfigurationDrawerView = null;
   };
-  if (import.meta.client) {
-    const route = useRoute();
-    watch(
-      () => route.fullPath,
-      () => {
-        if (state.value.blocksConfigurationDrawerView === 'blocksSettings') {
-          closeBlocksConfigurationDrawer();
-        }
-      },
-    );
-  }
 
   return {
     ...toRefs(state.value),


### PR DESCRIPTION
## Issue:

useBlockManager.ts:29 [nuxt] useRoute was called within middleware. This may lead to misleading results. Instead, use the (to, from) arguments passed to the middleware to access the new and old routes. Learn more: https://nuxt.com/docs/4.x/guide/directory-structure/app/middleware#accessing-route-in-middleware
at useBlockManager.ts:29:17
at block-classes.ts:22:29
at useBlockClasses.ts:26:12
useSiteConfiguration.ts:121
Closes: AB#ID

## Describe your changes

- [What changed]
- [Notable implementation decisions]
- [Known limitations]

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
