### PR TITLE
fix: added autofocus on modal input

### DIFF
--- a/apps/web/app/components/blocks/PriceCard/ItemPropertiesSelectModal.vue
+++ b/apps/web/app/components/blocks/PriceCard/ItemPropertiesSelectModal.vue
@@ -27,7 +27,7 @@
       </div>
       <div class="w-full px-5 py-3 border-b border-neutral-200">
         <SfInput
-          ref="searchInputRef"
+          id="item-properties-search"
           v-model="searchQuery"
           :placeholder="getEditorTranslation('search-placeholder')"
           size="sm"
@@ -174,7 +174,6 @@ import {
   SfIconHelp,
   SfModal,
 } from '@storefront-ui/vue';
-import type { ComponentPublicInstance } from 'vue';
 import type { PropertyPlaceholderToken } from '~/composables/useRichTextEditor/types';
 
 const emit = defineEmits<{
@@ -182,11 +181,9 @@ const emit = defineEmits<{
   close: [];
 }>();
 
-const searchInputRef = ref<ComponentPublicInstance | null>(null);
-
 onMounted(() => {
   nextTick(() => {
-    searchInputRef.value?.$el?.querySelector('input')?.focus();
+    document.getElementById('item-properties-search')?.focus();
   });
 });
 

--- a/apps/web/app/components/blocks/PriceCard/ItemPropertiesSelectModal.vue
+++ b/apps/web/app/components/blocks/PriceCard/ItemPropertiesSelectModal.vue
@@ -26,7 +26,12 @@
         </div>
       </div>
       <div class="w-full px-5 py-3 border-b border-neutral-200">
-        <SfInput v-model="searchQuery" :placeholder="getEditorTranslation('search-placeholder')" size="sm">
+        <SfInput
+          ref="searchInputRef"
+          v-model="searchQuery"
+          :placeholder="getEditorTranslation('search-placeholder')"
+          size="sm"
+        >
           <template #prefix>
             <SfIconSearch class="text-neutral-400" size="sm" />
           </template>
@@ -169,12 +174,21 @@ import {
   SfIconHelp,
   SfModal,
 } from '@storefront-ui/vue';
+import type { ComponentPublicInstance } from 'vue';
 import type { PropertyPlaceholderToken } from '~/composables/useRichTextEditor/types';
 
 const emit = defineEmits<{
   insert: [tokens: PropertyPlaceholderToken[]];
   close: [];
 }>();
+
+const searchInputRef = ref<ComponentPublicInstance | null>(null);
+
+onMounted(() => {
+  nextTick(() => {
+    searchInputRef.value?.$el?.querySelector('input')?.focus();
+  });
+});
 
 const {
   loading: isLoading,


### PR DESCRIPTION
## Issue:

Closes: AB#ID

## Describe your changes

- when opening the property modal, input will be focused
- [Notable implementation decisions]
- [Known limitations]

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
