### PR TITLE
fix: keep editor toolbar above sticky header

### DIFF
--- a/apps/web/app/components/ui/Toolbar/Toolbar.vue
+++ b/apps/web/app/components/ui/Toolbar/Toolbar.vue
@@ -1,8 +1,7 @@
 <template>
   <div
     :key="`${$route.meta?.identifier ?? ''}:${$route.meta?.type ?? ''}`"
-    class="mb-3 font-editor"
-    :class="['sticky top-0 bg-white h-[52px] shadow-[0px_15px_20px_-15px_#111]', drawerZIndexClass]"
+    class="mb-3 font-editor sticky top-0 bg-white h-[52px] shadow-[0px_15px_20px_-15px_#111] md:z-editor-toolbar"
     data-testid="edit-mode-toolbar"
   >
     <div class="relative flex items-center pr-5">
@@ -76,7 +75,6 @@ const editLabel = 'Switch to Edit mode to modify your page content and layout.';
 
 const { hasChanges: localizationHasChanges } = useEditorLocalizationKeys();
 const { isEditing, isEditingEnabled, disableActions } = useEditor();
-const { isDrawerOpen } = useDrawerState();
 
 const { data, cleanData, loading, isSettling } = useBlocks();
 
@@ -97,10 +95,6 @@ const toggleEdit = () => {
     isEditing.value = false;
   }
 };
-
-const drawerZIndexClass = computed(() =>
-  isDrawerOpen.value ? 'lg:z-editor-drawer md:z-editor-toolbar' : 'md:z-editor-drawer',
-);
 
 watch(
   () => data.value,


### PR DESCRIPTION
## Issue:

Closes: AB#ID

## Describe your changes

- Fixed an editor-only stacking issue where toolbar dropdowns could render behind the storefront header when the header container sticky setting was enabled.
- Simplified the editor toolbar z-index behavior so the toolbar consistently stays on the `z-editor-toolbar` layer at desktop breakpoints instead of conditionally dropping to the drawer layer.
- Removed the now-unused `useDrawerState()` dependency from `Toolbar.vue`.
- Known limitations:
  - This was verified manually in the PWA editor, but no automated test coverage was added in this change.
  - The fix targets the editor toolbar stacking context specifically; it does not change storefront sticky header behavior outside editor mode.

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- None

### Functionality

- [x] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [x] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

Added screenshots showing the editor dropdown behavior before and after enabling the sticky header option.