### PR TITLE
Fix/initial page layout block

### DIFF
--- a/apps/web/app/composables/useBlockManager/useBlockManager.ts
+++ b/apps/web/app/composables/useBlockManager/useBlockManager.ts
@@ -68,12 +68,9 @@ export const useBlockManager = () => {
     const copiedData = JSON.parse(JSON.stringify(data.value));
     const parentInfo = findBlockParent(copiedData, targetUuid);
 
-    if (!parentInfo) {
-      console.error('block not found');
-      return;
-    }
+    const parent = parentInfo?.parent ?? copiedData;
+    const index = parentInfo?.index ?? 0;
 
-    const { parent, index } = parentInfo;
     const targetBlock = parent[index];
     if (!targetBlock) return;
 

--- a/apps/web/app/composables/useBlockManager/useBlockManager.ts
+++ b/apps/web/app/composables/useBlockManager/useBlockManager.ts
@@ -68,6 +68,7 @@ export const useBlockManager = () => {
     const copiedData = JSON.parse(JSON.stringify(data.value));
     const parentInfo = findBlockParent(copiedData, targetUuid);
 
+    // parentInfo can be null if the targetUuid is not found in the blocks, in that case we will add the new block to the beginning of the blocks array
     const parent = parentInfo?.parent ?? copiedData;
     const index = parentInfo?.index ?? 0;
 


### PR DESCRIPTION
## Issue:

When we create a new Category/Page or in an existing page with no blocks, its layout in Editor has no parent blocks, and the table of contents is not created.
The parentInfo returns null and exits the code with the error 'block not found'.
As a result, we cannot enter an initial block in the layout.


## Describe your changes

If parentInfo returns null, we add the new block to the beginning of the blocks array


