### PR TITLE
docs: fix broken links and add CI check

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,6 +17,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  fitness-docs:
+    if: github.repository == 'plentymarkets/plentyshop-pwa'
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node
+        uses: ./.github/actions/setup
+      - name: Build with VitePress
+        run: |
+          npm run docs:build
+          touch ${{ github.workspace }}/docs/.vitepress/dist/.nojekyll
+      - name: Install & Run htmltest
+        run: |
+          cd docs/.vitepress
+          curl https://htmltest.wjdp.uk | bash
+          bin/htmltest
   fitness-compliance:
     runs-on: ubuntu-slim
     timeout-minutes: 5

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ apps/web/coverage/*
 packages/shop-cli/coverage/*
 !packages/shop-cli/coverage/coverage-summary.json
 !packages/shop-cli/coverage/coverage-final.json
+/docs/.vitepress/tmp/.htmltest
 
 # misc
 .DS_Store

--- a/docs/.vitepress/.htmltest.yml
+++ b/docs/.vitepress/.htmltest.yml
@@ -1,0 +1,6 @@
+DirectoryPath: "./dist/"
+# Internal links are checked by Vitepress build
+CheckInternal: false
+IgnoreURLs:
+  - http://localhost:3000/
+  - https://help.plentyone.com/

--- a/docs/.vitepress/.htmltest.yml
+++ b/docs/.vitepress/.htmltest.yml
@@ -4,3 +4,7 @@ CheckInternal: false
 IgnoreURLs:
   - http://localhost:3000/
   - https://help.plentyone.com/
+  - https://www.linkedin.com/company/plentyone-ecommerce/
+  - https://www.facebook.com/plentyonecommerce/
+  - https://www.instagram.com/plentyone_ecommerce/
+  - https://www.youtube.com/@PlentyONE_ecommerce

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -14,7 +14,11 @@ export default withMermaid({
   description:
     "Documentation for PlentyONE Shop, built with VueJS, Nuxt 3 and Alokai.",
   cleanUrls: true,
-  ignoreDeadLinks: true,
+  ignoreDeadLinks: [
+    /^https?:\/\/localhost/,
+    // ignore links to auto-generated API reference
+    /\/reference\//,
+  ],
   lastUpdated: true,
   srcExclude: [
     '**/README.md',

--- a/docs/guide/editor/blocks-architecture.md
+++ b/docs/guide/editor/blocks-architecture.md
@@ -61,11 +61,11 @@ When the two diverge, the editor shows an unsaved-changes indicator.
 When the merchant saves, `doSaveBlocksWithGlobalBlocks()` sends the serialised block tree back to the backend.
 The response is re-assembled and both `data` and `cleanData` are updated, resetting the dirty state.
 
-For details on how blocks are rendered, see [Blocks rendering](/guide/concept/blocks-rendering.md).
+For details on how blocks are rendered, see [Blocks rendering](/guide/editor/blocks-rendering.md).
 
-For details on how block data is persisted, see [Blocks saving](/guide/concept/blocks-saving.md).
+For details on how block data is persisted, see [Blocks saving](/guide/editor/blocks-saving.md).
 
-For the distinction between global and non-global blocks, see [Global blocks vs. non-global blocks](/guide/concept/blocks-global-vs-non-global.md).
+For the distinction between global and non-global blocks, see [Global blocks vs. non-global blocks](/guide/editor/blocks-global-vs-non-global.md).
 
 ## Blockified vs. non-blockified pages
 
@@ -92,7 +92,7 @@ Pages like checkout, my account, and legal pages do not use blocks.
 They are rendered with traditional Vue components and have no editor overlay.
 The blocks plugin detects that these pages are not blockified and skips the data fetch.
 
-For the distinction between structure and content blocks, see [Structure vs. content form](/guide/concept/blocks-structure-vs-content.md).
+For the distinction between structure and content blocks, see [Structure vs. content form](/guide/editor/blocks-structure-vs-content.md).
 
 ## Use cases
 
@@ -117,14 +117,14 @@ Because content categories are blockified, they can use the full blocks editor t
 
 How-to guides
 
-1. [Site settings](/guide/how-to/editor/site-settings.md) — How to add custom settings to the editor
-2. [Editor overview](/guide/how-to/editor/index.md) — Overview of all editor-related guides
+1. [Site settings](/guide/editor/site-settings.md) — How to add custom settings to the editor
+2. [Editor overview](/guide/editor/index.md) — Overview of all editor-related guides
 
 Linked concepts
 
-1. [Blocks rendering](/guide/concept/blocks-rendering.md) — How blocks are rendered on the frontend
-2. [Blocks saving](/guide/concept/blocks-saving.md) — How block data is persisted
-3. [Global blocks vs. non-global blocks](/guide/concept/blocks-global-vs-non-global.md) — The distinction between global and page-specific blocks
-4. [Structure vs. content form](/guide/concept/blocks-structure-vs-content.md) — The two block types and how they compose
-5. [Data flow](https://docs.vuestorefront.io/general/basics/data-flow) — General Alokai data flow concept
-6. [Composable-centric data fetching](/guide/concept/composable-centric-data-fetching.md) — How composables manage data in plentyshop PWA
+1. [Blocks rendering](/guide/editor/blocks-rendering.md) — How blocks are rendered on the frontend
+2. [Blocks saving](/guide/editor/blocks-saving.md) — How block data is persisted
+3. [Global blocks vs. non-global blocks](/guide/editor/blocks-global-vs-non-global.md) — The distinction between global and page-specific blocks
+4. [Structure vs. content form](/guide/editor/blocks-structure-vs-content.md) — The two block types and how they compose
+5. [Data flow](https://docs.vuestorefront.io/general/basics/data-flow) — General Alokai data flow editor
+6. [Composable-centric data fetching](/guide/themes/composable-centric-data-fetching.md) — How composables manage data in plentyshop PWA

--- a/docs/guide/editor/blocks-architecture.md
+++ b/docs/guide/editor/blocks-architecture.md
@@ -126,5 +126,5 @@ Linked concepts
 2. [Blocks saving](/guide/editor/blocks-saving.md) — How block data is persisted
 3. [Global blocks vs. non-global blocks](/guide/editor/blocks-global-vs-non-global.md) — The distinction between global and page-specific blocks
 4. [Structure vs. content form](/guide/editor/blocks-structure-vs-content.md) — The two block types and how they compose
-5. [Data flow](https://docs.vuestorefront.io/general/basics/data-flow) — General Alokai data flow editor
+5. [Data flow](https://docs.vuestorefront.io/general/basics/data-flow) — General Alokai data flow concept
 6. [Composable-centric data fetching](/guide/themes/composable-centric-data-fetching.md) — How composables manage data in plentyshop PWA

--- a/docs/guide/editor/blocks-global-vs-non-global.md
+++ b/docs/guide/editor/blocks-global-vs-non-global.md
@@ -40,6 +40,6 @@ By restricting editing to the homepage and propagating changes globally, the sys
 
 Linked concepts
 
-1. [Blocks architecture](/guide/concept/blocks-architecture.md) — Overview of the blocks system
-2. [Blocks saving](/guide/concept/blocks-saving.md) — How global and page blocks are saved together
-3. [Structure vs. content form](/guide/concept/blocks-structure-vs-content.md) — Block type system used by global blocks
+1. [Blocks architecture](/guide/editor/blocks-architecture.md) — Overview of the blocks system
+2. [Blocks saving](/guide/editor/blocks-saving.md) — How global and page blocks are saved together
+3. [Structure vs. content form](/guide/editor/blocks-structure-vs-content.md) — Block type system used by global blocks

--- a/docs/guide/editor/blocks-rendering.md
+++ b/docs/guide/editor/blocks-rendering.md
@@ -40,5 +40,5 @@ This creates a seamless transition where the old content remains visible during 
 
 Linked concepts
 
-1. [Blocks architecture](/guide/concept/blocks-architecture.md) — Overview of the blocks system
-2. [Structure vs. content form](/guide/concept/blocks-structure-vs-content.md) — How structure and content blocks compose
+1. [Blocks architecture](/guide/editor/blocks-architecture.md) — Overview of the blocks system
+2. [Structure vs. content form](/guide/editor/blocks-structure-vs-content.md) — How structure and content blocks compose

--- a/docs/guide/editor/blocks-saving.md
+++ b/docs/guide/editor/blocks-saving.md
@@ -18,5 +18,5 @@ Global blocks saved on the homepage propagate to all pages, since every page rea
 
 Linked concepts
 
-1. [Blocks architecture](/guide/concept/blocks-architecture.md) — Overview of the blocks system and data flow
-2. [Global blocks vs. non-global blocks](/guide/concept/blocks-global-vs-non-global.md) — How global block propagation works
+1. [Blocks architecture](/guide/editor/blocks-architecture.md) — Overview of the blocks system and data flow
+2. [Global blocks vs. non-global blocks](/guide/editor/blocks-global-vs-non-global.md) — How global block propagation works

--- a/docs/guide/editor/blocks-structure-vs-content.md
+++ b/docs/guide/editor/blocks-structure-vs-content.md
@@ -55,5 +55,5 @@ The `EditableBlocks` and `PageBlock` components traverse this tree recursively, 
 
 Linked concepts
 
-1. [Blocks architecture](/guide/concept/blocks-architecture.md) — Overview of the blocks system
-2. [Blocks rendering](/guide/concept/blocks-rendering.md) — How the recursive rendering works
+1. [Blocks architecture](/guide/editor/blocks-architecture.md) — Overview of the blocks system
+2. [Blocks rendering](/guide/editor/blocks-rendering.md) — How the recursive rendering works

--- a/docs/guide/introduction/quickstart.md
+++ b/docs/guide/introduction/quickstart.md
@@ -26,7 +26,7 @@ We recommend working with a fork of the [shop repository](https://github.com/ple
 
 ::: warning :warning: Repository visibility
 GitHub forks are always publicly visible.
-If you want to maintain a private repository that's still connected to the main project, refer to our [guide on update strategies](../how-to/project-update-strategies.md).
+If you want to maintain a private repository that's still connected to the main project, refer to our [guide on update strategies](/guide/themes/project-update-strategies.md).
 :::
 
 ### GitHub PAT
@@ -179,6 +179,6 @@ For the go-live option to become available, the shop has to run in preview mode.
 Once you have your shop running, you can begin customising it.
 Here are a few places to start:
 
-- **Theme customization**: Customize the look and feel [look and feel](/guide/how-to/theme.md) of your shop.
+- **Theme customization**: Customize the look and feel [look and feel](/guide/themes/styling.md) of your shop.
 - **Advanced PlentyONE setup**: Complete the [setup journey](https://knowledge.plentymarkets.com/en-gb/manual/main/online-store/shop.html#shop-preparation) in PlentyONE to enable additional payment and shipping providers, bot protection, and more.
-- **Project updates**: Learn about [different strategies](/guide/how-to/project-update-strategies.md) for managing updates from the main project.
+- **Project updates**: Learn about [different strategies](/guide/themes/project-update-strategies.md) for managing updates from the main project.

--- a/docs/guide/introduction/quickstart.md
+++ b/docs/guide/introduction/quickstart.md
@@ -179,6 +179,6 @@ For the go-live option to become available, the shop has to run in preview mode.
 Once you have your shop running, you can begin customising it.
 Here are a few places to start:
 
-- **Theme customization**: Customize the look and feel [look and feel](/guide/themes/styling.md) of your shop.
+- **Theme customization**: Customize the [look and feel](/guide/themes/styling.md) of your shop.
 - **Advanced PlentyONE setup**: Complete the [setup journey](https://knowledge.plentymarkets.com/en-gb/manual/main/online-store/shop.html#shop-preparation) in PlentyONE to enable additional payment and shipping providers, bot protection, and more.
 - **Project updates**: Learn about [different strategies](/guide/themes/project-update-strategies.md) for managing updates from the main project.

--- a/docs/guide/modules/custom-js-css.md
+++ b/docs/guide/modules/custom-js-css.md
@@ -7,13 +7,13 @@ This guide will show you how to add custom CSS and JS in the head of the page.
 ::: warning
 Adding resources directly to the head could impact the performance of the page.
 We recommend adding JS and CSS code the native way. This means that the JS code is scoped to a `component` or `plugin` and the CSS is scoped to its `component`.
-Hooking into `tailwind` is also a valid way of extending the app's styles, as detailed in the [tailwind](/guide/how-to/module/tailwind.md) guide.
+Hooking into `tailwind` is also a valid way of extending the app's styles, as detailed in the [tailwind](/guide/modules/tailwind.md) guide.
 :::
 
 ## Prerequisites / Preparation
 
 This guide requires you to already have created a module.
-If you haven't created a module yet, you can follow the [How-to create a module](/guide/how-to/module/index.md) guide.
+If you haven't created a module yet, you can follow the [How-to create a module](/guide/modules/index.md) guide.
 
 ## Create and register a plugin to inject your resources
 

--- a/docs/guide/modules/i18n.md
+++ b/docs/guide/modules/i18n.md
@@ -13,7 +13,7 @@ You need to insert your module before the `@nuxtjs/i18n` in the `modules` of you
 ## Prerequisites / Preparation
 
 This guide requires that you already have created a module.
-If you haven't created a module yet, you can follow the [How-to create a module](/guide/how-to/module/index.md) guide.
+If you haven't created a module yet, you can follow the [How-to create a module](/guide/modules/index.md) guide.
 
 Add the `@nuxtjs/i18n` module to your module repository as a dev-dependency and to the `compilerOptions` types array in the `tsconfig.json`.
 

--- a/docs/guide/modules/inject-components.md
+++ b/docs/guide/modules/inject-components.md
@@ -71,11 +71,11 @@ You can edit the code directly in the playground above to see how component inje
 
 #### Versions lower than shop version v.2.16.0 and shop-core v.1.20.0:
 
-All existing predefined areas are listed in the [`apps/web/app/composables/useModuleRendering/areas.ts`](https://github.com/plentymarkets/plentyshop-pwa/blob/main/apps/web/app/composables/useModuleRendering/areas.ts) file within your shop repository.
+All existing predefined areas are listed in the [`apps/web/shop-core.config.ts`](https://github.com/plentymarkets/plentyshop-pwa/blob/main/apps/web/shop-core.config.ts) file within your shop repository.
 
 ### Adding a new custom area
 
-1. In your shop repository, open the file `apps/web/app/composables/useModuleRendering/areas.ts` and add a new entry to the areas array. If you try to inject your component into a non-existing entry, your shop will throw an error.
+1. In your shop repository, open the file `apps/web/shop-core.config.ts` and add a new entry to the areas array. If you try to inject your component into a non-existing entry, your shop will throw an error.
 2. In the location of the template in which you want to display this new area, add the following:
 
 ```html

--- a/docs/guide/modules/inject-components.md
+++ b/docs/guide/modules/inject-components.md
@@ -75,7 +75,7 @@ All existing predefined areas are listed in the [`apps/web/shop-core.config.ts`]
 
 ### Adding a new custom area
 
-1. In your shop repository, open the file `apps/web/shop-core.config.ts` and add a new entry to the areas array. If you try to inject your component into a non-existing entry, your shop will throw an error.
+1. In your shop repository, open the file `apps/web/shop-core.config.ts` and add a new entry to the `renderingAreas` array. If you try to inject your component into a non-existing entry, your shop will throw an error.
 2. In the location of the template in which you want to display this new area, add the following:
 
 ```html

--- a/docs/guide/modules/tailwind.md
+++ b/docs/guide/modules/tailwind.md
@@ -14,7 +14,7 @@ You need to insert your module before the `@nuxtjs/tailwindcss` in the `modules`
 ## Prerequisites / Preparation
 
 This guide requires that you already have created a module.
-If you haven't created a module yet, you can follow the [How-to create a module](/guide/how-to/module/index.md) guide.
+If you haven't created a module yet, you can follow the [How-to create a module](/guide/modules/index.md) guide.
 
 Add the `@nuxtjs/tailwindcss` module to your module repository as a dev-dependency and to the `compilerOptions` types array in the `tsconfig.json`.
 

--- a/docs/guide/product/experimental-features.md
+++ b/docs/guide/product/experimental-features.md
@@ -21,7 +21,7 @@ To create a new experimental feature, carry out the following steps:
    The flag is accessible via `useRuntimeConfig().public.<myFlag>`.
 
 ::: tip :bulb: Opt-in
-If you want to allow users to opt in to the feature, create a [site setting](../how-to/editor/site-settings.md) for it.
+If you want to allow users to opt in to the feature, create a [site setting](/guide/editor/site-settings.md) for it.
 :::
 
 ## Further reading

--- a/docs/guide/product/faq.md
+++ b/docs/guide/product/faq.md
@@ -17,12 +17,12 @@
 ## Does the shop support plentyShop LTS themes and widgets?
 
 No, the shop doesn't support any LTS plugins.
-Refer to our [module guides](/guide/how-to/module/index.md) to learn about the Nuxt extension ecosystem.
+Refer to our [module guides](/guide/modules/index.md) to learn about the Nuxt extension ecosystem.
 
 ## Does the shop support the plentyShop LTS ShopBuilder?
 
 No, the shop doesn't support ShopBuilder.
-Refer to our [editor guides](/guide/how-to/editor/index.md) to learn about our replacement technology.
+Refer to our [editor guides](/guide/editor/index.md) to learn about our replacement technology.
 
 ## How can I distribute extensions I develop to merchants?
 
@@ -31,4 +31,4 @@ This means you have to include any extensions you build directly in your own pro
 Widespread distribution isn't supported yet.
 
 Note that building extensions via Nuxt modules may still be the best option for you, depending on what you want to customise.
-For details, refer to the [update strategies guide](/guide/how-to/project-update-strategies.md).
+For details, refer to the [update strategies guide](/guide/themes/project-update-strategies.md).

--- a/docs/guide/themes/custom-api-endpoints.md
+++ b/docs/guide/themes/custom-api-endpoints.md
@@ -86,4 +86,4 @@ The method name in `extendApiMethods` must match the method name used in the SDK
 
 ## References
 
-- [Alokai: Middleware Extensions](https://docs.alokai.com/middleware/legacy/guides/extensions#adding-an-endpoint)
+- [Alokai: Middleware Extensions](https://docs.alokai.com/middleware/guides/extensions)

--- a/docs/guide/themes/i18n.md
+++ b/docs/guide/themes/i18n.md
@@ -4,7 +4,7 @@ Internationalisation (i18n) provides a way for you to customise your shop to acc
 
 ## Locales
 
-The i18n configuration affects language and currency. It's important that the app's configuration matches the settings of the system [you connect to](middleware.md). Otherwise, you'll receive incorrect data or data in the wrong language.
+The i18n configuration affects language and currency. It's important that the app's configuration matches the settings of the system you connect to. Otherwise, you'll receive incorrect data or data in the wrong language.
 
 **Configuration:**
 
@@ -202,7 +202,7 @@ Starting with shop version v2.8.0 we introduced the new localization editor, in 
 
 #### Migrating to Auto-Imported `t`
 
-1. **Remove** any manual imports or injections of `t` in your components, [example](/guide/how-to/i18n.md#usage-example)
+1. **Remove** any manual imports or injections of `t` in your components, [example](#usage-example)
 2. Use `t('key.path')` directly in your templates and scripts
 3. Make sure your IDE is updated for best auto-completion support
 


### PR DESCRIPTION
## Issue:

Broken links in the documentation remain undetected until they're reported.

## Describe your changes

- Update Vitepress configuration to check for broken links on build
- Adds [htmltest](https://github.com/wjdp/htmltest) to Integration Gate CI
- Fixes broken links throughout the documentation

It's necessary to use Vitepress build instead of htmltest for checking internal links because htmltest can't handle the missing `.html` file extension.

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
