### PR TITLE
fix: hide recommended products block if no data

### DIFF
--- a/apps/web/app/components/EditableBlocks/EditableBlocks.vue
+++ b/apps/web/app/components/EditableBlocks/EditableBlocks.vue
@@ -138,7 +138,7 @@ const {
   siteConfigurationDrawerView: siteConfigurationDrawerViewRef,
 } = useSiteConfiguration();
 const { drawerOpen: localizationDrawerOpen } = useEditorLocalizationKeys();
-const { shouldShowBlock, clearRegistry } = useBlocksVisibility();
+const { shouldShowBlock, clearRegistry, isHydrationComplete } = useBlocksVisibility();
 
 const drawerOpen = computed<boolean>(() => siteConfigurationDrawerOpenRef.value);
 const drawerView = computed<string | null>(() => siteConfigurationDrawerViewRef.value);
@@ -150,6 +150,10 @@ const enabledActions = computed(
 useEditorUnsavedChangesGuard({
   enabled: !props.readOnly,
   onConfirmLeave: () => closeSiteConfigurationDrawer(),
+});
+
+onMounted(() => {
+  isHydrationComplete.value = true;
 });
 
 onBeforeUnmount(() => {

--- a/apps/web/app/components/blocks/ProductRecommendedProducts/ProductRecommendedProducts.vue
+++ b/apps/web/app/components/blocks/ProductRecommendedProducts/ProductRecommendedProducts.vue
@@ -31,6 +31,7 @@ const categoryId = productGetters.getCategoryIds(currentProduct.value)[0] ?? '';
 const shouldRenderAfterUpdate = ref(false);
 
 const { data: recommendedProducts, fetchProductRecommended } = useProductRecommended(props.meta.uuid);
+const { registerBlockVisibility } = useBlocksVisibility();
 
 const shouldShowSlider = computed(
   () =>
@@ -52,9 +53,10 @@ const contentSource = computed(() => ({
 
 watch(
   shouldFetch,
-  (visible) => {
+  async (visible) => {
     if (visible) {
-      fetchProductRecommended(contentSource.value);
+      const products = await fetchProductRecommended(contentSource.value);
+      registerBlockVisibility(props.meta.uuid, (products?.length ?? 0) > 0);
       shouldRenderAfterUpdate.value = true;
     }
   },
@@ -69,13 +71,14 @@ watch(
     () => props.content.source?.crossSellingRelation,
     () => locale.value,
   ],
-  () => {
+  async () => {
     if (
       shouldFetch.value &&
       ((props.content.source?.itemId && props.content.source?.type === 'cross_selling') ||
         (props.content.source?.categoryId && props.content.source?.type === 'category'))
     ) {
-      fetchProductRecommended(contentSource.value);
+      const products = await fetchProductRecommended(contentSource.value);
+      registerBlockVisibility(props.meta.uuid, (products?.length ?? 0) > 0);
     }
     shouldRenderAfterUpdate.value = true;
   },


### PR DESCRIPTION
## Issue:

Closes #2603 

## Describe your changes

- Adds visibility control to recommended products block based on whether or not products are available

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
