### PR TITLE
chore: add ai-tool label and ignore ai experiments

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -55,7 +55,7 @@ labels:
         any:
           - '.github/copilot-instructions.md'
           - '.github/agents/*.md'
-          - '.github/instructions/*.instruction.md'
+          - '.github/instructions/*.instructions.md'
           - '.github/skills/**/SKILL.md'
           - '.github/skills/**/*.sh'
           

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -48,3 +48,14 @@ labels:
           - '.github/workflows/*.yaml'
           - '.github/actions/*.yml'
           - '.github/actions/*.yaml'
+  - label: 'ai-tool'
+    sync: true
+    matcher:
+      files:
+        any:
+          - '.github/copilot-instructions.md'
+          - '.github/agents/*.md'
+          - '.github/instructions/*.instruction.md'
+          - '.github/skills/**/SKILL.md'
+          - '.github/skills/**/*.sh'
+          

--- a/.gitignore
+++ b/.gitignore
@@ -30,10 +30,14 @@ apps/web/coverage/*
 packages/shop-cli/coverage/*
 !packages/shop-cli/coverage/coverage-summary.json
 !packages/shop-cli/coverage/coverage-final.json
+
 # misc
 .DS_Store
 .idea
 *.pem
+.vscode
+*.code-workspace
+*.tsbuildinfo
 
 # debug
 npm-debug.log*
@@ -60,9 +64,11 @@ lib/
 apps/web/docs/reference/
 apps/web/reference/
 
-.vscode
-*.code-workspace
-*.tsbuildinfo
-
 # shop-cli config
 .plentyone/shop-cli.json
+
+# copilot experiments
+.github/agents/experimental-*.md
+.github/instructions/experimental-*.instruction.md
+.github/skills/experimental-*/SKILL.md
+.github/skills/experimental-*/*.sh

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,6 @@ apps/web/reference/
 
 # copilot experiments
 .github/agents/experimental-*.md
-.github/instructions/experimental-*.instruction.md
+.github/instructions/experimental-*.instructions.md
 .github/skills/experimental-*/SKILL.md
 .github/skills/experimental-*/*.sh


### PR DESCRIPTION
## Issue:

Local experimentation with Copilot instructions and skills over a longer period of time are currently a friction point because they need to be manually carried across branches and excluded from commits.

## Describe your changes

- Defines file name patterns for Copilot experiments and adds them to `.gitignore`
- Extends labeler configuration to flag Copilot agents, instructions, and skills that are shared

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
