### PR TITLE
fix: z-index issue on category page mobile

### DIFF
--- a/apps/web/app/components/blocks/structure/MultiGrid/MultiGrid.vue
+++ b/apps/web/app/components/blocks/structure/MultiGrid/MultiGrid.vue
@@ -4,7 +4,7 @@
       v-for="(column, colIndex) in columns"
       :key="colIndex"
       :class="getColumnClasses(colIndex)"
-      class="group/col relative z-[1]"
+      class="group/col relative md:z-[1]"
       data-testid="multi-grid-column"
     >
       <div


### PR DESCRIPTION
## Issue:

Closes: [AB#194502](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/194502)

## Describe your changes

- [What changed]
 In MultiGrid.vue used the md:z-[1] instead of z-[1]
- [Notable implementation decisions]
- [Known limitations]

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
