### PR TITLE
Fix: hreflang locale links use the wrong slug for translated category pages

### DIFF
--- a/apps/web/app/composables/useUrlPageMeta/useUrlPageMeta.ts
+++ b/apps/web/app/composables/useUrlPageMeta/useUrlPageMeta.ts
@@ -49,6 +49,12 @@ const setPreviousAndNextLink = (productsCatalog: Facet, facetsFromUrl: FacetSear
   }
 };
 
+const getQuerySuffix = (fullPath: string) => {
+  const query = fullPath.split('?')[1]?.split('#')[0];
+
+  return query ? `?${query}` : '';
+};
+
 export const useUrlPageMeta: UseUrlPageMetaReturn = () => {
   const state = useState<UseUrlPageMetaState>(`useUrlPageMeta`, () => ({
     loading: false,
@@ -118,6 +124,7 @@ export const useUrlPageMeta: UseUrlPageMetaReturn = () => {
     const route = useRouter().currentRoute.value;
     const localePath = useLocalePath();
     const runtimeConfig = useRuntimeConfig();
+    const querySuffix = getQuerySuffix(route.fullPath);
 
     const canonicalLink =
       canonicalOverride && canonicalOverride.trim() !== ''
@@ -139,15 +146,17 @@ export const useUrlPageMeta: UseUrlPageMetaReturn = () => {
 
     if (productsCatalog.languageUrls) {
       Object.keys(productsCatalog.languageUrls).forEach((key) => {
+        const localizedPath =
+          key === `x-default`
+            ? localePath(productsCatalog.languageUrls[key] || '/', $i18n.defaultLocale)
+            : localePath(productsCatalog.languageUrls[key] || '/', key as Locale);
+
         useHead({
           link: [
             {
               rel: 'alternate',
               hreflang: key,
-              href:
-                key === `x-default`
-                  ? `${runtimeConfig.public.domain}${localePath(route.fullPath, $i18n.locale.value)}`
-                  : `${runtimeConfig.public.domain}${localePath(route.fullPath, key as Locale)}`,
+              href: `${runtimeConfig.public.domain}${localizedPath}${querySuffix}`,
             },
           ],
         });


### PR DESCRIPTION
## Issue:
The `<link rel="alternate" hreflang>` uses the wrong slug for translated category pages.
As a result, crawlers and search engines that rely on hreflang for language targeting are getting a lot of 404 error pages



On multilingual category pages, the hreflang alternate links in <head> point to the wrong URL for the unselected language. 

Example — visiting the German category page /bewaesserungssysteme/magnetventile/ produces:
```
<!-- Wrong — The German slug used for the English alternate -->
<link rel="alternate" hreflang="en" href="https://www.irritop.com**/en/bewaesserungssysteme/magnetventile/**">
<link rel="alternate" hreflang="de" href="https://www.irritop.com/bewaesserungssysteme/magnetventile/">
```

Expected — the English alternate should use the real English slug provided by the API:
```
<link rel="alternate" hreflang="en" href="https://www.irritop.com**/en/irrigation-systems/valves/**">
<link rel="alternate" hreflang="de" href="https://www.irritop.com/bewaesserungssysteme/magnetventile/">
```

The slug is taken from the current browser route instead of the backend-provided translated URL.
The localePath only adds/removes the locale prefix — it does not translate the path slug. The translated slug is already available in the API response under productsCatalog.languageUrls[locale] but was not being used.




## Describe your changes

The alternate-tag generation for category pages now uses the backend-provided translated paths instead of rebuilding URLs from route.fullPath. The fix applies localePath to each productsCatalog.languageUrls[locale], so the prefix still follows Nuxt i18n rules, but the slug itself comes from the backend response.

