### PR TITLE
feat: Use Custom individual Variation Titles

### DIFF
--- a/apps/web/app/components/settings/item/item/variation-title/VariationTitleProperty.vue
+++ b/apps/web/app/components/settings/item/item/variation-title/VariationTitleProperty.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="py-2 mb-2">
+    <p class="mb-4">{{ getEditorTranslation('description') }}</p>
+    <div class="flex justify-between mb-2 items-center gap-2">
+      <UiFormLabel>{{ getEditorTranslation('label') }}</UiFormLabel>
+      <SfTooltip :label="getEditorTranslation('tooltip')" :placement="'left'" class="z-[9999]">
+        <SfIconInfo :size="'sm'" />
+      </SfTooltip>
+    </div>
+    <SfInput
+      v-model="variationTitlePropertyId"
+      type="number"
+      inputmode="numeric"
+      min="1"
+      :placeholder="getEditorTranslation('placeholder')"
+      data-testid="variation-title-property-input"
+    />
+    <p class="mt-2 text-sm text-neutral-500">
+      {{ getEditorTranslation('hint') }}
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { SfIconInfo, SfInput, SfTooltip } from '@storefront-ui/vue';
+
+const { updateSetting, getSetting } = useSiteSettings('variationTitleProperty');
+const variationTitlePropertyId = computed({
+  get: () => getSetting() || '',
+  set: (value: string | number) => {
+    const normalizedValue = String(value ?? '').trim();
+
+    updateSetting(normalizedValue);
+  },
+});
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "label": "Variation title property",
+    "description": "Enter the variation property ID that should be used as the storefront item title. When set, the matching property value replaces the default item name wherever the normalized item name is used.",
+    "tooltip": "Use the variation property ID from the backend. Leave this empty to fall back to the default Variation Texts / Variation Title mapping.",
+    "placeholder": "Enter variation property ID",
+    "hint": "Leave the field empty to use the default Variation Texts / Variation Title mapping."
+  },
+  "de": {
+    "label": "Variation title property",
+    "description": "Enter the variation property ID that should be used as the storefront item title. When set, the matching property value replaces the default item name wherever the normalized item name is used.",
+    "tooltip": "Use the variation property ID from the backend. Leave this empty to fall back to the default Variation Texts / Variation Title mapping.",
+    "placeholder": "Enter variation property ID",
+    "hint": "Leave the field empty to use the default Variation Texts / Variation Title mapping."
+  }
+}
+</i18n>

--- a/apps/web/app/components/settings/item/item/variation-title/VariationTitleProperty.vue
+++ b/apps/web/app/components/settings/item/item/variation-title/VariationTitleProperty.vue
@@ -38,18 +38,18 @@ const variationTitlePropertyId = computed({
 <i18n lang="json">
 {
   "en": {
-    "label": "Variation title property",
-    "description": "Enter the variation property ID that should be used as the storefront item title. When set, the matching property value replaces the default item name wherever the normalized item name is used.",
-    "tooltip": "Use the variation property ID from the backend. Leave this empty to fall back to the default Variation Texts / Variation Title mapping.",
+    "label": "Variation title property ID",
+    "description": "Enter the variation property ID that should be used as the storefront item title. When set, the matching property value replaces the default item name.",
+    "tooltip": "Use the variation property ID from the backend. Leave this empty to fall back to the default Title.",
     "placeholder": "Enter variation property ID",
-    "hint": "Leave the field empty to use the default Variation Texts / Variation Title mapping."
+    "hint": "Leave the field empty to use the default Title."
   },
   "de": {
-    "label": "Variation title property",
-    "description": "Enter the variation property ID that should be used as the storefront item title. When set, the matching property value replaces the default item name wherever the normalized item name is used.",
-    "tooltip": "Use the variation property ID from the backend. Leave this empty to fall back to the default Variation Texts / Variation Title mapping.",
+    "label": "Variation title property ID",
+    "description": "Enter the variation property ID that should be used as the storefront item title. When set, the matching property value replaces the default item name.",
+    "tooltip": "Use the variation property ID from the backend. Leave this empty to fall back to the default Title.",
     "placeholder": "Enter variation property ID",
-    "hint": "Leave the field empty to use the default Variation Texts / Variation Title mapping."
+    "hint": "Leave the field empty to use the default Title."
   }
 }
 </i18n>

--- a/apps/web/app/components/settings/item/item/variation-title/types.ts
+++ b/apps/web/app/components/settings/item/item/variation-title/types.ts
@@ -1,0 +1,4 @@
+export interface VariationTitlePropertyOption {
+  label: string;
+  value: string;
+}

--- a/apps/web/app/composables/index.ts
+++ b/apps/web/app/composables/index.ts
@@ -73,6 +73,7 @@ export * from './useProductReviewAverage';
 export * from './useProductReviews';
 export * from './useProducts';
 export * from './useQuickCheckout';
+export * from './useProductNameNormalizer';
 export * from './useResetProductPageModal';
 export * from './useReturnOrder';
 export * from './useRestrictedAddress';

--- a/apps/web/app/composables/useCart/useCart.ts
+++ b/apps/web/app/composables/useCart/useCart.ts
@@ -7,6 +7,7 @@ import type {
   Cart,
   PlentyEvents,
 } from '@plentymarkets/shop-api';
+import { normalizeCartProductNames } from '~/utils/product-name-normalizer';
 
 const migrateVariationData = (oldCart: Cart, nextCart: Cart = {} as Cart): Cart => {
   if (!oldCart || !oldCart.items || !nextCart || !nextCart.items) {
@@ -64,7 +65,7 @@ export const useCart = () => {
    */
   const setCart = (data: Cart) => {
     const { setPattern } = usePriceFormatter();
-    state.value.data = data;
+    state.value.data = normalizeCartProductNames(data);
     setPattern(data.currencyPattern);
     useWishlist().setWishlistItemIds(Object.values(data?.itemWishListIds || []));
   };
@@ -119,7 +120,9 @@ export const useCart = () => {
     try {
       const { data } = await useSdk().plentysystems.doAddCartItem(params);
 
-      state.value.data = data ? migrateVariationData(state.value.data, data) : state.value.data;
+      state.value.data = data
+        ? normalizeCartProductNames(migrateVariationData(state.value.data, data))
+        : state.value.data;
 
       const item = state?.value?.data?.items?.find((item) => item.variationId === params.productId);
 
@@ -139,10 +142,10 @@ export const useCart = () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const errorEvents = apiError.events as any;
       if (errorEvents?.AfterBasketChanged?.basket) {
-        state.value.data = {
+        state.value.data = normalizeCartProductNames({
           ...errorEvents.AfterBasketChanged.basket,
           items: errorEvents.AfterBasketChanged.basketItems,
-        };
+        });
       }
       useHandleError(apiError);
     } finally {
@@ -169,7 +172,7 @@ export const useCart = () => {
     try {
       const { data } = await useSdk().plentysystems.doAddCartItems(params);
 
-      state.value.data = migrateVariationData(state.value.data, data) ?? state.value.data;
+      state.value.data = normalizeCartProductNames(migrateVariationData(state.value.data, data)) ?? state.value.data;
 
       params.forEach((param) => {
         const item = state?.value?.data?.items?.find((item) => item.variationId === param.productId);
@@ -190,10 +193,10 @@ export const useCart = () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const errorEvents = apiError.events as any;
       if (errorEvents?.AfterBasketChanged?.basket) {
-        state.value.data = {
+        state.value.data = normalizeCartProductNames({
           ...errorEvents.AfterBasketChanged.basket,
           items: errorEvents.AfterBasketChanged.basketItems,
-        };
+        });
       }
       useHandleError(apiError);
     } finally {

--- a/apps/web/app/composables/useCart/useCart.ts
+++ b/apps/web/app/composables/useCart/useCart.ts
@@ -48,6 +48,7 @@ const isCartItemError = (data: Cart | CartItemError): data is CartItemError => {
  */
 export const useCart = () => {
   const { emit } = usePlentyEvent();
+  const { getSetting: getVariationTitlePropertySetting } = useSiteSettings('variationTitleProperty');
   const state = useState('useCart', () => ({
     data: {} as Cart,
     useAsShippingAddress: true,
@@ -65,7 +66,7 @@ export const useCart = () => {
    */
   const setCart = (data: Cart) => {
     const { setPattern } = usePriceFormatter();
-    state.value.data = normalizeCartProductNames(data);
+    state.value.data = normalizeCartProductNames(data, getVariationTitlePropertySetting());
     setPattern(data.currencyPattern);
     useWishlist().setWishlistItemIds(Object.values(data?.itemWishListIds || []));
   };
@@ -121,7 +122,7 @@ export const useCart = () => {
       const { data } = await useSdk().plentysystems.doAddCartItem(params);
 
       state.value.data = data
-        ? normalizeCartProductNames(migrateVariationData(state.value.data, data))
+        ? normalizeCartProductNames(migrateVariationData(state.value.data, data), getVariationTitlePropertySetting())
         : state.value.data;
 
       const item = state?.value?.data?.items?.find((item) => item.variationId === params.productId);
@@ -145,7 +146,7 @@ export const useCart = () => {
         state.value.data = normalizeCartProductNames({
           ...errorEvents.AfterBasketChanged.basket,
           items: errorEvents.AfterBasketChanged.basketItems,
-        });
+        }, getVariationTitlePropertySetting());
       }
       useHandleError(apiError);
     } finally {
@@ -172,7 +173,9 @@ export const useCart = () => {
     try {
       const { data } = await useSdk().plentysystems.doAddCartItems(params);
 
-      state.value.data = normalizeCartProductNames(migrateVariationData(state.value.data, data)) ?? state.value.data;
+      state.value.data =
+        normalizeCartProductNames(migrateVariationData(state.value.data, data), getVariationTitlePropertySetting()) ??
+        state.value.data;
 
       params.forEach((param) => {
         const item = state?.value?.data?.items?.find((item) => item.variationId === param.productId);
@@ -196,7 +199,7 @@ export const useCart = () => {
         state.value.data = normalizeCartProductNames({
           ...errorEvents.AfterBasketChanged.basket,
           items: errorEvents.AfterBasketChanged.basketItems,
-        });
+        }, getVariationTitlePropertySetting());
       }
       useHandleError(apiError);
     } finally {
@@ -233,7 +236,11 @@ export const useCart = () => {
 
         send({ message: t('storefrontError.cart.reachedMaximumQuantity'), type: 'warning' });
       } else {
-        state.value.data = migrateVariationData(state.value.data, data as Cart) ?? state.value.data;
+        state.value.data =
+          normalizeCartProductNames(
+            migrateVariationData(state.value.data, data as Cart),
+            getVariationTitlePropertySetting(),
+          ) ?? state.value.data;
         // @ts-expect-error The type of `state.value.data.apiEvents` is not recognized
         if (state.value.data?.apiEvents) {
           // @ts-expect-error The type of `state.value.data.apiEvents` is not recognized

--- a/apps/web/app/composables/useCart/useCart.ts
+++ b/apps/web/app/composables/useCart/useCart.ts
@@ -7,7 +7,6 @@ import type {
   Cart,
   PlentyEvents,
 } from '@plentymarkets/shop-api';
-import { normalizeCartProductNames } from '~/utils/product-name-normalizer';
 
 const migrateVariationData = (oldCart: Cart, nextCart: Cart = {} as Cart): Cart => {
   if (!oldCart || !oldCart.items || !nextCart || !nextCart.items) {
@@ -48,7 +47,7 @@ const isCartItemError = (data: Cart | CartItemError): data is CartItemError => {
  */
 export const useCart = () => {
   const { emit } = usePlentyEvent();
-  const { getSetting: getVariationTitlePropertySetting } = useSiteSettings('variationTitleProperty');
+  const { normalizeCartProductNames } = useProductNameNormalizer();
   const state = useState('useCart', () => ({
     data: {} as Cart,
     useAsShippingAddress: true,
@@ -66,7 +65,7 @@ export const useCart = () => {
    */
   const setCart = (data: Cart) => {
     const { setPattern } = usePriceFormatter();
-    state.value.data = normalizeCartProductNames(data, getVariationTitlePropertySetting());
+    state.value.data = normalizeCartProductNames(data);
     setPattern(data.currencyPattern);
     useWishlist().setWishlistItemIds(Object.values(data?.itemWishListIds || []));
   };
@@ -121,9 +120,7 @@ export const useCart = () => {
     try {
       const { data } = await useSdk().plentysystems.doAddCartItem(params);
 
-      state.value.data = data
-        ? normalizeCartProductNames(migrateVariationData(state.value.data, data), getVariationTitlePropertySetting())
-        : state.value.data;
+      state.value.data = data ? normalizeCartProductNames(migrateVariationData(state.value.data, data)) : state.value.data;
 
       const item = state?.value?.data?.items?.find((item) => item.variationId === params.productId);
 
@@ -146,7 +143,7 @@ export const useCart = () => {
         state.value.data = normalizeCartProductNames({
           ...errorEvents.AfterBasketChanged.basket,
           items: errorEvents.AfterBasketChanged.basketItems,
-        }, getVariationTitlePropertySetting());
+        });
       }
       useHandleError(apiError);
     } finally {
@@ -173,9 +170,7 @@ export const useCart = () => {
     try {
       const { data } = await useSdk().plentysystems.doAddCartItems(params);
 
-      state.value.data =
-        normalizeCartProductNames(migrateVariationData(state.value.data, data), getVariationTitlePropertySetting()) ??
-        state.value.data;
+      state.value.data = normalizeCartProductNames(migrateVariationData(state.value.data, data)) ?? state.value.data;
 
       params.forEach((param) => {
         const item = state?.value?.data?.items?.find((item) => item.variationId === param.productId);
@@ -199,7 +194,7 @@ export const useCart = () => {
         state.value.data = normalizeCartProductNames({
           ...errorEvents.AfterBasketChanged.basket,
           items: errorEvents.AfterBasketChanged.basketItems,
-        }, getVariationTitlePropertySetting());
+        });
       }
       useHandleError(apiError);
     } finally {
@@ -236,11 +231,7 @@ export const useCart = () => {
 
         send({ message: t('storefrontError.cart.reachedMaximumQuantity'), type: 'warning' });
       } else {
-        state.value.data =
-          normalizeCartProductNames(
-            migrateVariationData(state.value.data, data as Cart),
-            getVariationTitlePropertySetting(),
-          ) ?? state.value.data;
+        state.value.data = normalizeCartProductNames(migrateVariationData(state.value.data, data as Cart)) ?? state.value.data;
         // @ts-expect-error The type of `state.value.data.apiEvents` is not recognized
         if (state.value.data?.apiEvents) {
           // @ts-expect-error The type of `state.value.data.apiEvents` is not recognized

--- a/apps/web/app/composables/useProduct/useProduct.ts
+++ b/apps/web/app/composables/useProduct/useProduct.ts
@@ -5,6 +5,7 @@ import type { UseProductReturn, UseProductState, FetchProduct } from '~/composab
 
 import { generateBreadcrumbs } from '~/utils/productHelper';
 import { getProductTemplate } from '~/utils/blockTemplates/product';
+import { normalizeProductName } from '~/utils/product-name-normalizer';
 
 const useProductTemplateData = async (locale: string) => await getProductTemplate(locale);
 
@@ -103,7 +104,7 @@ export const useProduct: UseProductReturn = (slug) => {
     );
 
     properties.setProperties(data.value?.data.properties ?? []);
-    state.value.data = data.value?.data ?? ({} as Product);
+    state.value.data = normalizeProductName(data.value?.data ?? ({} as Product));
     handlePreviewProduct(state, $i18n.locale.value, true);
     state.value.loading = false;
     return state.value.data;

--- a/apps/web/app/composables/useProduct/useProduct.ts
+++ b/apps/web/app/composables/useProduct/useProduct.ts
@@ -20,6 +20,7 @@ const useProductTemplateData = async (locale: string) => await getProductTemplat
  */
 export const useProduct: UseProductReturn = (slug) => {
   const properties = useProductOrderProperties();
+  const { getSetting: getVariationTitlePropertySetting } = useSiteSettings('variationTitleProperty');
   const state = useState<UseProductState>(`useProduct-${slug}`, () => ({
     data: {} as Product,
     fakeData: {} as Product,
@@ -104,7 +105,7 @@ export const useProduct: UseProductReturn = (slug) => {
     );
 
     properties.setProperties(data.value?.data.properties ?? []);
-    state.value.data = normalizeProductName(data.value?.data ?? ({} as Product));
+    state.value.data = normalizeProductName(data.value?.data ?? ({} as Product), getVariationTitlePropertySetting());
     handlePreviewProduct(state, $i18n.locale.value, true);
     state.value.loading = false;
     return state.value.data;

--- a/apps/web/app/composables/useProduct/useProduct.ts
+++ b/apps/web/app/composables/useProduct/useProduct.ts
@@ -5,7 +5,6 @@ import type { UseProductReturn, UseProductState, FetchProduct } from '~/composab
 
 import { generateBreadcrumbs } from '~/utils/productHelper';
 import { getProductTemplate } from '~/utils/blockTemplates/product';
-import { normalizeProductName } from '~/utils/product-name-normalizer';
 
 const useProductTemplateData = async (locale: string) => await getProductTemplate(locale);
 
@@ -20,7 +19,7 @@ const useProductTemplateData = async (locale: string) => await getProductTemplat
  */
 export const useProduct: UseProductReturn = (slug) => {
   const properties = useProductOrderProperties();
-  const { getSetting: getVariationTitlePropertySetting } = useSiteSettings('variationTitleProperty');
+  const { normalizeProductName } = useProductNameNormalizer();
   const state = useState<UseProductState>(`useProduct-${slug}`, () => ({
     data: {} as Product,
     fakeData: {} as Product,
@@ -105,7 +104,7 @@ export const useProduct: UseProductReturn = (slug) => {
     );
 
     properties.setProperties(data.value?.data.properties ?? []);
-    state.value.data = normalizeProductName(data.value?.data ?? ({} as Product), getVariationTitlePropertySetting());
+    state.value.data = normalizeProductName(data.value?.data ?? ({} as Product));
     handlePreviewProduct(state, $i18n.locale.value, true);
     state.value.loading = false;
     return state.value.data;

--- a/apps/web/app/composables/useProductNameNormalizer/index.ts
+++ b/apps/web/app/composables/useProductNameNormalizer/index.ts
@@ -1,0 +1,1 @@
+export * from './useProductNameNormalizer';

--- a/apps/web/app/composables/useProductNameNormalizer/useProductNameNormalizer.ts
+++ b/apps/web/app/composables/useProductNameNormalizer/useProductNameNormalizer.ts
@@ -1,0 +1,26 @@
+import type { Cart, Facet, ItemSearchResult, Product, WishlistItem } from '@plentymarkets/shop-api';
+import {
+  getNormalizedProductName as getNormalizedProductNameBase,
+  normalizeCartProductNames as normalizeCartProductNamesBase,
+  normalizeFacetProductNames as normalizeFacetProductNamesBase,
+  normalizeItemSearchResultProductNames as normalizeItemSearchResultProductNamesBase,
+  normalizeProductCollection as normalizeProductCollectionBase,
+  normalizeProductName as normalizeProductNameBase,
+  normalizeWishlistProductNames as normalizeWishlistProductNamesBase,
+} from '~/utils/product-name-normalizer';
+
+export const useProductNameNormalizer = () => {
+  const { getSetting: getVariationTitlePropertySetting } = useSiteSettings('variationTitleProperty');
+
+  const getSettingValue = () => getVariationTitlePropertySetting();
+
+  return {
+    getNormalizedProductName: (product?: unknown | null) => getNormalizedProductNameBase(product, getSettingValue()),
+    normalizeProductName: <T>(product?: T | null) => normalizeProductNameBase(product, getSettingValue()),
+    normalizeProductCollection: (products?: Product[] | null) => normalizeProductCollectionBase(products, getSettingValue()),
+    normalizeFacetProductNames: (facet?: Facet | null) => normalizeFacetProductNamesBase(facet, getSettingValue()),
+    normalizeItemSearchResultProductNames: (result?: ItemSearchResult | null) => normalizeItemSearchResultProductNamesBase(result, getSettingValue()),
+    normalizeCartProductNames: (cart?: Cart | null) => normalizeCartProductNamesBase(cart, getSettingValue()),
+    normalizeWishlistProductNames: (wishlistItems?: WishlistItem[] | null) => normalizeWishlistProductNamesBase(wishlistItems, getSettingValue()),
+  };
+};

--- a/apps/web/app/composables/useProductRecommended/useProductRecommended.ts
+++ b/apps/web/app/composables/useProductRecommended/useProductRecommended.ts
@@ -4,6 +4,7 @@ import type {
   FetchProductRecommended,
 } from '~/composables/useProductRecommended/types';
 import type { FacetSearchCriteria } from '@plentymarkets/shop-api';
+import { normalizeProductCollection } from '~/utils/product-name-normalizer';
 
 /**
  * Composable for managing recommended products data
@@ -52,7 +53,7 @@ export const useProductRecommended: UseProductRecommendedReturn = (categoryId: s
     );
 
     useHandleError(error.value ?? null);
-    state.value.data = data?.value?.data?.products ?? state.value.data;
+    state.value.data = normalizeProductCollection(data?.value?.data?.products ?? state.value.data);
     state.value.loading = false;
     return state.value.data;
   };

--- a/apps/web/app/composables/useProductRecommended/useProductRecommended.ts
+++ b/apps/web/app/composables/useProductRecommended/useProductRecommended.ts
@@ -4,7 +4,6 @@ import type {
   FetchProductRecommended,
 } from '~/composables/useProductRecommended/types';
 import type { FacetSearchCriteria } from '@plentymarkets/shop-api';
-import { normalizeProductCollection } from '~/utils/product-name-normalizer';
 
 /**
  * Composable for managing recommended products data
@@ -16,7 +15,7 @@ import { normalizeProductCollection } from '~/utils/product-name-normalizer';
  * ```
  */
 export const useProductRecommended: UseProductRecommendedReturn = (categoryId: string) => {
-  const { getSetting: getVariationTitlePropertySetting } = useSiteSettings('variationTitleProperty');
+  const { normalizeProductCollection } = useProductNameNormalizer();
   const state = useState<UseProductRecommendedState>(`useProductRecommended-${categoryId}`, () => ({
     data: [],
     loading: false,
@@ -54,10 +53,7 @@ export const useProductRecommended: UseProductRecommendedReturn = (categoryId: s
     );
 
     useHandleError(error.value ?? null);
-    state.value.data = normalizeProductCollection(
-      data?.value?.data?.products ?? state.value.data,
-      getVariationTitlePropertySetting(),
-    );
+    state.value.data = normalizeProductCollection(data?.value?.data?.products ?? state.value.data);
     state.value.loading = false;
     return state.value.data;
   };

--- a/apps/web/app/composables/useProductRecommended/useProductRecommended.ts
+++ b/apps/web/app/composables/useProductRecommended/useProductRecommended.ts
@@ -16,6 +16,7 @@ import { normalizeProductCollection } from '~/utils/product-name-normalizer';
  * ```
  */
 export const useProductRecommended: UseProductRecommendedReturn = (categoryId: string) => {
+  const { getSetting: getVariationTitlePropertySetting } = useSiteSettings('variationTitleProperty');
   const state = useState<UseProductRecommendedState>(`useProductRecommended-${categoryId}`, () => ({
     data: [],
     loading: false,
@@ -53,7 +54,10 @@ export const useProductRecommended: UseProductRecommendedReturn = (categoryId: s
     );
 
     useHandleError(error.value ?? null);
-    state.value.data = normalizeProductCollection(data?.value?.data?.products ?? state.value.data);
+    state.value.data = normalizeProductCollection(
+      data?.value?.data?.products ?? state.value.data,
+      getVariationTitlePropertySetting(),
+    );
     state.value.loading = false;
     return state.value.data;
   };

--- a/apps/web/app/composables/useProducts/useProducts.ts
+++ b/apps/web/app/composables/useProducts/useProducts.ts
@@ -4,6 +4,7 @@ import type { UseProductsState, FetchProducts, UseProductsReturn } from '~/compo
 import { getCategoryTemplate } from '~/utils/blockTemplates/category';
 import { fakeFacetCallEN } from '~/utils/facets/fakeFacetCallEN';
 import { fakeFacetCallDE } from '~/utils/facets/fakeFacetCallDE';
+import { normalizeFacetProductNames, normalizeProductName } from '~/utils/product-name-normalizer';
 
 const useBlockTemplatesData = async (locale: string) => await getCategoryTemplate(locale);
 
@@ -104,7 +105,7 @@ export const useProducts: UseProductsReturn = (category = '') => {
 
     if (data.value?.data) {
       data.value.data.pagination.perPageOptions = defaults.PER_PAGE_STEPS;
-      state.value.data = data.value.data;
+      state.value.data = normalizeFacetProductNames(data.value.data);
       handlePreviewProducts(state, $i18n.locale.value);
 
       const defaultData =
@@ -129,7 +130,7 @@ export const useProducts: UseProductsReturn = (category = '') => {
   const setCurrentProduct: SetCurrentProduct = async (product: Product) => {
     state.value.loading = true;
 
-    state.value.currentProduct = product;
+    state.value.currentProduct = normalizeProductName(product);
 
     state.value.loading = false;
   };

--- a/apps/web/app/composables/useProducts/useProducts.ts
+++ b/apps/web/app/composables/useProducts/useProducts.ts
@@ -17,6 +17,7 @@ const useBlockTemplatesData = async (locale: string) => await getCategoryTemplat
  * ```
  */
 export const useProducts: UseProductsReturn = (category = '') => {
+  const { getSetting: getVariationTitlePropertySetting } = useSiteSettings('variationTitleProperty');
   const state = useState<UseProductsState>(`useProducts${category}`, () => ({
     data: {} as Facet,
     loading: false,
@@ -105,7 +106,7 @@ export const useProducts: UseProductsReturn = (category = '') => {
 
     if (data.value?.data) {
       data.value.data.pagination.perPageOptions = defaults.PER_PAGE_STEPS;
-      state.value.data = normalizeFacetProductNames(data.value.data);
+      state.value.data = normalizeFacetProductNames(data.value.data, getVariationTitlePropertySetting());
       handlePreviewProducts(state, $i18n.locale.value);
 
       const defaultData =
@@ -130,7 +131,7 @@ export const useProducts: UseProductsReturn = (category = '') => {
   const setCurrentProduct: SetCurrentProduct = async (product: Product) => {
     state.value.loading = true;
 
-    state.value.currentProduct = normalizeProductName(product);
+    state.value.currentProduct = normalizeProductName(product, getVariationTitlePropertySetting());
 
     state.value.loading = false;
   };

--- a/apps/web/app/composables/useProducts/useProducts.ts
+++ b/apps/web/app/composables/useProducts/useProducts.ts
@@ -4,7 +4,6 @@ import type { UseProductsState, FetchProducts, UseProductsReturn } from '~/compo
 import { getCategoryTemplate } from '~/utils/blockTemplates/category';
 import { fakeFacetCallEN } from '~/utils/facets/fakeFacetCallEN';
 import { fakeFacetCallDE } from '~/utils/facets/fakeFacetCallDE';
-import { normalizeFacetProductNames, normalizeProductName } from '~/utils/product-name-normalizer';
 
 const useBlockTemplatesData = async (locale: string) => await getCategoryTemplate(locale);
 
@@ -17,7 +16,7 @@ const useBlockTemplatesData = async (locale: string) => await getCategoryTemplat
  * ```
  */
 export const useProducts: UseProductsReturn = (category = '') => {
-  const { getSetting: getVariationTitlePropertySetting } = useSiteSettings('variationTitleProperty');
+  const { normalizeFacetProductNames, normalizeProductName } = useProductNameNormalizer();
   const state = useState<UseProductsState>(`useProducts${category}`, () => ({
     data: {} as Facet,
     loading: false,
@@ -106,7 +105,7 @@ export const useProducts: UseProductsReturn = (category = '') => {
 
     if (data.value?.data) {
       data.value.data.pagination.perPageOptions = defaults.PER_PAGE_STEPS;
-      state.value.data = normalizeFacetProductNames(data.value.data, getVariationTitlePropertySetting());
+      state.value.data = normalizeFacetProductNames(data.value.data);
       handlePreviewProducts(state, $i18n.locale.value);
 
       const defaultData =
@@ -131,7 +130,7 @@ export const useProducts: UseProductsReturn = (category = '') => {
   const setCurrentProduct: SetCurrentProduct = async (product: Product) => {
     state.value.loading = true;
 
-    state.value.currentProduct = normalizeProductName(product, getVariationTitlePropertySetting());
+    state.value.currentProduct = normalizeProductName(product);
 
     state.value.loading = false;
   };

--- a/apps/web/app/composables/useSearch/useSearch.ts
+++ b/apps/web/app/composables/useSearch/useSearch.ts
@@ -1,6 +1,7 @@
 import type { ApiError, ItemSearchParams, ItemSearchResult } from '@plentymarkets/shop-api';
 import { defaults } from '~/composables';
 import type { UseSearchReturn, UseSearchState, GetSearch } from '~/composables/useSearch/types';
+import { normalizeItemSearchResultProductNames } from '~/utils/product-name-normalizer';
 
 /**
  * @description Composable for managing products search.
@@ -37,7 +38,7 @@ export const useSearch: UseSearchReturn = () => {
       const { data } = await useSdk().plentysystems.getSearch(params);
       state.value.productsPerPage = params.itemsPerPage || defaults.DEFAULT_ITEMS_PER_PAGE;
       if (data) data.pagination.perPageOptions = defaults.PER_PAGE_STEPS;
-      state.value.data = data;
+      state.value.data = normalizeItemSearchResultProductNames(data);
     } catch (error) {
       useHandleError(error as ApiError);
     } finally {

--- a/apps/web/app/composables/useSearch/useSearch.ts
+++ b/apps/web/app/composables/useSearch/useSearch.ts
@@ -12,6 +12,7 @@ import { normalizeItemSearchResultProductNames } from '~/utils/product-name-norm
  * ```
  */
 export const useSearch: UseSearchReturn = () => {
+  const { getSetting: getVariationTitlePropertySetting } = useSiteSettings('variationTitleProperty');
   const state = useState<UseSearchState>('search', () => ({
     data: {} as ItemSearchResult,
     loading: false,
@@ -38,7 +39,7 @@ export const useSearch: UseSearchReturn = () => {
       const { data } = await useSdk().plentysystems.getSearch(params);
       state.value.productsPerPage = params.itemsPerPage || defaults.DEFAULT_ITEMS_PER_PAGE;
       if (data) data.pagination.perPageOptions = defaults.PER_PAGE_STEPS;
-      state.value.data = normalizeItemSearchResultProductNames(data);
+      state.value.data = normalizeItemSearchResultProductNames(data, getVariationTitlePropertySetting());
     } catch (error) {
       useHandleError(error as ApiError);
     } finally {

--- a/apps/web/app/composables/useSearch/useSearch.ts
+++ b/apps/web/app/composables/useSearch/useSearch.ts
@@ -1,7 +1,6 @@
 import type { ApiError, ItemSearchParams, ItemSearchResult } from '@plentymarkets/shop-api';
 import { defaults } from '~/composables';
 import type { UseSearchReturn, UseSearchState, GetSearch } from '~/composables/useSearch/types';
-import { normalizeItemSearchResultProductNames } from '~/utils/product-name-normalizer';
 
 /**
  * @description Composable for managing products search.
@@ -12,7 +11,7 @@ import { normalizeItemSearchResultProductNames } from '~/utils/product-name-norm
  * ```
  */
 export const useSearch: UseSearchReturn = () => {
-  const { getSetting: getVariationTitlePropertySetting } = useSiteSettings('variationTitleProperty');
+  const { normalizeItemSearchResultProductNames } = useProductNameNormalizer();
   const state = useState<UseSearchState>('search', () => ({
     data: {} as ItemSearchResult,
     loading: false,
@@ -39,7 +38,7 @@ export const useSearch: UseSearchReturn = () => {
       const { data } = await useSdk().plentysystems.getSearch(params);
       state.value.productsPerPage = params.itemsPerPage || defaults.DEFAULT_ITEMS_PER_PAGE;
       if (data) data.pagination.perPageOptions = defaults.PER_PAGE_STEPS;
-      state.value.data = normalizeItemSearchResultProductNames(data, getVariationTitlePropertySetting());
+      state.value.data = normalizeItemSearchResultProductNames(data);
     } catch (error) {
       useHandleError(error as ApiError);
     } finally {

--- a/apps/web/app/composables/useWishlist/useWishlist.ts
+++ b/apps/web/app/composables/useWishlist/useWishlist.ts
@@ -4,6 +4,7 @@ import type {
   AddWishlistItemParams,
   DeleteWishlistItemParams,
 } from '@plentymarkets/shop-api';
+import { normalizeWishlistProductNames } from '~/utils/product-name-normalizer';
 import type {
   FetchWishlist,
   UseWishlistReturn,
@@ -46,7 +47,7 @@ export const useWishlist: UseWishlistReturn = () => {
     return await useSdk()
       .plentysystems.getWishlist()
       .then(({ data }) => {
-        state.value.data = data ?? state.value.data;
+        state.value.data = normalizeWishlistProductNames(data ?? state.value.data);
         state.value.loading = false;
         return state.value.data;
       });

--- a/apps/web/app/composables/useWishlist/useWishlist.ts
+++ b/apps/web/app/composables/useWishlist/useWishlist.ts
@@ -27,6 +27,7 @@ import type {
  * ```
  */
 export const useWishlist: UseWishlistReturn = () => {
+  const { getSetting: getVariationTitlePropertySetting } = useSiteSettings('variationTitleProperty');
   const state = useState<UseWishlistState>('wishlist', () => ({
     data: [] as WishlistItem[],
     loading: false,
@@ -47,7 +48,7 @@ export const useWishlist: UseWishlistReturn = () => {
     return await useSdk()
       .plentysystems.getWishlist()
       .then(({ data }) => {
-        state.value.data = normalizeWishlistProductNames(data ?? state.value.data);
+        state.value.data = normalizeWishlistProductNames(data ?? state.value.data, getVariationTitlePropertySetting());
         state.value.loading = false;
         return state.value.data;
       });

--- a/apps/web/app/composables/useWishlist/useWishlist.ts
+++ b/apps/web/app/composables/useWishlist/useWishlist.ts
@@ -4,7 +4,6 @@ import type {
   AddWishlistItemParams,
   DeleteWishlistItemParams,
 } from '@plentymarkets/shop-api';
-import { normalizeWishlistProductNames } from '~/utils/product-name-normalizer';
 import type {
   FetchWishlist,
   UseWishlistReturn,
@@ -27,7 +26,7 @@ import type {
  * ```
  */
 export const useWishlist: UseWishlistReturn = () => {
-  const { getSetting: getVariationTitlePropertySetting } = useSiteSettings('variationTitleProperty');
+  const { normalizeWishlistProductNames } = useProductNameNormalizer();
   const state = useState<UseWishlistState>('wishlist', () => ({
     data: [] as WishlistItem[],
     loading: false,
@@ -48,7 +47,7 @@ export const useWishlist: UseWishlistReturn = () => {
     return await useSdk()
       .plentysystems.getWishlist()
       .then(({ data }) => {
-        state.value.data = normalizeWishlistProductNames(data ?? state.value.data, getVariationTitlePropertySetting());
+        state.value.data = normalizeWishlistProductNames(data ?? state.value.data);
         state.value.loading = false;
         return state.value.data;
       });

--- a/apps/web/app/utils/__tests__/product-name-normalizer.spec.ts
+++ b/apps/web/app/utils/__tests__/product-name-normalizer.spec.ts
@@ -1,0 +1,58 @@
+import type { Cart, Product, WishlistItem } from '@plentymarkets/shop-api';
+import {
+  getNormalizedProductName,
+  normalizeCartProductNames,
+  normalizeProductName,
+  normalizeWishlistProductNames,
+} from '../product-name-normalizer';
+
+const createProduct = (): Product =>
+  ({
+    texts: {
+      name1: 'Original Name',
+    },
+    variationProperties: [
+      {
+        name: 'Variation Texts',
+        properties: [
+          {
+            names: {
+              name: 'Variation Title',
+            },
+            values: {
+              value: 'Normalized Name',
+            },
+          },
+        ],
+      },
+    ],
+  }) as Product;
+
+describe('product name normalizer', () => {
+  it('should extract the variation title as normalized product name', () => {
+    expect(getNormalizedProductName(createProduct())).toBe('Normalized Name');
+  });
+
+  it('should overwrite product texts.name1 with the normalized name', () => {
+    const product = createProduct();
+
+    expect(normalizeProductName(product).texts?.name1).toBe('Normalized Name');
+  });
+
+  it('should normalize cart item variation names', () => {
+    const cart = {
+      items: [{ variation: createProduct() }],
+    } as Cart;
+    const normalizedCart = normalizeCartProductNames(cart);
+    const firstItem = normalizedCart.items?.[0];
+
+    expect(firstItem).toBeDefined();
+    expect(firstItem?.variation?.texts?.name1).toBe('Normalized Name');
+  });
+
+  it('should normalize wishlist item variation names', () => {
+    const wishlistItems: WishlistItem[] = [createProduct() as WishlistItem];
+
+    expect(normalizeWishlistProductNames(wishlistItems)[0]?.texts?.name1).toBe('Normalized Name');
+  });
+});

--- a/apps/web/app/utils/__tests__/product-name-normalizer.spec.ts
+++ b/apps/web/app/utils/__tests__/product-name-normalizer.spec.ts
@@ -16,7 +16,10 @@ const createProduct = (): Product =>
         name: 'Variation Texts',
         properties: [
           {
+            id: 10,
+            cast: 'text',
             names: {
+              propertyId: 10,
               name: 'Variation Title',
             },
             values: {
@@ -29,21 +32,81 @@ const createProduct = (): Product =>
   }) as Product;
 
 describe('product name normalizer', () => {
-  it('should extract the variation title as normalized product name', () => {
-    expect(getNormalizedProductName(createProduct())).toBe('Normalized Name');
+  it('should return the default product name when no property id is configured', () => {
+    expect(getNormalizedProductName(createProduct())).toBe('Original Name');
+  });
+
+  it('should extract a configured variation property as normalized product name', () => {
+    const product = {
+      texts: {
+        name1: 'Original Name',
+      },
+      variationProperties: [
+        {
+          name: 'Custom Group',
+          properties: [
+            {
+              id: 42,
+              cast: 'text',
+              names: {
+                propertyId: 42,
+                name: 'Custom Property',
+              },
+              values: {
+                value: 'Configured Name',
+              },
+            },
+          ],
+        },
+      ],
+    } as Product;
+
+    expect(getNormalizedProductName(product, '42')).toBe('Configured Name');
+  });
+
+  it('should return the default product name when the configured property id does not exist', () => {
+    expect(getNormalizedProductName(createProduct(), '999')).toBe('Original Name');
+  });
+
+  it('should return the default product name when the configured property is not text', () => {
+    const product = {
+      texts: {
+        name1: 'Original Name',
+      },
+      variationProperties: [
+        {
+          name: 'Custom Group',
+          properties: [
+            {
+              id: 42,
+              cast: 'file',
+              names: {
+                propertyId: 42,
+                name: 'Custom Property',
+              },
+              values: {
+                value: 'Configured Name',
+              },
+            },
+          ],
+        },
+      ],
+    } as Product;
+
+    expect(getNormalizedProductName(product, '42')).toBe('Original Name');
   });
 
   it('should overwrite product texts.name1 with the normalized name', () => {
     const product = createProduct();
 
-    expect(normalizeProductName(product).texts?.name1).toBe('Normalized Name');
+    expect(normalizeProductName(product, '10').texts?.name1).toBe('Normalized Name');
   });
 
   it('should normalize cart item variation names', () => {
     const cart = {
       items: [{ variation: createProduct() }],
     } as Cart;
-    const normalizedCart = normalizeCartProductNames(cart);
+    const normalizedCart = normalizeCartProductNames(cart, '10');
     const firstItem = normalizedCart.items?.[0];
 
     expect(firstItem).toBeDefined();
@@ -53,6 +116,6 @@ describe('product name normalizer', () => {
   it('should normalize wishlist item variation names', () => {
     const wishlistItems: WishlistItem[] = [createProduct() as WishlistItem];
 
-    expect(normalizeWishlistProductNames(wishlistItems)[0]?.texts?.name1).toBe('Normalized Name');
+    expect(normalizeWishlistProductNames(wishlistItems, '10')[0]?.texts?.name1).toBe('Normalized Name');
   });
 });

--- a/apps/web/app/utils/__tests__/product-name-normalizer.spec.ts
+++ b/apps/web/app/utils/__tests__/product-name-normalizer.spec.ts
@@ -32,8 +32,8 @@ const createProduct = (): Product =>
   }) as Product;
 
 describe('product name normalizer', () => {
-  it('should return the default product name when no property id is configured', () => {
-    expect(getNormalizedProductName(createProduct())).toBe('Original Name');
+  it('should return null when no property id is configured', () => {
+    expect(getNormalizedProductName(createProduct())).toBeNull();
   });
 
   it('should extract a configured variation property as normalized product name', () => {
@@ -64,11 +64,11 @@ describe('product name normalizer', () => {
     expect(getNormalizedProductName(product, '42')).toBe('Configured Name');
   });
 
-  it('should return the default product name when the configured property id does not exist', () => {
-    expect(getNormalizedProductName(createProduct(), '999')).toBe('Original Name');
+  it('should return null when the configured property id does not exist', () => {
+    expect(getNormalizedProductName(createProduct(), '999')).toBeNull();
   });
 
-  it('should return the default product name when the configured property is not text', () => {
+  it('should return null when the configured property is not text', () => {
     const product = {
       texts: {
         name1: 'Original Name',
@@ -93,7 +93,14 @@ describe('product name normalizer', () => {
       ],
     } as Product;
 
-    expect(getNormalizedProductName(product, '42')).toBe('Original Name');
+    expect(getNormalizedProductName(product, '42')).toBeNull();
+  });
+
+  it('should keep the original product name when no valid replacement is resolved', () => {
+    const product = createProduct();
+
+    expect(normalizeProductName(product).texts?.name1).toBe('Original Name');
+    expect(normalizeProductName(createProduct(), '999').texts?.name1).toBe('Original Name');
   });
 
   it('should overwrite product texts.name1 with the normalized name', () => {

--- a/apps/web/app/utils/product-name-normalizer.ts
+++ b/apps/web/app/utils/product-name-normalizer.ts
@@ -1,0 +1,142 @@
+import type { Cart, Facet, ItemSearchResult, Product, WishlistItem } from '@plentymarkets/shop-api';
+
+type ProductNameSource = {
+  texts?: {
+    name1?: string;
+  };
+  variationProperties?: Array<{
+    name: string | null;
+    properties: Array<{
+      names: {
+        name: string | null;
+      };
+      values: {
+        value: string | null;
+      };
+    }>;
+  }>;
+};
+
+const isProductNameSource = (value: unknown): value is ProductNameSource => {
+  return typeof value === 'object' && value !== null;
+};
+
+const VARIATION_TEXTS_GROUP_NAME = 'Variation Texts';
+const VARIATION_TITLE_NAME = 'Variation Title';
+
+/**
+ * Returns the custom variation title used as the canonical storefront product name.
+ */
+export const getNormalizedProductName = (product?: unknown | null): string => {
+  if (!isProductNameSource(product)) {
+    return '';
+  }
+
+  const variationTitle = product?.variationProperties
+    ?.find((propertyGroup) => propertyGroup.name === VARIATION_TEXTS_GROUP_NAME)
+    ?.properties?.find((property) => property.names.name === VARIATION_TITLE_NAME)
+    ?.values.value;
+
+  return variationTitle?.trim() ?? '';
+};
+
+/**
+ * Rewrites the product name in-place so existing product getters resolve the normalized name.
+ */
+export const normalizeProductName = <T>(product?: T | null): T => {
+  if (!product) {
+    return {} as T;
+  }
+
+  if (!isProductNameSource(product)) {
+    return product;
+  }
+
+  const normalizedName = getNormalizedProductName(product);
+
+  if (!normalizedName) {
+    return product;
+  }
+
+  product.texts = {
+    ...(product.texts ?? {}),
+    name1: normalizedName,
+  };
+
+  return product;
+};
+
+/**
+ * Normalizes all product names in a product collection.
+ */
+export const normalizeProductCollection = (products?: Product[] | null): Product[] => {
+  if (!products?.length) {
+    return products ?? [];
+  }
+
+  products.forEach((product) => normalizeProductName(product));
+
+  return products;
+};
+
+/**
+ * Normalizes product names in facet responses.
+ */
+export const normalizeFacetProductNames = (facet?: Facet | null): Facet => {
+  if (!facet) {
+    return {} as Facet;
+  }
+
+  if (facet.products) {
+    normalizeProductCollection(facet.products);
+  }
+
+  return facet;
+};
+
+/**
+ * Normalizes product names in search responses.
+ */
+export const normalizeItemSearchResultProductNames = (result?: ItemSearchResult | null): ItemSearchResult => {
+  if (!result) {
+    return {} as ItemSearchResult;
+  }
+
+  if (result.products) {
+    normalizeProductCollection(result.products);
+  }
+
+  return result;
+};
+
+/**
+ * Normalizes product names for cart item variations.
+ */
+export const normalizeCartProductNames = (cart?: Cart | null): Cart => {
+  if (!cart) {
+    return {} as Cart;
+  }
+
+  cart.items?.forEach((item) => normalizeProductName(item.variation));
+
+  return cart;
+};
+
+/**
+ * Normalizes product names for wishlist item variations.
+ */
+export const normalizeWishlistProductNames = (wishlistItems?: WishlistItem[] | null): WishlistItem[] => {
+  if (!wishlistItems?.length) {
+    return wishlistItems ?? [];
+  }
+
+  wishlistItems.forEach((wishlistItem) => {
+    normalizeProductName(wishlistItem);
+
+    if ('variation' in wishlistItem) {
+      normalizeProductName(wishlistItem.variation);
+    }
+  });
+
+  return wishlistItems;
+};

--- a/apps/web/app/utils/product-name-normalizer.ts
+++ b/apps/web/app/utils/product-name-normalizer.ts
@@ -30,22 +30,18 @@ const getVariationTitleSettingPropertyId = (settingValue = ''): number | null =>
   return Number.isNaN(propertyId) ? null : propertyId;
 };
 
-const getDefaultProductName = (product: ProductNameSource): string => {
-  return product.texts?.name1?.trim() || '';
-};
-
 /**
  * Returns the custom variation title used as the canonical storefront product name.
  */
-export const getNormalizedProductName = (product?: unknown | null, settingValue = ''): string => {
+export const getNormalizedProductName = (product?: unknown | null, settingValue = ''): string | null => {
   if (!isProductNameSource(product)) {
-    return '';
+    return null;
   }
 
   const propertyId = getVariationTitleSettingPropertyId(settingValue);
 
   if (!propertyId) {
-    return getDefaultProductName(product);
+    return null;
   }
 
   const variationProperties = product.variationProperties ?? [];
@@ -54,10 +50,10 @@ export const getNormalizedProductName = (product?: unknown | null, settingValue 
     .find((property) => property.names.propertyId === propertyId || property.id === propertyId);
 
   if (!configuredVariationTitle || configuredVariationTitle.cast !== 'text') {
-    return getDefaultProductName(product);
+    return null;
   }
 
-  return configuredVariationTitle.values.value?.trim() || getDefaultProductName(product);
+  return configuredVariationTitle.values.value?.trim() || null;
 };
 
 /**

--- a/apps/web/app/utils/product-name-normalizer.ts
+++ b/apps/web/app/utils/product-name-normalizer.ts
@@ -7,7 +7,10 @@ type ProductNameSource = {
   variationProperties?: Array<{
     name: string | null;
     properties: Array<{
+      id?: number;
+      cast?: string;
       names: {
+        propertyId?: number;
         name: string | null;
       };
       values: {
@@ -21,29 +24,46 @@ const isProductNameSource = (value: unknown): value is ProductNameSource => {
   return typeof value === 'object' && value !== null;
 };
 
-const VARIATION_TEXTS_GROUP_NAME = 'Variation Texts';
-const VARIATION_TITLE_NAME = 'Variation Title';
+const getVariationTitleSettingPropertyId = (settingValue = ''): number | null => {
+  const propertyId = Number.parseInt(settingValue, 10);
+
+  return Number.isNaN(propertyId) ? null : propertyId;
+};
+
+const getDefaultProductName = (product: ProductNameSource): string => {
+  return product.texts?.name1?.trim() || '';
+};
 
 /**
  * Returns the custom variation title used as the canonical storefront product name.
  */
-export const getNormalizedProductName = (product?: unknown | null): string => {
+export const getNormalizedProductName = (product?: unknown | null, settingValue = ''): string => {
   if (!isProductNameSource(product)) {
     return '';
   }
 
-  const variationTitle = product?.variationProperties
-    ?.find((propertyGroup) => propertyGroup.name === VARIATION_TEXTS_GROUP_NAME)
-    ?.properties?.find((property) => property.names.name === VARIATION_TITLE_NAME)
-    ?.values.value;
+  const propertyId = getVariationTitleSettingPropertyId(settingValue);
 
-  return variationTitle?.trim() ?? '';
+  if (!propertyId) {
+    return getDefaultProductName(product);
+  }
+
+  const variationProperties = product.variationProperties ?? [];
+  const configuredVariationTitle = variationProperties
+    .flatMap((propertyGroup) => propertyGroup.properties ?? [])
+    .find((property) => property.names.propertyId === propertyId || property.id === propertyId);
+
+  if (!configuredVariationTitle || configuredVariationTitle.cast !== 'text') {
+    return getDefaultProductName(product);
+  }
+
+  return configuredVariationTitle.values.value?.trim() || getDefaultProductName(product);
 };
 
 /**
  * Rewrites the product name in-place so existing product getters resolve the normalized name.
  */
-export const normalizeProductName = <T>(product?: T | null): T => {
+export const normalizeProductName = <T>(product?: T | null, settingValue = ''): T => {
   if (!product) {
     return {} as T;
   }
@@ -52,7 +72,7 @@ export const normalizeProductName = <T>(product?: T | null): T => {
     return product;
   }
 
-  const normalizedName = getNormalizedProductName(product);
+  const normalizedName = getNormalizedProductName(product, settingValue);
 
   if (!normalizedName) {
     return product;
@@ -69,12 +89,12 @@ export const normalizeProductName = <T>(product?: T | null): T => {
 /**
  * Normalizes all product names in a product collection.
  */
-export const normalizeProductCollection = (products?: Product[] | null): Product[] => {
+export const normalizeProductCollection = (products?: Product[] | null, settingValue = ''): Product[] => {
   if (!products?.length) {
     return products ?? [];
   }
 
-  products.forEach((product) => normalizeProductName(product));
+  products.forEach((product) => normalizeProductName(product, settingValue));
 
   return products;
 };
@@ -82,13 +102,13 @@ export const normalizeProductCollection = (products?: Product[] | null): Product
 /**
  * Normalizes product names in facet responses.
  */
-export const normalizeFacetProductNames = (facet?: Facet | null): Facet => {
+export const normalizeFacetProductNames = (facet?: Facet | null, settingValue = ''): Facet => {
   if (!facet) {
     return {} as Facet;
   }
 
   if (facet.products) {
-    normalizeProductCollection(facet.products);
+    normalizeProductCollection(facet.products, settingValue);
   }
 
   return facet;
@@ -97,13 +117,13 @@ export const normalizeFacetProductNames = (facet?: Facet | null): Facet => {
 /**
  * Normalizes product names in search responses.
  */
-export const normalizeItemSearchResultProductNames = (result?: ItemSearchResult | null): ItemSearchResult => {
+export const normalizeItemSearchResultProductNames = (result?: ItemSearchResult | null, settingValue = ''): ItemSearchResult => {
   if (!result) {
     return {} as ItemSearchResult;
   }
 
   if (result.products) {
-    normalizeProductCollection(result.products);
+    normalizeProductCollection(result.products, settingValue);
   }
 
   return result;
@@ -112,12 +132,12 @@ export const normalizeItemSearchResultProductNames = (result?: ItemSearchResult 
 /**
  * Normalizes product names for cart item variations.
  */
-export const normalizeCartProductNames = (cart?: Cart | null): Cart => {
+export const normalizeCartProductNames = (cart?: Cart | null, settingValue = ''): Cart => {
   if (!cart) {
     return {} as Cart;
   }
 
-  cart.items?.forEach((item) => normalizeProductName(item.variation));
+  cart.items?.forEach((item) => normalizeProductName(item.variation, settingValue));
 
   return cart;
 };
@@ -125,16 +145,16 @@ export const normalizeCartProductNames = (cart?: Cart | null): Cart => {
 /**
  * Normalizes product names for wishlist item variations.
  */
-export const normalizeWishlistProductNames = (wishlistItems?: WishlistItem[] | null): WishlistItem[] => {
+export const normalizeWishlistProductNames = (wishlistItems?: WishlistItem[] | null, settingValue = ''): WishlistItem[] => {
   if (!wishlistItems?.length) {
     return wishlistItems ?? [];
   }
 
   wishlistItems.forEach((wishlistItem) => {
-    normalizeProductName(wishlistItem);
+    normalizeProductName(wishlistItem, settingValue);
 
     if ('variation' in wishlistItem) {
-      normalizeProductName(wishlistItem.variation);
+      normalizeProductName(wishlistItem.variation, settingValue);
     }
   });
 

--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -11,7 +11,7 @@ import { FailOnLargeChunksPlugin } from './app/configuration/vite.config';
 export default defineNuxtConfig({
   srcDir: 'app/',
   telemetry: false,
-  devtools: { enabled: true },
+  devtools: { enabled: false },
   css: ['~/assets/richtext.css'],
   typescript: {
     typeCheck: true,


### PR DESCRIPTION
## Issue:

If an Item has no variations, the default title on the website is Item Texts/Name1 and is multilingual.
If an item has variations, then the default Title is [Item Name1]. [Variation Attribute].
Adding variation attributes at the end of the item's name may be ok for color/size type variations, but there are many other cases where we need to use an individual name for each variation.
In such a case, we cannot use the Variation/Basic Settings/Variation name field, as it is not multilingual.
The solution is to create a text variation property and use it as the variation name on the website.

## Solution

Instead of the default Variation Titles, we use a text variation property as our multilingual Variation Title
We set the variation property ID to be used as the storefront item title. **When set**, the matching property value replaces the default Item name wherever the item name is used. In all other cases, if ID is empty/missing/non-integer/id does not exist, the default Item name is used.


## Describe your changes

-- Create a new Site Setting, Item/Variation Title to enter the variation property ID as an integer value. If empty/missing/non-integer/id does not exist, the default Item name is used. 
-- Create composer/useProductNameNormalizer as a wrapper so the setting lookup happens in one place
-- Create utils/product-name-normalizer that has the normalizer logic
-- We added the normalizer to various composable that use Item Titles. 
useProduct.ts,
useProducts.ts,
useProductRecommended.ts,
useSearch.ts,
useCart.ts,
and useWishlist.ts

