### PR TITLE
fix: mobile view in preview mode

### DIFF
--- a/apps/web/app/app.vue
+++ b/apps/web/app/app.vue
@@ -43,12 +43,13 @@ import { categoryGetters } from '@plentymarkets/shop-api';
 
 const bodyClass = ref('');
 const route = useRoute();
+const viewport = useViewport();
 const { disableActions } = useEditor();
 const { siteConfigurationDrawerOpen, blocksConfigurationDrawerOpen, currentFont } = useSiteConfiguration();
 const { setStaticPageMeta } = useUrlPageMeta();
 const { isInEditorClient } = useEditorState();
 
-const clientPreview = computed(() => isInEditorClient.value);
+const clientPreview = computed(() => isInEditorClient.value && viewport.isGreaterOrEquals('lg'));
 
 const { getSetting: getFavicon } = useSiteSettings('favicon');
 const { getSetting: getOgTitle } = useSiteSettings('ogTitle');

--- a/apps/web/app/components/PageBlock/PageBlock.vue
+++ b/apps/web/app/components/PageBlock/PageBlock.vue
@@ -110,6 +110,7 @@ const props = withDefaults(defineProps<PageBlockProps>(), {
   readOnly: false,
 });
 
+const viewport = useViewport();
 const { isInEditorClient } = useEditorState();
 const { openDrawerWithView } = useSiteConfiguration();
 const attrs = useAttrs();
@@ -136,7 +137,7 @@ const shouldShowBottomAddInGrid = computed(() =>
     getBlockDepth,
   }),
 );
-const clientPreview = ref(false);
+const clientPreview = computed(() => isInEditorClient.value && viewport.isGreaterOrEquals('lg'));
 const buttonLabel = 'Insert a new block at this position.';
 
 const getBlockComponent = computed(() => {
@@ -192,7 +193,6 @@ const observeLazyLoadSection = (blockName: string) => {
 };
 
 onNuxtReady(() => {
-  clientPreview.value = isInEditorClient.value;
   if (shouldLazyLoad(props.block.name)) observeLazyLoadSection(props.block.name);
 });
 

--- a/apps/web/app/components/blocks/SortFilter/SortFilter.vue
+++ b/apps/web/app/components/blocks/SortFilter/SortFilter.vue
@@ -94,8 +94,9 @@ const showSortAndFilter = ref(false);
 const { isOpen, open, close } = useDisclosure();
 const { t } = useI18n({ useScope: 'global' });
 
+const viewport = useViewport();
 const { isInEditorClient } = useEditorState();
-const clientPreview = computed(() => isInEditorClient.value);
+const clientPreview = computed(() => isInEditorClient.value && viewport.isGreaterOrEquals('lg'));
 
 const showAllFiltersImmediately = computed(() => props.content?.showAllFiltersImmediately ?? true);
 const numberOfFiltersToShowInitially = computed(() => props.content?.numberOfFiltersToShowInitially ?? 0);


### PR DESCRIPTION
## Issue:

Closes: [AB#194204](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/194204)

## Describe your changes

- Adds a condition to only display editor elements on desktop
- Elements are hidden on tablet and mobile
- On smaller viewport, only the exit editor button indicates that the user is currently in the editor

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
