### PR TITLE
fix: adding a page allows a name with only numbers

### DIFF
--- a/apps/web/app/composables/useAddPage/__tests__/validation.spec.ts
+++ b/apps/web/app/composables/useAddPage/__tests__/validation.spec.ts
@@ -1,3 +1,5 @@
+import { pageNameSchema } from '../validation';
+
 describe('pageNameSchema', () => {
   it('should reject names consisting only of numbers', async () => {
     const result = await pageNameSchema.isValid('12345');

--- a/apps/web/app/composables/useAddPage/__tests__/validation.spec.ts
+++ b/apps/web/app/composables/useAddPage/__tests__/validation.spec.ts
@@ -1,0 +1,11 @@
+describe('pageNameSchema', () => {
+  it('should reject names consisting only of numbers', async () => {
+    const result = await pageNameSchema.isValid('12345');
+    expect(result).toBe(false);
+  });
+
+  it('should accept names with letters', async () => {
+    expect(await pageNameSchema.isValid('My Page')).toBe(true);
+    expect(await pageNameSchema.isValid('Page123')).toBe(true);
+  });
+});

--- a/apps/web/app/composables/useAddPage/__tests__/validation.spec.ts
+++ b/apps/web/app/composables/useAddPage/__tests__/validation.spec.ts
@@ -10,4 +10,14 @@ describe('pageNameSchema', () => {
     expect(await pageNameSchema.isValid('My Page')).toBe(true);
     expect(await pageNameSchema.isValid('Page123')).toBe(true);
   });
+
+  it('should reject numbers with spaces', async () => {
+    const result = await pageNameSchema.isValid(' 12345 ');
+    expect(result).toBe(false);
+  });
+
+  it('should reject empty names', async () => {
+    const result = await pageNameSchema.isValid('');
+    expect(result).toBe(false);
+  });
 });

--- a/apps/web/app/composables/useAddPage/index.ts
+++ b/apps/web/app/composables/useAddPage/index.ts
@@ -1,2 +1,1 @@
 export * from './useAddPage';
-export * from './validation';

--- a/apps/web/app/composables/useAddPage/index.ts
+++ b/apps/web/app/composables/useAddPage/index.ts
@@ -1,1 +1,2 @@
 export * from './useAddPage';
+export * from './validation';

--- a/apps/web/app/composables/useAddPage/useAddPage.ts
+++ b/apps/web/app/composables/useAddPage/useAddPage.ts
@@ -1,6 +1,7 @@
 import { useForm } from 'vee-validate';
 import { toTypedSchema } from '@vee-validate/yup';
-import { object, string } from 'yup';
+import { object } from 'yup';
+import { pageNameSchema } from './validation';
 import type { CategoryEntry, CategoryTreeItem, CategoryDetails, ApiError } from '@plentymarkets/shop-api';
 import { categoryEntryGetters } from '@plentymarkets/shop-api';
 
@@ -138,7 +139,7 @@ export const useAddPageModal = () => {
 
   const validationSchema = toTypedSchema(
     object({
-      pageName: string().required('Enter a page name').default(''),
+      pageName: pageNameSchema,
     }),
   );
 

--- a/apps/web/app/composables/useAddPage/validation.ts
+++ b/apps/web/app/composables/useAddPage/validation.ts
@@ -1,0 +1,6 @@
+import { string } from 'yup';
+
+export const pageNameSchema = string()
+  .required('Enter a page name')
+  .test('no-numbers-only', 'Page name cannot consist only of numbers', (value) => !/^\d+$/.test(value ?? ''))
+  .default('');

--- a/apps/web/app/composables/useAddPage/validation.ts
+++ b/apps/web/app/composables/useAddPage/validation.ts
@@ -2,5 +2,5 @@ import { string } from 'yup';
 
 export const pageNameSchema = string()
   .required('Enter a page name')
-  .test('no-numbers-only', 'Page name cannot consist only of numbers', (value) => !/^\d+$/.test(value ?? ''))
+  .test('no-numbers-only', 'Page name cannot consist only of numbers', (value) => !/^\d+$/.test(value.trim() ?? ''))
   .default('');


### PR DESCRIPTION
## Issue:

Closes: [AB#191951](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/191951)

## Describe your changes

- [What changed]
- [Notable implementation decisions]
- [Known limitations]

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
