### PR TITLE
fix: ignore blocksLists in service worker cache

### DIFF
--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -247,7 +247,7 @@ export default defineNuxtConfig({
     workbox: {
       navigateFallback: null,
       globPatterns: ['**/*.{js,json,css,html,ico,svg,png,webp,ico,woff,woff2,ttf,eit,otf}', '_nuxt-plenty/icons/*'],
-      globIgnores: ['manifest**.webmanifest'],
+      globIgnores: ['manifest**.webmanifest', '_nuxt-plenty/editor/blocksLists.json'],
       additionalManifestEntries: [
         {
           url: '/offline',


### PR DESCRIPTION
## Issue:

As a file in Nuxt's `public` directory, `blocksLists.json` has been included in the PWA's service worker. This means the asset is cached. On some occasions, however, this resulted in the blocks list not getting updated in time for the user to see new entries when adding a block.

## Describe your changes

- Adds `_nuxt-plenty/editor/blocksLists.json` to `pwa.workbox.globIgnores` in `nuxt.config.ts`

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
