### PR TITLE
docs: add guide for controlling block visibility

### DIFF
--- a/docs/guide/editor/blocks-visibility.md
+++ b/docs/guide/editor/blocks-visibility.md
@@ -24,7 +24,7 @@ Use this approach when your block fetches or derives data at runtime and should 
 
 4. Add `{ immediate: true }` to the watch options so the block registers its state on the initial render, not only when the value changes later.
 
-The following example is for a block placed on an item category page. If your block lives on a different page type, substitute `text` with whatever ref holds your block's runtime data.
+The following example is for a block placed on a product page. If your block lives on a different page type, substitute `text` with whatever ref holds your block's runtime data.
 
 ```vue
 <script setup lang="ts">
@@ -51,7 +51,7 @@ watch(
 </script>
 ```
 
-To verify the implementation, place the block on an item category page. Navigate to a page where the backend returns a non-empty value — the block renders normally. Then navigate to a page where the value is empty or absent — the block is suppressed and no empty shell appears in the storefront.
+To verify the implementation, place the block on a product page. Navigate to a page where the backend returns a non-empty value — the block renders normally. Then navigate to a page where the value is empty or absent — the block is suppressed and no empty shell appears in the storefront.
 
 ::: info
 Do not unregister manually in `onBeforeUnmount`. The registry is cleared automatically when the page unmounts.
@@ -63,5 +63,5 @@ In editor mode, all blocks are always shown regardless of the registry. This pre
 
 ## See also
 
-- [Blocks rendering](/guide/editor/blocks-rendering) — How block visibility is evaluated during the render cycle
-- [Blocks architecture](/guide/editor/blocks-architecture) — Overview of the blocks data flow
+- [Blocks rendering](/guide/editor/blocks-rendering.md) — How block visibility is evaluated during the render cycle
+- [Blocks architecture](/guide/editor/blocks-architecture.md) — Overview of the blocks data flow

--- a/docs/guide/editor/blocks-visibility.md
+++ b/docs/guide/editor/blocks-visibility.md
@@ -1,0 +1,67 @@
+# How to control block visibility based on runtime data
+
+## Overview
+
+This guide explains how to hide a block when it has no meaningful runtime data to display — for example, when a product has no description text, or when a recommendations query returns an empty list.
+
+Use this approach when your block fetches or derives data at runtime and should not render an empty shell when that data is absent. Do not use it for purely static blocks; the default static-content check already handles those.
+
+::: info Theme developers only
+`useBlocksVisibility` is only available inside `apps/web/`. It is not available in Nuxt modules.
+:::
+
+## Register block visibility
+
+1. Obtain a computed ref for the data your block depends on.
+
+2. Destructure `registerBlockVisibility` from `useBlocksVisibility`.
+
+3. Watch the computed ref and call `registerBlockVisibility` on every change, passing `props.meta.uuid` as the first argument and a boolean indicating whether there is content to display as the second.
+
+   ::: tip
+   `props.meta.uuid` is a unique identifier provided automatically to every block component by the block framework.
+   :::
+
+4. Add `{ immediate: true }` to the watch options so the block registers its state on the initial render, not only when the value changes later.
+
+The following example is for a block placed on an item category page. If your block lives on a different page type, substitute `text` with whatever ref holds your block's runtime data.
+
+```vue
+<script setup lang="ts">
+import { productGetters } from '@plentymarkets/shop-api';
+import type { MyBlockProps } from './types';
+
+const props = defineProps<MyBlockProps>();
+
+// Step 1: computed ref for the block's runtime data
+const { currentProduct } = useProducts();
+const text = computed(() => productGetters.getDescription(currentProduct.value));
+
+// Step 2: destructure from the composable
+const { registerBlockVisibility } = useBlocksVisibility();
+
+// Steps 3 & 4: watch with immediate:true to register on first render and on every change
+watch(
+  text,
+  (value) => {
+    registerBlockVisibility(props.meta.uuid, !!value); // [!code highlight]
+  },
+  { immediate: true },
+);
+</script>
+```
+
+To verify the implementation, place the block on an item category page. Navigate to a page where the backend returns a non-empty value — the block renders normally. Then navigate to a page where the value is empty or absent — the block is suppressed and no empty shell appears in the storefront.
+
+::: info
+Do not unregister manually in `onBeforeUnmount`. The registry is cleared automatically when the page unmounts.
+:::
+
+::: info
+In editor mode, all blocks are always shown regardless of the registry. This prevents blocks from appearing to disappear while a merchant is configuring the page.
+:::
+
+## See also
+
+- [Blocks rendering](/guide/editor/blocks-rendering) — How block visibility is evaluated during the render cycle
+- [Blocks architecture](/guide/editor/blocks-architecture) — Overview of the blocks data flow

--- a/docs/guide/editor/sidebar.json
+++ b/docs/guide/editor/sidebar.json
@@ -12,6 +12,10 @@
         "link": "/guide/editor/site-settings.md"
       },
       {
+        "text": "Control block visibility",
+        "link": "/guide/editor/blocks-visibility.md"
+      },
+      {
         "text": "Migrate site settings",
         "link": "/guide/editor/site-settings-migration.md"
       }


### PR DESCRIPTION
## Issue:

Follow-up to #2653 

## Describe your changes

- Adds a guide for dynamically displaying blocks based on runtime data

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
