### PR TITLE
fix: z-index of SiteConfigurationDrawer

### DIFF
--- a/apps/web/app/components/LocalizationView/LocalizationView.vue
+++ b/apps/web/app/components/LocalizationView/LocalizationView.vue
@@ -33,7 +33,9 @@
       </EditorFormPanel>
     </div>
   </div>
-  <EditorLocalizationDrawer v-if="keys.length > 0 && drawerOpen" />
+  <Teleport to="body">
+    <EditorLocalizationDrawer v-if="keys.length > 0 && drawerOpen" />
+  </Teleport>
 </template>
 
 <script setup lang="ts">

--- a/apps/web/app/components/SettingsToolbar/SettingsToolbar.vue
+++ b/apps/web/app/components/SettingsToolbar/SettingsToolbar.vue
@@ -1,6 +1,6 @@
 <template>
   <aside
-    class="h-[calc(100vh-50px)] bg-white z-[1] @md:z-[10] @lg:z-[150] mb-3 w-[54px] min-w-[54px] border-r"
+    class="h-[calc(100vh-50px)] bg-white z-[1] @md:z-[10] @lg:z-[150] mb-3 w-toolbar min-w-toolbar border-r"
     data-testid="edit-mode-side-toolbar"
   >
     <div class="relative flex flex-col px-1 py-1">

--- a/apps/web/app/components/SiteConfigurationDrawer/SiteConfigurationDrawer.vue
+++ b/apps/web/app/components/SiteConfigurationDrawer/SiteConfigurationDrawer.vue
@@ -1,7 +1,7 @@
 <template>
   <Transition name="drawer-left" appear>
     <div
-      class="flex-shrink-0 w-1/4 min-w-[250px] max-w-[300px] bg-neutral-50 border-0 border-gray-300 z-[51] relative h-full"
+      class="flex-shrink-0 w-1/4 min-w-[250px] max-w-[300px] bg-neutral-50 border-0 border-gray-300 z-[15] relative h-full"
     >
       <Transition v-if="siteConfigurationDrawerView" :name="transitionName" mode="out-in" appear>
         <div :key="siteConfigurationDrawerView" class="h-full">

--- a/apps/web/app/components/editor/Localization/EditorLocalizationDrawer.vue
+++ b/apps/web/app/components/editor/Localization/EditorLocalizationDrawer.vue
@@ -1,7 +1,7 @@
 <template>
   <SfDrawer
     v-model="open"
-    class="bg-white border-0 shadow-[inset_0px_0px_20px_-20px_#111] category-drawer !absolute ml-[100%] w-[calc(100vw-54px-100%)] flex flex-col overflow-hidden z-[20]"
+    class="bg-white border-0 shadow-[inset_0px_0px_20px_-20px_#111] category-drawer !fixed top-0 h-full flex flex-col overflow-hidden z-[60] [--toolbar-w:theme(spacing.toolbar)] [--panel-w:clamp(250px,25vw,300px)] left-[calc(var(--toolbar-w)+var(--panel-w))] w-[calc(100vw-var(--toolbar-w)-var(--panel-w))]"
     :placement="'left'"
     :disable-click-away="true"
   >

--- a/apps/web/app/components/ui/Toolbar/ToolbarDeviceToggle.vue
+++ b/apps/web/app/components/ui/Toolbar/ToolbarDeviceToggle.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex items-center rounded-md border border-gray-200 overflow-hidden">
-    <SfTooltip label="Mobile (375px)" placement="bottom" :show-arrow="true">
+    <SfTooltip label="Mobile (375px)" placement="right" :show-arrow="true">
       <button
         data-testid="device-toggle-mobile"
         type="button"
@@ -16,7 +16,7 @@
         </SfIconBase>
       </button>
     </SfTooltip>
-    <SfTooltip label="Tablet (768px)" placement="bottom" :show-arrow="true">
+    <SfTooltip label="Tablet (768px)" placement="right" :show-arrow="true">
       <button
         data-testid="device-toggle-tablet"
         type="button"
@@ -32,7 +32,7 @@
         </SfIconBase>
       </button>
     </SfTooltip>
-    <SfTooltip label="Desktop" placement="bottom" :show-arrow="true">
+    <SfTooltip label="Desktop" placement="right" :show-arrow="true">
       <button
         data-testid="device-toggle-desktop"
         type="button"

--- a/apps/web/app/configuration/tailwind.config.ts
+++ b/apps/web/app/configuration/tailwind.config.ts
@@ -190,6 +190,7 @@ export default {
         m: '2.5rem',
         l: '3.125rem',
         xl: '3.75rem',
+        toolbar: '54px',
       },
     },
   },


### PR DESCRIPTION
## Issue:

Follow-up to #2670 

The change introduced `z-index` issues in other parts of the editor.

## Describe your changes

- Reverts z-index change on `SiteConfigurationDrawer`
- Fixes original issue in `EditorLocalizationDrawer` with Vue Teleport
- Fixes device toggle labels by changing their placement
- Extracts magic value to Tailwind config for maintainability

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
