### PR TITLE
feat: Use Custom individual Variation Titles

### DIFF
--- a/apps/web/app/components/settings/item/item/variation-title/VariationTitleProperty.vue
+++ b/apps/web/app/components/settings/item/item/variation-title/VariationTitleProperty.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="py-2 mb-2">
+    <p class="mb-4">{{ getEditorTranslation('description') }}</p>
+    <div class="flex justify-between mb-2 items-center gap-2">
+      <UiFormLabel>{{ getEditorTranslation('label') }}</UiFormLabel>
+      <SfTooltip :label="getEditorTranslation('tooltip')" :placement="'left'" class="z-[9999]">
+        <SfIconInfo :size="'sm'" />
+      </SfTooltip>
+    </div>
+    <SfInput
+      v-model="variationTitlePropertyId"
+      type="number"
+      inputmode="numeric"
+      min="1"
+      :placeholder="getEditorTranslation('placeholder')"
+      data-testid="variation-title-property-input"
+    />
+    <p class="mt-2 text-sm text-neutral-500">
+      {{ getEditorTranslation('hint') }}
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { SfIconInfo, SfInput, SfTooltip } from '@storefront-ui/vue';
+
+const { updateSetting, getSetting } = useSiteSettings('variationTitleProperty');
+const variationTitlePropertyId = computed({
+  get: () => getSetting() || '',
+  set: (value: string | number) => {
+    const normalizedValue = String(value ?? '').trim();
+
+    updateSetting(normalizedValue);
+  },
+});
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "label": "Variation title property ID",
+    "description": "Enter the variation property ID that should be used as the storefront item title. When set, each product uses the matching property value as its title. If a product has no value entered for that property, it falls back to the default Title.",
+    "tooltip": "Use the variation property ID from the backend. Leave this empty to fall back to the default Title.",
+    "placeholder": "Enter variation property ID",
+    "hint": "Leave the field empty to use the default Title."
+  },
+  "de": {
+    "label": "Variation title property ID",
+    "description": "Enter the variation property ID that should be used as the storefront item title. When set, each product uses the matching property value as its title. If a product has no value entered for that property, it falls back to the default Title.",
+    "tooltip": "Use the variation property ID from the backend. Leave this empty to fall back to the default Title.",
+    "placeholder": "Enter variation property ID",
+    "hint": "Leave the field empty to use the default Title."
+  }
+}
+</i18n>

--- a/apps/web/app/composables/index.ts
+++ b/apps/web/app/composables/index.ts
@@ -73,6 +73,7 @@ export * from './useProductReviewAverage';
 export * from './useProductReviews';
 export * from './useProducts';
 export * from './useQuickCheckout';
+export * from './useProductNameNormalizer';
 export * from './useResetProductPageModal';
 export * from './useReturnOrder';
 export * from './useRestrictedAddress';

--- a/apps/web/app/composables/useCart/useCart.ts
+++ b/apps/web/app/composables/useCart/useCart.ts
@@ -47,6 +47,7 @@ const isCartItemError = (data: Cart | CartItemError): data is CartItemError => {
  */
 export const useCart = () => {
   const { emit } = usePlentyEvent();
+  const { normalizeCartProductNames } = useProductNameNormalizer();
   const state = useState('useCart', () => ({
     data: {} as Cart,
     useAsShippingAddress: true,
@@ -64,7 +65,7 @@ export const useCart = () => {
    */
   const setCart = (data: Cart) => {
     const { setPattern } = usePriceFormatter();
-    state.value.data = data;
+    state.value.data = normalizeCartProductNames(data);
     setPattern(data.currencyPattern);
     useWishlist().setWishlistItemIds(Object.values(data?.itemWishListIds || []));
   };
@@ -119,7 +120,7 @@ export const useCart = () => {
     try {
       const { data } = await useSdk().plentysystems.doAddCartItem(params);
 
-      state.value.data = data ? migrateVariationData(state.value.data, data) : state.value.data;
+      state.value.data = data ? normalizeCartProductNames(migrateVariationData(state.value.data, data)) : state.value.data;
 
       const item = state?.value?.data?.items?.find((item) => item.variationId === params.productId);
 
@@ -139,10 +140,10 @@ export const useCart = () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const errorEvents = apiError.events as any;
       if (errorEvents?.AfterBasketChanged?.basket) {
-        state.value.data = {
+        state.value.data = normalizeCartProductNames({
           ...errorEvents.AfterBasketChanged.basket,
           items: errorEvents.AfterBasketChanged.basketItems,
-        };
+        });
       }
       useHandleError(apiError);
     } finally {
@@ -169,7 +170,7 @@ export const useCart = () => {
     try {
       const { data } = await useSdk().plentysystems.doAddCartItems(params);
 
-      state.value.data = migrateVariationData(state.value.data, data ?? undefined) ?? state.value.data;
+      state.value.data = normalizeCartProductNames(migrateVariationData(state.value.data, data)) ?? state.value.data;
 
       params.forEach((param) => {
         const item = state?.value?.data?.items?.find((item) => item.variationId === param.productId);
@@ -190,10 +191,10 @@ export const useCart = () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const errorEvents = apiError.events as any;
       if (errorEvents?.AfterBasketChanged?.basket) {
-        state.value.data = {
+        state.value.data = normalizeCartProductNames({
           ...errorEvents.AfterBasketChanged.basket,
           items: errorEvents.AfterBasketChanged.basketItems,
-        };
+        });
       }
       useHandleError(apiError);
     } finally {
@@ -230,7 +231,7 @@ export const useCart = () => {
 
         send({ message: t('storefrontError.cart.reachedMaximumQuantity'), type: 'warning' });
       } else {
-        state.value.data = migrateVariationData(state.value.data, data as Cart) ?? state.value.data;
+        state.value.data = normalizeCartProductNames(migrateVariationData(state.value.data, data as Cart)) ?? state.value.data;
         // @ts-expect-error The type of `state.value.data.apiEvents` is not recognized
         if (state.value.data?.apiEvents) {
           // @ts-expect-error The type of `state.value.data.apiEvents` is not recognized
@@ -268,7 +269,7 @@ export const useCart = () => {
         cartItemId: cartItem.id,
       });
 
-      state.value.data = migrateVariationData(state.value.data, data ?? undefined) ?? state.value.data;
+      state.value.data = normalizeCartProductNames(migrateVariationData(state.value.data, data)) ?? state.value.data;
       emit('frontend:removeFromCart', {
         deleteItemParams: { cartItemId: cartItem.id },
         cart: state.value.data,

--- a/apps/web/app/composables/useProduct/useProduct.ts
+++ b/apps/web/app/composables/useProduct/useProduct.ts
@@ -19,6 +19,7 @@ const useProductTemplateData = async (locale: string) => await getProductTemplat
  */
 export const useProduct: UseProductReturn = (slug) => {
   const properties = useProductOrderProperties();
+  const { normalizeProductName } = useProductNameNormalizer();
   const state = useState<UseProductState>(`useProduct-${slug}`, () => ({
     data: {} as Product,
     fakeData: {} as Product,
@@ -102,8 +103,8 @@ export const useProduct: UseProductReturn = (slug) => {
       fetchedBlocks && fetchedBlocks.length > 0 ? fetchedBlocks : await useProductTemplateData($i18n.locale.value),
     );
 
-    properties.setProperties(data.value?.data?.properties ?? []);
-    state.value.data = data.value?.data ?? ({} as Product);
+    properties.setProperties(data.value?.data.properties ?? []);
+    state.value.data = normalizeProductName(data.value?.data ?? ({} as Product));
     handlePreviewProduct(state, $i18n.locale.value, true);
     state.value.loading = false;
     return state.value.data;

--- a/apps/web/app/composables/useProductNameNormalizer/index.ts
+++ b/apps/web/app/composables/useProductNameNormalizer/index.ts
@@ -1,0 +1,1 @@
+export * from './useProductNameNormalizer';

--- a/apps/web/app/composables/useProductNameNormalizer/useProductNameNormalizer.ts
+++ b/apps/web/app/composables/useProductNameNormalizer/useProductNameNormalizer.ts
@@ -1,0 +1,26 @@
+import type { Cart, Facet, ItemSearchResult, Product, WishlistItem } from '@plentymarkets/shop-api';
+import {
+  getNormalizedProductName as getNormalizedProductNameBase,
+  normalizeCartProductNames as normalizeCartProductNamesBase,
+  normalizeFacetProductNames as normalizeFacetProductNamesBase,
+  normalizeItemSearchResultProductNames as normalizeItemSearchResultProductNamesBase,
+  normalizeProductCollection as normalizeProductCollectionBase,
+  normalizeProductName as normalizeProductNameBase,
+  normalizeWishlistProductNames as normalizeWishlistProductNamesBase,
+} from '~/utils/product-name-normalizer';
+
+export const useProductNameNormalizer = () => {
+  const { getSetting: getVariationTitlePropertySetting } = useSiteSettings('variationTitleProperty');
+
+  const getSettingValue = () => getVariationTitlePropertySetting();
+
+  return {
+    getNormalizedProductName: (product?: unknown | null) => getNormalizedProductNameBase(product, getSettingValue()),
+    normalizeProductName: <T>(product?: T | null) => normalizeProductNameBase(product, getSettingValue()),
+    normalizeProductCollection: (products?: Product[] | null) => normalizeProductCollectionBase(products, getSettingValue()),
+    normalizeFacetProductNames: (facet?: Facet | null) => normalizeFacetProductNamesBase(facet, getSettingValue()),
+    normalizeItemSearchResultProductNames: (result?: ItemSearchResult | null) => normalizeItemSearchResultProductNamesBase(result, getSettingValue()),
+    normalizeCartProductNames: (cart?: Cart | null) => normalizeCartProductNamesBase(cart, getSettingValue()),
+    normalizeWishlistProductNames: (wishlistItems?: WishlistItem[] | null) => normalizeWishlistProductNamesBase(wishlistItems, getSettingValue()),
+  };
+};

--- a/apps/web/app/composables/useProductRecommended/useProductRecommended.ts
+++ b/apps/web/app/composables/useProductRecommended/useProductRecommended.ts
@@ -15,6 +15,7 @@ import type { FacetSearchCriteria } from '@plentymarkets/shop-api';
  * ```
  */
 export const useProductRecommended: UseProductRecommendedReturn = (categoryId: string) => {
+  const { normalizeProductCollection } = useProductNameNormalizer();
   const state = useState<UseProductRecommendedState>(`useProductRecommended-${categoryId}`, () => ({
     data: [],
     loading: false,
@@ -52,7 +53,7 @@ export const useProductRecommended: UseProductRecommendedReturn = (categoryId: s
     );
 
     useHandleError(error.value ?? null);
-    state.value.data = data?.value?.data?.products ?? state.value.data;
+    state.value.data = normalizeProductCollection(data?.value?.data?.products ?? state.value.data);
     state.value.loading = false;
     return state.value.data;
   };

--- a/apps/web/app/composables/useProducts/useProducts.ts
+++ b/apps/web/app/composables/useProducts/useProducts.ts
@@ -16,6 +16,7 @@ const useBlockTemplatesData = async (locale: string) => await getCategoryTemplat
  * ```
  */
 export const useProducts: UseProductsReturn = (category = '') => {
+  const { normalizeFacetProductNames, normalizeProductName } = useProductNameNormalizer();
   const state = useState<UseProductsState>(`useProducts${category}`, () => ({
     data: {} as Facet,
     loading: false,
@@ -104,7 +105,7 @@ export const useProducts: UseProductsReturn = (category = '') => {
 
     if (data.value?.data) {
       data.value.data.pagination.perPageOptions = defaults.PER_PAGE_STEPS;
-      state.value.data = data.value.data;
+      state.value.data = normalizeFacetProductNames(data.value.data);
       handlePreviewProducts(state, $i18n.locale.value);
 
       const defaultData =
@@ -129,7 +130,7 @@ export const useProducts: UseProductsReturn = (category = '') => {
   const setCurrentProduct: SetCurrentProduct = async (product: Product) => {
     state.value.loading = true;
 
-    state.value.currentProduct = product;
+    state.value.currentProduct = normalizeProductName(product);
 
     state.value.loading = false;
   };

--- a/apps/web/app/composables/useSearch/useSearch.ts
+++ b/apps/web/app/composables/useSearch/useSearch.ts
@@ -11,6 +11,7 @@ import type { UseSearchReturn, UseSearchState, GetSearch } from '~/composables/u
  * ```
  */
 export const useSearch: UseSearchReturn = () => {
+  const { normalizeItemSearchResultProductNames } = useProductNameNormalizer();
   const state = useState<UseSearchState>('search', () => ({
     data: {} as ItemSearchResult,
     loading: false,
@@ -37,7 +38,7 @@ export const useSearch: UseSearchReturn = () => {
       const { data } = await useSdk().plentysystems.getSearch(params);
       state.value.productsPerPage = params.itemsPerPage || defaults.DEFAULT_ITEMS_PER_PAGE;
       if (data) data.pagination.perPageOptions = defaults.PER_PAGE_STEPS;
-      state.value.data = data ?? state.value.data;
+      state.value.data = normalizeItemSearchResultProductNames(data);
     } catch (error) {
       useHandleError(error as ApiError);
     } finally {

--- a/apps/web/app/composables/useWishlist/useWishlist.ts
+++ b/apps/web/app/composables/useWishlist/useWishlist.ts
@@ -26,6 +26,7 @@ import type {
  * ```
  */
 export const useWishlist: UseWishlistReturn = () => {
+  const { normalizeWishlistProductNames } = useProductNameNormalizer();
   const state = useState<UseWishlistState>('wishlist', () => ({
     data: [] as WishlistItem[],
     loading: false,
@@ -46,7 +47,7 @@ export const useWishlist: UseWishlistReturn = () => {
     return await useSdk()
       .plentysystems.getWishlist()
       .then(({ data }) => {
-        state.value.data = data ?? state.value.data;
+        state.value.data = normalizeWishlistProductNames(data ?? state.value.data);
         state.value.loading = false;
         return state.value.data;
       });

--- a/apps/web/app/utils/__tests__/product-name-normalizer.spec.ts
+++ b/apps/web/app/utils/__tests__/product-name-normalizer.spec.ts
@@ -1,0 +1,146 @@
+import type { Cart, Product, WishlistItem } from '@plentymarkets/shop-api';
+import {
+  getNormalizedProductName,
+  normalizeCartProductNames,
+  normalizeProductName,
+  normalizeWishlistProductNames,
+} from '../product-name-normalizer';
+
+const createProduct = (): Product =>
+  ({
+    texts: {
+      name1: 'Original Name',
+    },
+    variationProperties: [
+      {
+        name: 'Variation Texts',
+        properties: [
+          {
+            id: 10,
+            cast: 'text',
+            names: {
+              propertyId: 10,
+              name: 'Variation Title',
+            },
+            values: {
+              value: 'Normalized Name',
+            },
+          },
+        ],
+      },
+    ],
+  }) as Product;
+
+describe('product name normalizer', () => {
+  it('should return null when no property id is configured', () => {
+    expect(getNormalizedProductName(createProduct())).toBeNull();
+  });
+
+  it.each(['', '   ', '0', '-1', '1.5', '10abc', '1e1'])(
+    'should return null when the configured property id is malformed: %p',
+    (settingValue) => {
+      expect(getNormalizedProductName(createProduct(), settingValue)).toBeNull();
+    },
+  );
+
+  it('should accept a numeric configured property id without throwing', () => {
+    expect(getNormalizedProductName(createProduct(), 10 as never)).toBe('Normalized Name');
+  });
+
+  it('should extract a configured variation property as normalized product name', () => {
+    const product = {
+      texts: {
+        name1: 'Original Name',
+      },
+      variationProperties: [
+        {
+          name: 'Custom Group',
+          properties: [
+            {
+              id: 42,
+              cast: 'text',
+              names: {
+                propertyId: 42,
+                name: 'Custom Property',
+              },
+              values: {
+                value: 'Configured Name',
+              },
+            },
+          ],
+        },
+      ],
+    } as Product;
+
+    expect(getNormalizedProductName(product, '42')).toBe('Configured Name');
+  });
+
+  it('should return null when the configured property id does not exist', () => {
+    expect(getNormalizedProductName(createProduct(), '999')).toBeNull();
+  });
+
+  it('should return null when the configured property is not text', () => {
+    const product = {
+      texts: {
+        name1: 'Original Name',
+      },
+      variationProperties: [
+        {
+          name: 'Custom Group',
+          properties: [
+            {
+              id: 42,
+              cast: 'file',
+              names: {
+                propertyId: 42,
+                name: 'Custom Property',
+              },
+              values: {
+                value: 'Configured Name',
+              },
+            },
+          ],
+        },
+      ],
+    } as Product;
+
+    expect(getNormalizedProductName(product, '42')).toBeNull();
+  });
+
+  it('should keep the original product name when no valid replacement is resolved', () => {
+    const product = createProduct();
+
+    expect(normalizeProductName(product).texts?.name1).toBe('Original Name');
+    expect(normalizeProductName(createProduct(), '999').texts?.name1).toBe('Original Name');
+  });
+
+  it.each(['', '   ', '0', '-1', '1.5', '10abc', '1e1'])(
+    'should keep the original product name when the configured property id is malformed: %p',
+    (settingValue) => {
+      expect(normalizeProductName(createProduct(), settingValue).texts?.name1).toBe('Original Name');
+    },
+  );
+
+  it('should overwrite product texts.name1 with the normalized name', () => {
+    const product = createProduct();
+
+    expect(normalizeProductName(product, '10').texts?.name1).toBe('Normalized Name');
+  });
+
+  it('should normalize cart item variation names', () => {
+    const cart = {
+      items: [{ variation: createProduct() }],
+    } as Cart;
+    const normalizedCart = normalizeCartProductNames(cart, '10');
+    const firstItem = normalizedCart.items?.[0];
+
+    expect(firstItem).toBeDefined();
+    expect(firstItem?.variation?.texts?.name1).toBe('Normalized Name');
+  });
+
+  it('should normalize wishlist item variation names', () => {
+    const wishlistItems: WishlistItem[] = [createProduct() as WishlistItem];
+
+    expect(normalizeWishlistProductNames(wishlistItems, '10')[0]?.texts?.name1).toBe('Normalized Name');
+  });
+});

--- a/apps/web/app/utils/product-name-normalizer.ts
+++ b/apps/web/app/utils/product-name-normalizer.ts
@@ -1,0 +1,172 @@
+import type { Cart, Facet, ItemSearchResult, Product, WishlistItem } from '@plentymarkets/shop-api';
+
+type ProductNameSource = {
+  texts?: {
+    name1?: string;
+  };
+  variationProperties?: Array<{
+    name: string | null;
+    properties: Array<{
+      id?: number;
+      cast?: string;
+      names: {
+        propertyId?: number;
+        name: string | null;
+      };
+      values: {
+        value: string | null;
+      };
+    }>;
+  }>;
+};
+
+const isProductNameSource = (value: unknown): value is ProductNameSource => {
+  return typeof value === 'object' && value !== null;
+};
+
+const getVariationTitleSettingPropertyId = (settingValue: unknown = ''): number | null => {
+  if (typeof settingValue === 'number') {
+    return Number.isInteger(settingValue) && settingValue > 0 ? settingValue : null;
+  }
+
+  if (typeof settingValue !== 'string') {
+    return null;
+  }
+
+  const normalizedSettingValue = settingValue.trim();
+
+  if (!/^\d+$/.test(normalizedSettingValue)) {
+    return null;
+  }
+
+  const propertyId = Number(normalizedSettingValue);
+
+  return propertyId > 0 ? propertyId : null;
+};
+
+/**
+ * Returns the custom variation title used as the canonical storefront product name.
+ */
+export const getNormalizedProductName = (product?: unknown | null, settingValue = ''): string | null => {
+  if (!isProductNameSource(product)) {
+    return null;
+  }
+
+  const propertyId = getVariationTitleSettingPropertyId(settingValue);
+
+  if (!propertyId) {
+    return null;
+  }
+
+  const variationProperties = product.variationProperties ?? [];
+  const configuredVariationTitle = variationProperties
+    .flatMap((propertyGroup) => propertyGroup.properties ?? [])
+    .find((property) => property.names.propertyId === propertyId || property.id === propertyId);
+
+  if (!configuredVariationTitle || configuredVariationTitle.cast !== 'text') {
+    return null;
+  }
+
+  return configuredVariationTitle.values.value?.trim() || null;
+};
+
+/**
+ * Rewrites the product name in-place so existing product getters resolve the normalized name.
+ */
+export const normalizeProductName = <T>(product?: T | null, settingValue = ''): T => {
+  if (!product) {
+    return {} as T;
+  }
+
+  if (!isProductNameSource(product)) {
+    return product;
+  }
+
+  const normalizedName = getNormalizedProductName(product, settingValue);
+
+  if (!normalizedName) {
+    return product;
+  }
+
+  product.texts = {
+    ...(product.texts ?? {}),
+    name1: normalizedName,
+  };
+
+  return product;
+};
+
+/**
+ * Normalizes all product names in a product collection.
+ */
+export const normalizeProductCollection = (products?: Product[] | null, settingValue = ''): Product[] => {
+  if (!products?.length) {
+    return products ?? [];
+  }
+
+  products.forEach((product) => normalizeProductName(product, settingValue));
+
+  return products;
+};
+
+/**
+ * Normalizes product names in facet responses.
+ */
+export const normalizeFacetProductNames = (facet?: Facet | null, settingValue = ''): Facet => {
+  if (!facet) {
+    return {} as Facet;
+  }
+
+  if (facet.products) {
+    normalizeProductCollection(facet.products, settingValue);
+  }
+
+  return facet;
+};
+
+/**
+ * Normalizes product names in search responses.
+ */
+export const normalizeItemSearchResultProductNames = (result?: ItemSearchResult | null, settingValue = ''): ItemSearchResult => {
+  if (!result) {
+    return {} as ItemSearchResult;
+  }
+
+  if (result.products) {
+    normalizeProductCollection(result.products, settingValue);
+  }
+
+  return result;
+};
+
+/**
+ * Normalizes product names for cart item variations.
+ */
+export const normalizeCartProductNames = (cart?: Cart | null, settingValue = ''): Cart => {
+  if (!cart) {
+    return {} as Cart;
+  }
+
+  cart.items?.forEach((item) => normalizeProductName(item.variation, settingValue));
+
+  return cart;
+};
+
+/**
+ * Normalizes product names for wishlist item variations.
+ */
+export const normalizeWishlistProductNames = (wishlistItems?: WishlistItem[] | null, settingValue = ''): WishlistItem[] => {
+  if (!wishlistItems?.length) {
+    return wishlistItems ?? [];
+  }
+
+  wishlistItems.forEach((wishlistItem) => {
+    normalizeProductName(wishlistItem, settingValue);
+
+    if ('variation' in wishlistItem) {
+      normalizeProductName(wishlistItem.variation, settingValue);
+    }
+  });
+
+  return wishlistItems;
+};


### PR DESCRIPTION
Issue:
If an Item has no variations, the default title on the website is Item Texts/Name1 and is multilingual.
If an item has variations, then the default Title is [Item Name1]. [Variation Attribute].
Adding variation attributes at the end of the item's name may be ok for color/size type variations, but there are many other cases where we need to use an individual name for each variation.
In such a case, we cannot use the Variation/Basic Settings/Variation name field, as it is not multilingual.
We can create a text variation property that is multilingual and use it as the variation name on the website.

Solution
Instead of the default Variation Titles, we use a text variation property as our multilingual Variation Title
We create a new site setting to set the variation property ID to be used as the storefront item title. When set, the matching property value replaces the default Item name wherever the item name is used. In all other cases, if ID is empty/missing/non-integer/id does not exist, the default Item name is used. The rule applies to each variation. Even if we have set a property ID and a variation that does not have any text in this property, then the default Title is used.

Describe your changes
-- Create a new Site Setting, Item/Variation Title to enter the variation property ID as an integer value. If empty/missing/non-integer/id does not exist, the default Item name is used for each variation.
-- Create composer/useProductNameNormalizer as a wrapper so the setting lookup happens in one place
-- Create utils/product-name-normalizer that has the normalizer logic
-- We added the normalizer to various composable that use Item Titles.
useProduct.ts,
useProducts.ts,
useProductRecommended.ts,
useSearch.ts,
useCart.ts,
and useWishlist.ts