### PR TITLE
Feat: Add fully module-scoped blocks without core changes

### DIFF
--- a/apps/web/app/components/editor/GridElementsPanel/GridElementsPanel.vue
+++ b/apps/web/app/components/editor/GridElementsPanel/GridElementsPanel.vue
@@ -2,7 +2,7 @@
   <EditorFormPanel v-model="isOpen" content-class="p-0">
     <template #title>
       <span class="inline-flex items-center gap-1.5">
-        {{ getEditorTranslation('elements') }}
+        {{ props.sectionLabel ?? getEditorTranslation('elements') }}
         <span
           v-if="totalCount > 0"
           class="text-3xs font-bold px-1.5 py-0.5 rounded-full"
@@ -53,7 +53,7 @@
           @click="props.customAdd ? emit('add-element') : onAddElement()"
         >
           <SfIconAdd size="xs" />
-          {{ getEditorTranslation('add-element') }}
+          {{ props.addButtonLabel ?? getEditorTranslation('add-element') }}
         </button>
       </div>
 

--- a/apps/web/app/components/editor/GridElementsPanel/types.ts
+++ b/apps/web/app/components/editor/GridElementsPanel/types.ts
@@ -7,6 +7,8 @@ export interface GridElementsPanelProps {
   minItems?: number;
   customAdd?: boolean;
   quickAddOptions?: QuickAddOption[];
+  sectionLabel?: string;
+  addButtonLabel?: string;
 }
 
 export type GridElementsPanelEmits = {

--- a/apps/web/app/composables/useBlocksList/mergeBlocksListsWithModuleContributions.ts
+++ b/apps/web/app/composables/useBlocksList/mergeBlocksListsWithModuleContributions.ts
@@ -1,0 +1,87 @@
+import type { BlocksList, BlockListCategory } from './types';
+
+type BlocksListContribution = Partial<BlocksList>;
+
+type BlocksListContributionModule = {
+  default?: BlocksListContribution;
+};
+
+const moduleBlocksListContributionFiles = import.meta.glob<BlocksListContributionModule>(
+  '~~/modules/*/runtime/components/blocks/**/blocks-list.json',
+  { eager: true },
+);
+
+const appendVariations = (
+  category: BlockListCategory,
+  variationsToAppend: BlockListCategory['variations'] = [],
+): BlockListCategory => ({
+  ...category,
+  variations: [...(category.variations ?? []), ...deepClone(variationsToAppend)],
+});
+
+const getRequiredKeys = (value: unknown): string[] =>
+  typeof value === 'object' && value !== null ? Object.keys(value as Record<string, unknown>) : [];
+
+const hasRequiredShape = (candidate: unknown, reference: unknown): boolean => {
+  const requiredKeys = getRequiredKeys(reference);
+  if (!requiredKeys.length) return true;
+  if (typeof candidate !== 'object' || candidate === null) return false;
+
+  const candidateRecord = candidate as Record<string, unknown>;
+  return requiredKeys.every((key) => key in candidateRecord);
+};
+
+const hasRequiredCategoryShape = (
+  category: BlockListCategory,
+  referenceCategory: BlockListCategory,
+): boolean => {
+  if (!hasRequiredShape(category, referenceCategory)) return false;
+  const referenceVariation = referenceCategory.variations?.[0];
+  if (!referenceVariation) return true;
+
+  return (category.variations ?? []).every((variation) => hasRequiredShape(variation, referenceVariation));
+};
+
+const findTargetCategoryKey = (
+  merged: BlocksList,
+  contributionKey: string,
+  contributionCategory: BlockListCategory,
+): string => {
+  if (merged[contributionKey]) return contributionKey;
+
+  const matchingByCategoryName = Object.entries(merged).find(
+    ([, existingCategory]) => existingCategory.category === contributionCategory.category,
+  );
+
+  return matchingByCategoryName?.[0] ?? contributionKey;
+};
+
+export const mergeBlocksListsWithModuleContributions = (baseBlocksLists: BlocksList): BlocksList => {
+  const firstDefaultCategory = Object.values(baseBlocksLists)[0];
+  const sortedContributions = Object.entries(moduleBlocksListContributionFiles)
+    .sort(([pathA], [pathB]) => pathA.localeCompare(pathB))
+    .map(([, module]) => module.default)
+    .filter(Boolean) as BlocksListContribution[];
+
+  return sortedContributions.reduce<BlocksList>((acc, contribution) => {
+    const merged = acc;
+
+    // Module JSON must follow the same root structure as default blocksLists.json.
+    for (const [contributionKey, contributionCategory] of Object.entries(contribution)) {
+      if (!contributionCategory) continue;
+
+      const targetCategoryKey = findTargetCategoryKey(merged, contributionKey, contributionCategory);
+      const referenceCategory = merged[targetCategoryKey] ?? firstDefaultCategory;
+      if (!referenceCategory || !hasRequiredCategoryShape(contributionCategory, referenceCategory)) continue;
+
+      if (!merged[targetCategoryKey]) {
+        merged[targetCategoryKey] = deepClone(contributionCategory);
+        continue;
+      }
+
+      merged[targetCategoryKey] = appendVariations(merged[targetCategoryKey], contributionCategory.variations ?? []);
+    }
+
+    return merged;
+  }, deepClone(baseBlocksLists));
+};

--- a/apps/web/app/composables/useBlocksList/useBlocksList.ts
+++ b/apps/web/app/composables/useBlocksList/useBlocksList.ts
@@ -1,4 +1,5 @@
 import type { BlocksList, BlocksListContext, BlockListCategory, UseBlocksListReturn } from './types';
+import { mergeBlocksListsWithModuleContributions } from './mergeBlocksListsWithModuleContributions';  // NK added
 
 const blocksLists = ref<BlocksList>({});
 const blocksListContext = ref<BlocksListContext>('');
@@ -34,7 +35,8 @@ export const useBlocksList: UseBlocksListReturn = () => {
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
-      blocksLists.value = await response.json();
+      const baseBlocksLists = (await response.json()) as BlocksList; // NK added
+      blocksLists.value = mergeBlocksListsWithModuleContributions(baseBlocksLists);  // NK added
     } catch (error) {
       throw new Error(`Failed to fetch blocksLists: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }

--- a/apps/web/app/utils/blocks/block-icons.ts
+++ b/apps/web/app/utils/blocks/block-icons.ts
@@ -3,6 +3,11 @@ const blockIconLoaders = import.meta.glob('@/components/**/blocks/**/icon.svg', 
   import: 'default',
 }) as Record<string, () => Promise<string>>;
 
+const moduleBlockIconLoaders = import.meta.glob('~~/modules/*/runtime/components/blocks/**/icon.svg', {
+  query: '?raw',
+  import: 'default',
+}) as Record<string, () => Promise<string>>;
+
 const normalizeIconPath = (path: string): string => {
   const match = path.match(/blocks\/(?:structure\/)?([^/]+)\/[^/]*icon\.svg/);
   return match?.[1] ?? '';
@@ -10,7 +15,7 @@ const normalizeIconPath = (path: string): string => {
 
 const blockIcons: Record<string, string> = reactive({});
 
-Object.entries(blockIconLoaders).forEach(([path, loader]) => {
+Object.entries({ ...blockIconLoaders, ...moduleBlockIconLoaders }).forEach(([path, loader]) => {
   const blockName = normalizeIconPath(path);
   if (blockName) {
     loader()

--- a/apps/web/app/utils/blocks/get-block-display-name.ts
+++ b/apps/web/app/utils/blocks/get-block-display-name.ts
@@ -18,6 +18,32 @@ const blockTypeNames: Record<string, string> = {
   FooterContainer: 'Footer Container',
 };
 
+type ModuleBlockTypeNamesExport = {
+  blockTypeNames?: Record<string, string>;
+  default?: Record<string, string>;
+};
+
+const moduleBlockTypeNamesFiles = import.meta.glob<ModuleBlockTypeNamesExport>(
+  '~~/modules/*/runtime/utils/blocks/block-type-names.ts',
+  { eager: true },
+);
+
+const moduleBlockTypeNames = Object.entries(moduleBlockTypeNamesFiles)
+  .sort(([pathA], [pathB]) => pathA.localeCompare(pathB))
+  .reduce<Record<string, string>>((acc, [, file]) => {
+    const maps = [file.blockTypeNames, file.default].filter(Boolean) as Record<string, string>[];
+
+    for (const names of maps) {
+      for (const [key, value] of Object.entries(names)) {
+        if (!(key in acc)) {
+          acc[key] = value;
+        }
+      }
+    }
+
+    return acc;
+  }, {});
+
 export const getBlockDisplayName = (blockName: string): string => {
-  return blockTypeNames[blockName] ?? blockName;
+  return moduleBlockTypeNames[blockName] ?? blockTypeNames[blockName] ?? blockName;
 };

--- a/apps/web/modules/nk-blocks/runtime/components/blocks/structure/Tabs/Tabs.vue
+++ b/apps/web/modules/nk-blocks/runtime/components/blocks/structure/Tabs/Tabs.vue
@@ -1,0 +1,207 @@
+<template>
+  <div :class="containerClasses" class="tabs-structure" data-testid="tabs-structure">
+    <div
+      v-if="visibleTabs.length > 0"
+      :class="tabsListClasses"
+      role="tablist"
+      :aria-label="t('tabs.structure.ariaLabel')"
+      aria-orientation="horizontal"
+    >
+      <template v-for="(tab, index) in visibleTabs" :key="tab.meta.uuid">
+        <UiButton
+          v-if="showTabsAsButtons"
+          :id="getTabId(tab.meta.uuid)"
+          type="button"
+          role="tab"
+          :variant="isActiveTab(index) ? 'primary' : 'secondary'"
+          :class="getTabButtonClasses(tab)"
+          :aria-selected="isActiveTab(index)"
+          :aria-controls="getPanelId(tab.meta.uuid)"
+          :data-testid="`tabs-trigger-${index}`"
+          @click="activeTabIndex = index"
+        >
+          {{ getTabLabel(tab, index) }}
+        </UiButton>
+
+        <button
+          v-else
+          :id="getTabId(tab.meta.uuid)"
+          type="button"
+          role="tab"
+          :class="getTabTextClasses(index)"
+          :aria-selected="isActiveTab(index)"
+          :aria-controls="getPanelId(tab.meta.uuid)"
+          :data-testid="`tabs-trigger-${index}`"
+          @click="activeTabIndex = index"
+        >
+          {{ getTabLabel(tab, index) }}
+        </button>
+      </template>
+    </div>
+
+    <div v-if="activeTab" class="pt-4">
+      <div
+        :id="getPanelId(activeTab.meta.uuid)"
+        :aria-labelledby="getTabId(activeTab.meta.uuid)"
+        :data-testid="`tabs-panel-${activeTabIndex}`"
+        role="tabpanel"
+      >
+        <slot name="content" :content-block="activeTab" :index="activeTabIndex" />
+
+        <UiBlockPlaceholder
+          v-if="shouldDisplayPlaceholder(activeTab.meta.uuid, 'bottom', drawerOpen, drawerView)"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Block } from '@plentymarkets/shop-api';
+
+type TabsAlignment = 'left' | 'center' | 'right';
+
+type TabsStructureConfiguration = {
+  layout?: {
+    fullWidth?: boolean;
+    showBorderUnderTabs?: boolean;
+    showTabsAsButtons?: boolean;
+    tabsAlignment?: TabsAlignment;
+  };
+};
+
+type TabSettings = {
+  label?: string;
+  roundedButtons?: boolean;
+  useBorder?: boolean;
+};
+
+type TabsStructureProps = {
+  content?: Block[];
+  configuration?: TabsStructureConfiguration;
+};
+
+const props = defineProps<TabsStructureProps>();
+
+const { shouldDisplayPlaceholder } = useBlockManager();
+const { siteConfigurationDrawerOpen, siteConfigurationDrawerView } = useSiteConfiguration();
+
+const drawerOpen = computed(() => siteConfigurationDrawerOpen.value);
+const drawerView = computed(() => siteConfigurationDrawerView.value);
+const { isFullWidth } = useFullWidthToggleForConfig(computed(() => props.configuration ?? {}));
+
+const showBorderUnderTabs = computed(() => props.configuration?.layout?.showBorderUnderTabs !== false);
+const showTabsAsButtons = computed(() => props.configuration?.layout?.showTabsAsButtons !== false);
+const tabsAlignment = computed<TabsAlignment>(() => props.configuration?.layout?.tabsAlignment ?? 'left');
+
+const visibleTabs = computed(() => {
+  return (props.content ?? []).filter((block) => block.configuration?.visible !== false);
+});
+
+const containerClasses = computed(() => {
+  return isFullWidth.value ? [] : ['px-4', 'md:px-6', 'max-w-screen-3xl', 'mx-auto'];
+});
+
+const tabsListClasses = computed(() => {
+  const alignmentClasses: Record<TabsAlignment, string> = {
+    left: 'justify-start',
+    center: 'justify-center',
+    right: 'justify-end',
+  };
+
+  return [
+    'flex overflow-x-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]',
+    showTabsAsButtons.value ? 'gap-2' : 'gap-4',
+    alignmentClasses[tabsAlignment.value],
+    showBorderUnderTabs.value ? 'border-b border-b-neutral-200 pb-4' : '',
+  ];
+});
+
+const activeTabIndex = ref(0);
+
+watch(
+  visibleTabs,
+  (tabs) => {
+    if (!tabs.length) {
+      activeTabIndex.value = 0;
+      return;
+    }
+
+    if (activeTabIndex.value >= tabs.length) {
+      activeTabIndex.value = 0;
+    }
+  },
+  { immediate: true },
+);
+
+const activeTab = computed(() => visibleTabs.value[activeTabIndex.value]);
+
+const isActiveTab = (index: number) => activeTabIndex.value === index;
+
+const getTabSettings = (block: Block): TabSettings => {
+  const config = block.configuration as Record<string, unknown> | undefined;
+  const tabSettings = config?.tabSettings as TabSettings | undefined;
+
+  return {
+    label: tabSettings?.label,
+  };
+};
+
+const getTabLabel = (block: Block, index: number) => {
+  const tabSettings = getTabSettings(block);
+  if (typeof tabSettings.label === 'string' && tabSettings.label.trim().length > 0) {
+    return tabSettings.label;
+  }
+
+  const content = block.content as Record<string, unknown> | undefined;
+  const text = content?.text as Record<string, unknown> | undefined;
+  const title = text?.title;
+
+  if (typeof title === 'string' && title.trim().length > 0) {
+    return title;
+  }
+
+  return t('tabs.structure.fallbackLabel', { index: index + 1 });
+};
+
+const getTabButtonClasses = (block: Block) => {
+  const tabSettings = getTabSettings(block);
+
+  return [
+    tabSettings.roundedButtons ? '!rounded-md' : '!rounded-sm',
+    tabSettings.useBorder ? 'border border-2' : 'border-0',
+  ];
+};
+
+const getTabTextClasses = (index: number) => {
+  if (isActiveTab(index)) {
+    return 'px-1 py-2 whitespace-nowrap border-b-2 border-primary-700 text-primary-700 font-medium';
+  }
+
+  return 'px-1 py-2 whitespace-nowrap border-b-2 border-transparent text-neutral-500 hover:text-neutral-700 hover:border-neutral-300';
+};
+
+const getTabId = (uuid: string) => `tabs-trigger-${uuid}`;
+const getPanelId = (uuid: string) => `tabs-panel-${uuid}`;
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "tabs": {
+      "structure": {
+        "ariaLabel": "Tabs",
+        "fallbackLabel": "Tab {index}"
+      }
+    }
+  },
+  "de": {
+    "tabs": {
+      "structure": {
+        "ariaLabel": "Tabs",
+        "fallbackLabel": "Tab {index}"
+      }
+    }
+  }
+}
+</i18n>

--- a/apps/web/modules/nk-blocks/runtime/components/blocks/structure/Tabs/TabsForm.vue
+++ b/apps/web/modules/nk-blocks/runtime/components/blocks/structure/Tabs/TabsForm.vue
@@ -1,0 +1,255 @@
+<template>
+  <div data-testid="tabs-structure-form" class="block-tabs-edit sticky h-[80vh] overflow-y-auto">
+    <div v-if="!editingBlock" class="space-y-0">
+      <EditorGridElementsPanel
+        v-model="elementsOpen"
+        :uuid="resolvedUuid"
+        :min-items="1"
+        :section-label="getEditorTranslation('tabs-label')"
+        :add-button-label="getEditorTranslation('add-tab-label')"
+        @edit-element="editTab"
+      />
+
+      <EditorFormPanel v-model="tabSettingsOpen" :title="getEditorTranslation('tab-settings-label')">
+        <div class="py-2">
+          <UiFormLabel>{{ getEditorTranslation('selected-tab-label') }}</UiFormLabel>
+          <select
+            v-model="selectedTabUuid"
+            class="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+            data-testid="tabs-selected-tab"
+          >
+            <option v-for="option in tabsOptions" :key="option.uuid" :value="option.uuid">
+              {{ option.label }}
+            </option>
+          </select>
+        </div>
+
+        <div v-if="selectedTab" class="py-2">
+          <UiFormLabel>{{ getEditorTranslation('tab-name-label') }}</UiFormLabel>
+          <SfInput v-model="selectedTabName" type="text" data-testid="tabs-tab-name" />
+        </div>
+      </EditorFormPanel>
+
+      <EditorFormPanel v-model="layoutOpen" :title="getEditorTranslation('layout-label')">
+        <EditorFullWidthToggle v-model="isFullWidth" :block-uuid="resolvedUuid" />
+
+        <div class="py-2 flex items-center justify-between">
+          <UiFormLabel>{{ getEditorTranslation('show-tabs-as-buttons-label') }}</UiFormLabel>
+          <SfSwitch v-model="showTabsAsButtons" data-testid="tabs-show-as-buttons" />
+        </div>
+
+        <div class="py-2 flex items-center justify-between">
+          <UiFormLabel>{{ getEditorTranslation('show-border-under-tabs-label') }}</UiFormLabel>
+          <SfSwitch v-model="showBorderUnderTabs" data-testid="tabs-show-border-under-tabs" />
+        </div>
+
+        <div class="py-2">
+          <EditorOptionsTabs
+            v-model="tabsAlignment"
+            :legend="getEditorTranslation('tabs-alignment-label')"
+            test-id-prefix="tabs-alignment"
+            :options="tabsAlignmentOptions"
+          />
+        </div>
+      </EditorFormPanel>
+    </div>
+
+    <div v-else class="space-y-0">
+      <component :is="blockForm" :uuid="editingBlock.meta.uuid" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { SfInput, SfSwitch } from '@storefront-ui/vue';
+import type { Block } from '@plentymarkets/shop-api';
+
+type TabsAlignment = 'left' | 'center' | 'right';
+
+type TabsStructureBlock = {
+  content?: Block[];
+  configuration?: {
+    visible?: boolean;
+    layout?: {
+      fullWidth?: boolean;
+      showBorderUnderTabs?: boolean;
+      showTabsAsButtons?: boolean;
+      tabsAlignment?: TabsAlignment;
+    };
+  };
+};
+
+const props = defineProps<{ uuid?: string }>();
+
+const { blockUuid } = useSiteConfiguration();
+const { allBlocks: data } = useBlocks();
+const { findOrDeleteBlockByUuid } = useBlockManager();
+
+const resolvedUuid = computed(() => props.uuid || blockUuid.value);
+const elementsOpen = ref(true);
+const layoutOpen = ref(true);
+const { editingBlock, blockForm } = useNestedBlockForm(resolvedUuid);
+const { pushEdit } = useBlockEditStack();
+
+const tabsStructure = computed(
+  () => (findOrDeleteBlockByUuid(data.value, resolvedUuid.value) || {}) as TabsStructureBlock,
+);
+
+const tabsConfiguration = computed(() => {
+  if (!tabsStructure.value.configuration) {
+    tabsStructure.value.configuration = { visible: true };
+  }
+
+  if (!tabsStructure.value.configuration.layout) {
+    tabsStructure.value.configuration.layout = {
+      fullWidth: false,
+      showBorderUnderTabs: true,
+      showTabsAsButtons: true,
+      tabsAlignment: 'left',
+    };
+  }
+
+  return tabsStructure.value.configuration;
+});
+
+const { isFullWidth } = useFullWidthToggleForConfig(computed(() => tabsConfiguration.value));
+
+const showBorderUnderTabs = computed({
+  get: () => tabsConfiguration.value.layout?.showBorderUnderTabs !== false,
+  set: (value: boolean) => {
+    if (!tabsConfiguration.value.layout) {
+      tabsConfiguration.value.layout = { fullWidth: false, showTabsAsButtons: true, tabsAlignment: 'left' };
+    }
+    tabsConfiguration.value.layout.showBorderUnderTabs = value;
+  },
+});
+
+const showTabsAsButtons = computed({
+  get: () => tabsConfiguration.value.layout?.showTabsAsButtons !== false,
+  set: (value: boolean) => {
+    if (!tabsConfiguration.value.layout) {
+      tabsConfiguration.value.layout = { fullWidth: false, showBorderUnderTabs: true, tabsAlignment: 'left' };
+    }
+    tabsConfiguration.value.layout.showTabsAsButtons = value;
+  },
+});
+
+const tabsAlignment = computed<TabsAlignment>({
+  get: () => tabsConfiguration.value.layout?.tabsAlignment ?? 'left',
+  set: (value: TabsAlignment) => {
+    if (!tabsConfiguration.value.layout) {
+      tabsConfiguration.value.layout = { fullWidth: false, showBorderUnderTabs: true, showTabsAsButtons: true };
+    }
+    tabsConfiguration.value.layout.tabsAlignment = value;
+  },
+});
+
+const tabsAlignmentOptions = computed(() => [
+  { value: 'left' as TabsAlignment, label: getEditorTranslation('position-left'), testId: 'tabs-align-left' },
+  { value: 'center' as TabsAlignment, label: getEditorTranslation('position-center'), testId: 'tabs-align-center' },
+  { value: 'right' as TabsAlignment, label: getEditorTranslation('position-right'), testId: 'tabs-align-right' },
+]);
+
+const tabSettingsOpen = ref(true);
+const selectedTabUuid = ref<string>('');
+
+const tabs = computed(() => tabsStructure.value.content ?? []);
+
+const tabsOptions = computed(() => {
+  return tabs.value.map((tab, index) => {
+    const settings = (tab.configuration as Record<string, unknown> | undefined)?.tabSettings as
+      | Record<string, unknown>
+      | undefined;
+    const label = typeof settings?.label === 'string' && settings.label.trim().length > 0
+      ? settings.label
+      : `${getEditorTranslation('tab-label')} ${index + 1}`;
+    return {
+      uuid: tab.meta.uuid,
+      label,
+    };
+  });
+});
+
+watch(
+  tabsOptions,
+  (options) => {
+    if (!options.length) {
+      selectedTabUuid.value = '';
+      return;
+    }
+
+    if (!options.some((option) => option.uuid === selectedTabUuid.value)) {
+      selectedTabUuid.value = options[0]?.uuid ?? '';
+    }
+  },
+  { immediate: true },
+);
+
+const selectedTab = computed(() => {
+  if (!selectedTabUuid.value) return null;
+  return tabs.value.find((tab) => tab.meta.uuid === selectedTabUuid.value) ?? null;
+});
+
+const ensureTabSettings = (block: Block) => {
+  if (!block.configuration) block.configuration = { visible: true };
+  const config = block.configuration as Record<string, unknown>;
+  const tabSettings = (config.tabSettings as Record<string, unknown> | undefined) ?? {};
+
+  if (typeof tabSettings.label !== 'string') tabSettings.label = '';
+
+  config.tabSettings = tabSettings;
+  return tabSettings;
+};
+
+const selectedTabName = computed({
+  get: () => {
+    if (!selectedTab.value) return '';
+    const settings = ensureTabSettings(selectedTab.value);
+    return String(settings.label ?? '');
+  },
+  set: (value: string) => {
+    if (!selectedTab.value) return;
+    const settings = ensureTabSettings(selectedTab.value);
+    settings.label = value;
+  },
+});
+
+const editTab = (block: Block) => {
+  pushEdit(block);
+};
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "layout-label": "Layout",
+    "tabs-label": "Tabs",
+    "add-tab-label": "Add Tab",
+    "tab-settings-label": "Tab Names",
+    "selected-tab-label": "Selected Tab",
+    "tab-label": "Tab",
+    "tab-name-label": "Tab name",
+    "show-tabs-as-buttons-label": "Show tabs as buttons",
+    "show-border-under-tabs-label": "Show border line under tabs",
+    "tabs-alignment-label": "Tabs alignment",
+    "position-left": "Left",
+    "position-center": "Center",
+    "position-right": "Right"
+  },
+  "de": {
+    "layout-label": "Layout",
+    "tabs-label": "Tabs",
+    "add-tab-label": "Add Tab",
+    "tab-settings-label": "Tab Names",
+    "selected-tab-label": "Selected Tab",
+    "tab-label": "Tab",
+    "tab-name-label": "Tab name",
+    "show-tabs-as-buttons-label": "Show tabs as buttons",
+    "show-border-under-tabs-label": "Show border line under tabs",
+    "tabs-alignment-label": "Tabs alignment",
+    "position-left": "Left",
+    "position-center": "Center",
+    "position-right": "Right"
+  }
+}
+</i18n>

--- a/apps/web/modules/nk-blocks/runtime/components/blocks/structure/Tabs/blocks-list.json
+++ b/apps/web/modules/nk-blocks/runtime/components/blocks/structure/Tabs/blocks-list.json
@@ -1,0 +1,86 @@
+{
+  "tabs": {
+    "category": "tabs",
+    "accessControl": ["content", "productCategory", "product"],
+    "title": "Tabs",
+    "blockName": "Tabs",
+    "variations": [
+      {
+        "title": "Tabs",
+        "image": "https://cdn02.plentymarkets.com/v5vzmmmcb10k/frontend/PWA/placeholder-image.png",
+        "template": {
+          "en": {
+            "name": "Tabs",
+            "type": "structure",
+            "meta": { "uuid": "5b6f4d2e-18af-43dc-9c7f-1a8af0e8c101" },
+            "configuration": {
+              "layout": {
+                "fullWidth": false,
+                "showBorderUnderTabs": true,
+                "tabsAlignment": "left"
+              }
+            },
+            "content": [
+              {
+                "name": "TextCard",
+                "type": "content",
+                "meta": { "uuid": "f2f26f36-6eb8-4f44-bb07-4c3094d6b201" },
+                "content": {
+                  "text": {
+                    "title": "Tab 1",
+                    "htmlDescription": "<p style=\"text-align: left;\">Add your tab content here.</p>",
+                    "textAlignment": "left",
+                    "color": "#000"
+                  },
+                  "button": {
+                    "label": "",
+                    "link": "",
+                    "variant": "primary"
+                  },
+                  "layout": {
+                    "fullWidth": false
+                  }
+                }
+              }
+            ]
+          },
+          "de": {
+            "name": "Tabs",
+            "type": "structure",
+            "meta": { "uuid": "0f75a405-f99b-48dc-ac27-30a42ea55058" },
+            "configuration": {
+              "layout": {
+                "fullWidth": false,
+                "showBorderUnderTabs": true,
+                "tabsAlignment": "left"
+              }
+            },
+            "content": [
+              {
+                "name": "TextCard",
+                "type": "content",
+                "meta": { "uuid": "7377427d-650e-462d-9c48-ae70691fdb0f" },
+                "content": {
+                  "text": {
+                    "title": "Tab 1",
+                    "htmlDescription": "<p style=\"text-align: left;\">Fuegen Sie hier Ihren Tab-Inhalt hinzu.</p>",
+                    "textAlignment": "left",
+                    "color": "#000"
+                  },
+                  "button": {
+                    "label": "",
+                    "link": "",
+                    "variant": "primary"
+                  },
+                  "layout": {
+                    "fullWidth": false
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/apps/web/modules/nk-blocks/runtime/components/blocks/structure/Tabs/icon.svg
+++ b/apps/web/modules/nk-blocks/runtime/components/blocks/structure/Tabs/icon.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3" y="5" width="18" height="14" rx="2" stroke="#374151" stroke-width="1.5"/>
+  <path d="M3 10H21" stroke="#374151" stroke-width="1.5"/>
+  <path d="M8 5V10" stroke="#374151" stroke-width="1.5"/>
+  <path d="M14 5V10" stroke="#374151" stroke-width="1.5"/>
+</svg>

--- a/apps/web/modules/nk-blocks/runtime/utils/blocks/block-type-names.ts
+++ b/apps/web/modules/nk-blocks/runtime/utils/blocks/block-type-names.ts
@@ -1,6 +1,3 @@
 export const blockTypeNames: Record<string, string> = {
   Tabs: 'Tabs',
-  FooterCompanyData: 'Company Data',
-  FooterPaymentShippingIcons: 'Payment & Shipment Icons',
-  FooterFootnote: 'Footer Footnote',
 };

--- a/apps/web/modules/nk-blocks/runtime/utils/blocks/block-type-names.ts
+++ b/apps/web/modules/nk-blocks/runtime/utils/blocks/block-type-names.ts
@@ -1,0 +1,6 @@
+export const blockTypeNames: Record<string, string> = {
+  Tabs: 'Tabs',
+  FooterCompanyData: 'Company Data',
+  FooterPaymentShippingIcons: 'Payment & Shipment Icons',
+  FooterFootnote: 'Footer Footnote',
+};


### PR DESCRIPTION
## Issue:

Be able to create new blocks entirely within a module, with all required files colocated in that block’s module folder, so no core file changes are needed.

I have also included a sample block [modules\nk-blocks] that creates a Tab structure block to demonstrate the new logic.
(We are also contributing this block to the project if you approve.)

## Describe your changes

**1.**  To enable custom blocks from modules without editing core block registry files, we introduced automatic module contribution discovery and merge logic for the editor block list.

Each block can provide its own [blocks-list.json] contribution
Module blocks now provide their own partial contribution files with the same schema family as the default root structure in [public\..\blocksLists.json]

New merge helper for module contributions
The merge is handled by [composables\useBlocksList\mergeBlocksListsWithModuleContributions.ts] and is invoked from [composables\useBlocksList\useBlocksList.ts].

**Merge behavior**

Reads module contribution files as partial BlocksList objects with a compatible root schema.
**Iterates each top-level contributed key.**
If the key already exists in the default or already merged list, it merges into that category.
If the key does not exist, but the contributed category field matches an existing category, it merges into that existing category path.
If neither key nor category match is found, it adds a new category entry.
**Validation before merge**
Before adding or merging a contribution, the helper validates the required structure against the matching default category shape:
Required top-level category fields must be present.
Required variation-level fields must be present based on the default variation shape.
**Resulting merge rules**
Existing category: append variations only.
New category: insert full category object.

Sample file with a full category addition from the partial JSON: 
[blocks-list.json](https://github.com/user-attachments/files/28471261/blocks-list.json)
Sample file with a variation addition from the partial JSON (Adds variation to an existing category)
[blocks-list.json](https://github.com/user-attachments/files/28471351/blocks-list.json)


2a. Add [block-type-names.ts] local file inside the block folder.
It exports blockTypeNames for custom blocks, so labels are provided by the module itself and picked up automatically by core runtime discovery.
2b. The [utils\blocks\get-block-display-name.ts] now auto-loads block-type-names files from modules [modules/*/runtime/utils/blocks/block-type-names.ts], merges them, and resolves names with module-first precedence while keeping core mappings as fallback. This allows new module blocks to define labels without touching core display-name maps.

3. Expanded icon discovery to automatically load module-provided block icons.
Implemented in [utils\blocks\block-icons.ts].

4. Changes in [components\editor\GridElementsPanel\GridElementsPanel.vue] and [components\editor\GridElementsPanel\types.ts] allow us to provide custom names to the Elements panel. 
e.g., instead of the title "ELEMENTS" and the button label "+ Add Element" we can now change them to "TABS" and "+ Add a Tab"

