### PR TITLE
fix: rich text editor console warning

### DIFF
--- a/apps/web/app/components/editor/RichTextEditor/RichTextEditorForm.vue
+++ b/apps/web/app/components/editor/RichTextEditor/RichTextEditorForm.vue
@@ -8,7 +8,7 @@
       @update:model-value="editorMode = $event"
     />
 
-    <div v-if="editorMode === 'wysiwyg'" class="py-2">
+    <div v-if="editorMode === 'wysiwyg'" class="py-2" data-testid="rte-content">
       <EditorRichTextEditor
         ref="contentRichTextEditor"
         v-model:expanded="expandedToolbars"
@@ -16,7 +16,6 @@
         :min-height="232"
         :expandable="true"
         :text-align="textAlign"
-        data-testid="rte-content"
         @update:model-value="$emit('update:modelValue', $event)"
         @request-html-modal="handleRequestHtmlModal"
       />


### PR DESCRIPTION
## Issue:

When opening any block form that contains the rich text editor, a console warning is logged for each instance.

```
[Vue warn]: Extraneous non-props attributes (data-testid) were passed to component but could not be automatically inherited because component renders fragment or text or teleport root nodes. 
  at <EditorRichTextEditor ref="contentRichTextEditor" expanded=true onUpdate:expanded=fn  ... > 
  at <EditorRichTextEditorForm model-value="" block-uuid="6fad7cec-e37e-48f4-b6d4-d99a6d66ad7d" onUpdate:modelValue=fn > 
  at <SfAccordionItem modelValue=false onUpdate:modelValue=fn summary-class="w-full hover:bg-neutral-100 px-4 py-5 flex justify-between items-center select-none border-b"  ... > 
  at <UiAccordionItem modelValue=false onUpdate:modelValue=fn data-testid="fourth-column-section"  ... > 
  at <BlocksFooterForm key="Footer-6fad7cec-e37e-48f4-b6d4-d99a6d66ad7d" ref="childComponentRef" uuid="6fad7cec-e37e-48f4-b6d4-d99a6d66ad7d"  ... > 
  at <AsyncComponentWrapper key="Footer-6fad7cec-e37e-48f4-b6d4-d99a6d66ad7d" ref="childComponentRef" uuid="6fad7cec-e37e-48f4-b6d4-d99a6d66ad7d"  ... > 
  at <BlockEditView key=0 > 
  at <BaseTransition appear=true persisted=false mode=undefined  ... > 
  at <Transition name="drawer-right" appear="" class="flex-shrink-0 bg-white font-editor border-l border-gray-300 overflow-y-auto" > 
  at <SiteConfigurationDrawerBlocksConfigurationDrawer key=1 class="flex-shrink-0 bg-white font-editor border-l border-gray-300 overflow-y-auto" > 
  at <AsyncComponentWrapper key=1 class="flex-shrink-0 bg-white font-editor border-l border-gray-300 overflow-y-auto" > 
  at <App key=4 > 
  at <NuxtRoot>
```

This happens because `RichTextEditor.vue` has two root nodes, which turns it into a [fragment](https://v3-migration.vuejs.org/new/fragments). Fragments can't auto-inherit fallthrough attributes.

## Describe your changes

- Moves the offending attribute to the enclosing `div`

An alternative would've been to bind the attributes explicitly in the child component, but since we currently don't have any test cases covering this behaviour, moving the test ID seems more straightforward.

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
