### PR TITLE
ci: add lint rule for SfButton and SfLink

### DIFF
--- a/apps/web/app/components/editor/RichTextEditor/RichTextEditorLinkModal.vue
+++ b/apps/web/app/components/editor/RichTextEditor/RichTextEditorLinkModal.vue
@@ -7,7 +7,7 @@
       <div class="bg-white rounded-xl shadow-2xl w-full max-w-md mx-4 overflow-visible">
         <div class="flex items-center justify-between px-5 py-4 border-b border-gray-100">
           <h2 class="text-sm font-semibold text-gray-800">{{ getEditorTranslation('insert-link') }}</h2>
-          <SfButton
+          <UiButton
             type="button"
             variant="tertiary"
             square
@@ -16,7 +16,7 @@
             @click="cancelAndRevert(props.close)"
           >
             <SfIconClose />
-          </SfButton>
+          </UiButton>
         </div>
 
         <div class="flex border-b border-gray-100 px-5 gap-1 pt-2">
@@ -112,11 +112,11 @@
         </div>
 
         <div class="flex items-center justify-end gap-2 px-5 py-4">
-          <SfButton type="button" variant="secondary" @click="cancelAndRevert(props.close)">
+          <UiButton type="button" variant="secondary" @click="cancelAndRevert(props.close)">
             {{ getEditorTranslation('cancel-button') }}
-          </SfButton>
+          </UiButton>
 
-          <SfButton
+          <UiButton
             type="button"
             :disabled="!canSubmit"
             :aria-disabled="!canSubmit"
@@ -126,7 +126,7 @@
             @click="canSubmit && handleSubmit(props.close)"
           >
             {{ getEditorTranslation('add-link-button') }}
-          </SfButton>
+          </UiButton>
         </div>
       </div>
     </div>
@@ -134,7 +134,7 @@
 </template>
 <script setup lang="ts">
 import type { Editor } from '@tiptap/core';
-import { SfButton, SfIconClose, SfSwitch } from '@storefront-ui/vue';
+import { SfIconClose, SfSwitch } from '@storefront-ui/vue';
 
 const props = defineProps<{
   editor: Editor | null | undefined;

--- a/apps/web/app/components/ui/PageSearch/PageSearch.vue
+++ b/apps/web/app/components/ui/PageSearch/PageSearch.vue
@@ -34,10 +34,10 @@
       </Multiselect>
     </div>
     <div class="px-1 mt-5">
-      <SfButton class="w-full" @click="openPages">
+      <UiButton class="w-full" @click="openPages">
         <SfIconMenu />
         Manage pages
-      </SfButton>
+      </UiButton>
     </div>
   </div>
 </template>
@@ -47,7 +47,7 @@ import { flattenPages } from '~/utils/pages';
 import Multiselect from 'vue-multiselect';
 import 'vue-multiselect/dist/vue-multiselect.min.css';
 
-import { SfIconHome, SfIconMenu, SfButton } from '@storefront-ui/vue';
+import { SfIconHome, SfIconMenu } from '@storefront-ui/vue';
 
 const { openDrawerWithView } = useSiteConfiguration();
 const emit = defineEmits(['pageSelected', 'close']);

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -66,6 +66,18 @@ export default withNuxt(
             message: 'Use Nuxt auto-imports instead of importing from vue directly.',
             allowTypeImports: true
           }
+        ],
+        paths: [
+          {
+            name: '@storefront-ui/vue',
+            importNames: ['SfButton'],
+            message: `SfButton doesn't conform to the app's design system. Use UiButton instead.`
+          },
+          {
+            name: '@storefront-ui/vue',
+            importNames: ['SfLink'],
+            message: `SfLink doesn't conform to the app's design system. Use UiLink instead.`
+          }
         ]
       }],
       '@typescript-eslint/no-unused-expressions': ['error', { allowTernary: true }],


### PR DESCRIPTION
## Issue:

Due to some design constraints, we have to use our own button and link implementations instead of using `SfButton` and `SfLink`. Without enforcement policies, this is easy to miss, though.

We actually had the rule for `SfButton` before, but it wasn't migrated properly in #876 

## Describe your changes

- Adds ESLint rules to disallowing importing `SfButton` and `SfLink`. This is generally sufficient to restrict usage.
- Updates components that use `SfButton`
- No components currently use `SfLink`, so no updates required

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
