### PR TITLE
fix: teleport link modal to body to display it in front of rte modal

### DIFF
--- a/apps/web/app/components/editor/RichTextEditor/RichTextEditorLinkModal.vue
+++ b/apps/web/app/components/editor/RichTextEditor/RichTextEditorLinkModal.vue
@@ -1,134 +1,136 @@
 <template>
-  <div
-    class="fixed inset-0 z-[600] flex items-center justify-center bg-black/40"
-    @mousedown.self="cancelAndRevert(props.close)"
-  >
-    <div class="bg-white rounded-xl shadow-2xl w-full max-w-md mx-4 overflow-visible">
-      <div class="flex items-center justify-between px-5 py-4 border-b border-gray-100">
-        <h2 class="text-sm font-semibold text-gray-800">{{ getEditorTranslation('insert-link') }}</h2>
-        <SfButton
-          type="button"
-          variant="tertiary"
-          square
-          size="sm"
-          class="text-gray-400 hover:text-gray-600"
-          @click="cancelAndRevert(props.close)"
-        >
-          <SfIconClose />
-        </SfButton>
-      </div>
-
-      <div class="flex border-b border-gray-100 px-5 gap-1 pt-2">
-        <button
-          v-for="tab in tabs"
-          :key="tab.value"
-          type="button"
-          class="px-3 py-2 text-sm font-medium rounded-t transition-colors relative"
-          :class="
-            activeTab === tab.value
-              ? 'text-blue-600 after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-blue-600 after:rounded-t'
-              : 'text-gray-500 hover:text-gray-700'
-          "
-          @click="activeTab = tab.value"
-        >
-          {{ tab.label }}
-        </button>
-      </div>
-
-      <div class="px-5 pt-4 pb-5 space-y-4">
-        <div>
-          <label class="block text-xs font-medium text-gray-600 mb-1.5">
-            {{ getEditorTranslation('text-label') }}
-          </label>
-          <input
-            v-model="linkText"
-            type="text"
-            placeholder="Link text"
-            class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
-          />
+  <Teleport to="body">
+    <div
+      class="fixed inset-0 z-[600] flex items-center justify-center bg-black/40"
+      @mousedown.self="cancelAndRevert(props.close)"
+    >
+      <div class="bg-white rounded-xl shadow-2xl w-full max-w-md mx-4 overflow-visible">
+        <div class="flex items-center justify-between px-5 py-4 border-b border-gray-100">
+          <h2 class="text-sm font-semibold text-gray-800">{{ getEditorTranslation('insert-link') }}</h2>
+          <SfButton
+            type="button"
+            variant="tertiary"
+            square
+            size="sm"
+            class="text-gray-400 hover:text-gray-600"
+            @click="cancelAndRevert(props.close)"
+          >
+            <SfIconClose />
+          </SfButton>
         </div>
-        <div v-if="activeTab === 'url'">
-          <div class="flex items-center justify-between mb-1.5">
-            <label class="block text-xs font-medium text-gray-600">
-              {{ getEditorTranslation('url-label') }}
-            </label>
 
-            <a
-              v-if="urlValue"
-              :href="urlValue"
-              aria-label="View link"
-              target="_blank"
-              rel="noopener noreferrer"
-              title="View link"
-              class="text-gray-500 hover:text-blue-600 transition-colors"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 -960 960 960"
-                class="w-4 h-4"
-                aria-hidden="true"
-                fill="currentColor"
+        <div class="flex border-b border-gray-100 px-5 gap-1 pt-2">
+          <button
+            v-for="tab in tabs"
+            :key="tab.value"
+            type="button"
+            class="px-3 py-2 text-sm font-medium rounded-t transition-colors relative"
+            :class="
+              activeTab === tab.value
+                ? 'text-blue-600 after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-blue-600 after:rounded-t'
+                : 'text-gray-500 hover:text-gray-700'
+            "
+            @click="activeTab = tab.value"
+          >
+            {{ tab.label }}
+          </button>
+        </div>
+
+        <div class="px-5 pt-4 pb-5 space-y-4">
+          <div>
+            <label class="block text-xs font-medium text-gray-600 mb-1.5">
+              {{ getEditorTranslation('text-label') }}
+            </label>
+            <input
+              v-model="linkText"
+              type="text"
+              placeholder="Link text"
+              class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+            />
+          </div>
+          <div v-if="activeTab === 'url'">
+            <div class="flex items-center justify-between mb-1.5">
+              <label class="block text-xs font-medium text-gray-600">
+                {{ getEditorTranslation('url-label') }}
+              </label>
+
+              <a
+                v-if="urlValue"
+                :href="urlValue"
+                aria-label="View link"
+                target="_blank"
+                rel="noopener noreferrer"
+                title="View link"
+                class="text-gray-500 hover:text-blue-600 transition-colors"
               >
-                <path
-                  d="M200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h280v80H200v560h560v-280h80v280q0 33-23.5 56.5T760-120H200Zm188-212-56-56 372-372H560v-80h280v280h-80v-144L388-332Z"
-                />
-              </svg>
-            </a>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 -960 960 960"
+                  class="w-4 h-4"
+                  aria-hidden="true"
+                  fill="currentColor"
+                >
+                  <path
+                    d="M200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h280v80H200v560h560v-280h80v280q0 33-23.5 56.5T760-120H200Zm188-212-56-56 372-372H560v-80h280v280h-80v-144L388-332Z"
+                  />
+                </svg>
+              </a>
+            </div>
+
+            <input
+              v-model="urlValue"
+              type="url"
+              placeholder="https://example.com"
+              class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+            />
+          </div>
+          <div v-else-if="activeTab === 'static'">
+            <label class="block text-xs font-medium text-gray-600 mb-1.5">
+              {{ getEditorTranslation('page-label') }}</label
+            >
+
+            <EditorPageSelect :model-value="staticPageValue" @update:model-value="staticPageValue = $event ?? ''" />
           </div>
 
-          <input
-            v-model="urlValue"
-            type="url"
-            placeholder="https://example.com"
-            class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
-          />
+          <div v-else-if="activeTab === 'category'">
+            <label class="block text-xs font-medium text-gray-600 mb-1.5">
+              {{ getEditorTranslation('category-label') }}
+            </label>
+
+            <EditorCategorySelect
+              :model-value="categoryValue"
+              :base-search-params="{}"
+              @update:model-value="categoryValue = $event ?? ''"
+              @update:selected-path="selectedCategoryPath = $event"
+            />
+          </div>
+
+          <div class="flex items-center justify-between pt-1">
+            <span class="text-sm text-gray-700"> {{ getEditorTranslation('open-window-toggle') }}</span>
+            <SfSwitch v-model="openInNewWindow" />
+          </div>
         </div>
-        <div v-else-if="activeTab === 'static'">
-          <label class="block text-xs font-medium text-gray-600 mb-1.5">
-            {{ getEditorTranslation('page-label') }}</label
+
+        <div class="flex items-center justify-end gap-2 px-5 py-4">
+          <SfButton type="button" variant="secondary" @click="cancelAndRevert(props.close)">
+            {{ getEditorTranslation('cancel-button') }}
+          </SfButton>
+
+          <SfButton
+            type="button"
+            :disabled="!canSubmit"
+            :aria-disabled="!canSubmit"
+            :class="{
+              'pointer-events-none opacity-40 cursor-not-allowed': !canSubmit,
+            }"
+            @click="canSubmit && handleSubmit(props.close)"
           >
-
-          <EditorPageSelect :model-value="staticPageValue" @update:model-value="staticPageValue = $event ?? ''" />
+            {{ getEditorTranslation('add-link-button') }}
+          </SfButton>
         </div>
-
-        <div v-else-if="activeTab === 'category'">
-          <label class="block text-xs font-medium text-gray-600 mb-1.5">
-            {{ getEditorTranslation('category-label') }}
-          </label>
-
-          <EditorCategorySelect
-            :model-value="categoryValue"
-            :base-search-params="{}"
-            @update:model-value="categoryValue = $event ?? ''"
-            @update:selected-path="selectedCategoryPath = $event"
-          />
-        </div>
-
-        <div class="flex items-center justify-between pt-1">
-          <span class="text-sm text-gray-700"> {{ getEditorTranslation('open-window-toggle') }}</span>
-          <SfSwitch v-model="openInNewWindow" />
-        </div>
-      </div>
-
-      <div class="flex items-center justify-end gap-2 px-5 py-4">
-        <SfButton type="button" variant="secondary" @click="cancelAndRevert(props.close)">
-          {{ getEditorTranslation('cancel-button') }}
-        </SfButton>
-
-        <SfButton
-          type="button"
-          :disabled="!canSubmit"
-          :aria-disabled="!canSubmit"
-          :class="{
-            'pointer-events-none opacity-40 cursor-not-allowed': !canSubmit,
-          }"
-          @click="canSubmit && handleSubmit(props.close)"
-        >
-          {{ getEditorTranslation('add-link-button') }}
-        </SfButton>
       </div>
     </div>
-  </div>
+  </Teleport>
 </template>
 <script setup lang="ts">
 import type { Editor } from '@tiptap/core';


### PR DESCRIPTION
## Issue:

When using the RTE's overlay mode and trying to insert a link, the link modal is hidden behind the RTE input. This happens because the link modal inherits the `z-index` from `RichTextEditor.vue` instead of applying its own.

## Describe your changes

- Wraps `RichTextEditorLinkModal` in a Teleport to extract it from the inheritance chain and apply its own `z-index`

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
