### PR TITLE
fix: blocks can't be placed on top of the utility bar

### DIFF
--- a/apps/web/app/components/editor/GridElementsPanel/GridElementsPanel.vue
+++ b/apps/web/app/components/editor/GridElementsPanel/GridElementsPanel.vue
@@ -197,10 +197,12 @@ const onDragEnd = () => {
     setGridColumnsWidth(newWidths);
   } else {
     const content = structure.value.content as Block[] | undefined;
+    const reordered = localItems.value.map((block, index) => ({ ...block, parent_slot: index }));
+
     if (Array.isArray(content)) {
-      content.splice(0, content.length, ...localItems.value);
+      content.splice(0, content.length, ...reordered);
     } else {
-      structure.value.content = [...localItems.value];
+      structure.value.content = [...reordered];
     }
   }
 };


### PR DESCRIPTION
## Issue:

Closes: [AB#198034](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/198034)

## Describe your changes

- [What changed]
- [Notable implementation decisions]
- [Known limitations]

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
