### PR TITLE
chore: create github deployment via api

### DIFF
--- a/.github/workflows/release-new-app.yml
+++ b/.github/workflows/release-new-app.yml
@@ -10,17 +10,24 @@ on:
 jobs:
   create-archive:
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - name: Create GitHub Deployment
         id: deployment
+        # required_contexts is intentionally empty: releases are manually published,
+        # so CI status checks are not enforced here.
         run: |
           deployment_id=$(gh api repos/${{ github.repository }}/deployments \
             --method POST \
-            -f ref="${{ github.sha }}" \
-            -f environment="production" \
-            -f description="Release ${{ github.event.release.tag_name }}" \
-            -F auto_merge=false \
-            -F required_contexts='[]' \
+            --input - <<EOF
+          {
+            "ref": "${{ github.sha }}",
+            "environment": "production",
+            "description": "Release ${{ github.event.release.tag_name }}",
+            "auto_merge": false,
+            "required_contexts": []
+          }
+          EOF
             --jq '.id')
           echo "id=$deployment_id" >> $GITHUB_OUTPUT
           gh api repos/${{ github.repository }}/deployments/$deployment_id/statuses \
@@ -55,7 +62,11 @@ jobs:
       - name: Set Deployment Status
         if: always() && steps.deployment.outputs.id != ''
         run: |
-          state=$([[ "${{ job.status }}" == "success" ]] && echo "success" || echo "failure")
+          case "${{ job.status }}" in
+            success)   state="success" ;;
+            cancelled) state="inactive" ;;
+            *)         state="failure" ;;
+          esac
           gh api repos/${{ github.repository }}/deployments/${{ steps.deployment.outputs.id }}/statuses \
             --method POST \
             -f state="$state"

--- a/.github/workflows/release-new-app.yml
+++ b/.github/workflows/release-new-app.yml
@@ -10,8 +10,25 @@ on:
 jobs:
   create-archive:
     runs-on: ubuntu-latest
-    environment: production
     steps:
+      - name: Create GitHub Deployment
+        id: deployment
+        run: |
+          deployment_id=$(gh api repos/${{ github.repository }}/deployments \
+            --method POST \
+            -f ref="${{ github.sha }}" \
+            -f environment="production" \
+            -f description="Release ${{ github.event.release.tag_name }}" \
+            -F auto_merge=false \
+            -F required_contexts='[]' \
+            --jq '.id')
+          echo "id=$deployment_id" >> $GITHUB_OUTPUT
+          gh api repos/${{ github.repository }}/deployments/$deployment_id/statuses \
+            --method POST \
+            -f state="in_progress"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout Repository
         uses: actions/checkout@v6
         with:
@@ -34,3 +51,13 @@ jobs:
           url: "https://pwapublish.plentysystems.com/storeDefaultApplication"
           forms: '{ "token": "${{ secrets.SUPPLIER_TOKEN }}", "version": "${{ github.event.release.tag_name }}" }'
           fileForms: '{ "file": "pwa.tar.gz" }'
+
+      - name: Set Deployment Status
+        if: always() && steps.deployment.outputs.id != ''
+        run: |
+          state=$([[ "${{ job.status }}" == "success" ]] && echo "success" || echo "failure")
+          gh api repos/${{ github.repository }}/deployments/${{ steps.deployment.outputs.id }}/statuses \
+            --method POST \
+            -f state="$state"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Issue:

The `release-new-app` workflow doesn't create GitHub deployments despite having an environment set up. The hypothesis is that this is because the workflow is triggered from a release tag and not from a branch, so the trigger doesn't have a proper ref associated with it.

## Describe your changes

- Creates a GitHub deployment via the API.

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
