### PR TITLE
chore: preserve trailing slash option

### DIFF
--- a/apps/web/modules/sitemap/__tests__/index.spec.ts
+++ b/apps/web/modules/sitemap/__tests__/index.spec.ts
@@ -111,12 +111,14 @@ describe('sitemap module', () => {
           plentySitemap?: {
             defaultLocale: string;
             locales: string[];
+            trailingSlash: 'always' | 'auto' | 'never';
           };
         }
       ).plentySitemap,
     ).toEqual({
       defaultLocale: 'en',
       locales: [],
+      trailingSlash: 'never',
     });
   });
 

--- a/apps/web/modules/sitemap/index.ts
+++ b/apps/web/modules/sitemap/index.ts
@@ -5,6 +5,7 @@ export interface ModuleOptions {
   locales?: string[];
   defaultLocale?: string;
   exclude?: string[];
+  trailingSlash?: 'always' | 'auto' | 'never';
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -21,6 +22,7 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.options.runtimeConfig.public.plentySitemap = {
       locales: _options.locales || [],
       defaultLocale: _options.defaultLocale ?? 'en',
+      trailingSlash: _options.trailingSlash ?? 'never',
     };
 
     const routeHasParams = (path: string) => {

--- a/apps/web/modules/sitemap/runtime/sitemap.xml.ts
+++ b/apps/web/modules/sitemap/runtime/sitemap.xml.ts
@@ -28,7 +28,7 @@ const parseTrailingSlashSetting = (value: unknown): number => {
 };
 
 const resolveTrailingSlashSetting = (siteSetting: number, defaultMode: string): number => {
-  if (siteSetting !== URL_TRAILING_SLASH_NO_CHANGE) return siteSetting;
+  // if (siteSetting !== URL_TRAILING_SLASH_NO_CHANGE) return siteSetting;
   if (defaultMode === 'never') return URL_TRAILING_SLASH_NEVER;
   if (defaultMode === 'always') return URL_TRAILING_SLASH_ALWAYS;
 
@@ -118,14 +118,14 @@ export default defineEventHandler(async (event) => {
   const host = getRequestHost(event);
   const baseUrl = host.startsWith('localhost') ? `http://${host}` : `https://${host}`;
   const config = useRuntimeConfig();
-  const { locales, defaultLocale } = config.public.plentySitemap;
+  const { locales, defaultLocale, trailingSlash } = config.public.plentySitemap;
   const publicConfig = config.public as Record<string, unknown>;
   const shopCore = publicConfig.shopCore as Record<string, unknown> | undefined;
   const apiUrlFromShopCore = typeof shopCore?.apiUrl === 'string' ? shopCore.apiUrl : '';
   const domain = typeof publicConfig.domain === 'string' ? publicConfig.domain : '';
   const apiUrl = apiUrlFromShopCore.length > 0 ? apiUrlFromShopCore : domain;
   const siteTrailingSlashSetting = await getSiteTrailingSlashSetting(apiUrl);
-  const effectiveTrailingSlash = resolveTrailingSlashSetting(siteTrailingSlashSetting, 'never');
+  const effectiveTrailingSlash = resolveTrailingSlashSetting(siteTrailingSlashSetting, trailingSlash);
   const urls: SitemapURL[] = [];
   const lastmod = buildTime;
   const buildPageUrl = (pagePath: string, locale?: string): string => {


### PR DESCRIPTION
## Issue:

Partial revert of #2710 until all other trailing slash changes are ready

## Describe your changes

- Re-adds module option for trailing slash
- Always uses module option
- Updates test to account for module option

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
