### PR TITLE
fix: url for items without canonical property

### DIFF
--- a/apps/web/app/composables/useStructuredData/__tests__/fixtures.ts
+++ b/apps/web/app/composables/useStructuredData/__tests__/fixtures.ts
@@ -43,6 +43,19 @@ export const buildProductWithUrlPath = (path: string): Product => {
   };
 };
 
+export const buildProductWithCanonicalHref = (href: string): Product => {
+  const product = buildProduct();
+  return {
+    ...product,
+    seoSettings: {
+      canonical: {
+        href,
+        alternate: [],
+      },
+    },
+  } as unknown as Product;
+};
+
 export const buildReviewWithCounts = (total: number, average: string): Review =>
   ({
     feedbacks: [],

--- a/apps/web/app/composables/useStructuredData/__tests__/useStructuredData.spec.ts
+++ b/apps/web/app/composables/useStructuredData/__tests__/useStructuredData.spec.ts
@@ -7,6 +7,7 @@ import {
   buildProductWithItemId,
   buildProductWithVariationId,
   buildProductWithUrlPath,
+  buildProductWithCanonicalHref,
   buildReviewWithCounts,
 } from './fixtures';
 
@@ -19,7 +20,7 @@ const { useRuntimeConfigMock } = vi.hoisted(() => ({
 }));
 mockNuxtImport('useRuntimeConfig', () => useRuntimeConfigMock);
 
-const routeRef = { fullPath: '/search?term=test' };
+const routeRef = { fullPath: '/search?term=test', path: '/search' };
 const { useRouteMock } = vi.hoisted(() => ({ useRouteMock: vi.fn(() => routeRef) }));
 mockNuxtImport('useRoute', () => useRouteMock);
 
@@ -78,6 +79,22 @@ const getCapturedJsonLdRaw = (): string => {
   return '';
 };
 
+const getCapturedCanonicalHref = (): string | undefined => {
+  const calls = mockUseHead.mock.calls;
+
+  for (let i = calls.length - 1; i >= 0; i--) {
+    const call = calls[i];
+    if (!call) continue;
+
+    const arg = call[0] as { link?: { rel: string; href: string }[] };
+    const canonicalLink = arg?.link?.find((link) => link.rel === 'canonical');
+
+    if (canonicalLink) return canonicalLink.href;
+  }
+
+  return undefined;
+};
+
 describe('useStructuredData', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -88,6 +105,7 @@ describe('useStructuredData', () => {
     reviewStateRef.value = {} as Review; // NOSONAR
     reviewAverageStateRef.value = {};
     routeRef.fullPath = '/search?term=test';
+    routeRef.path = '/search';
     runtimeConfigRef.public.domain = 'https://shop.example.com';
     isSingleProductUrlSchemeEnabled.value = false;
   });
@@ -235,6 +253,19 @@ describe('useStructuredData', () => {
       const rawJsonLd = getCapturedJsonLdRaw();
       expect(rawJsonLd).not.toContain('</script>');
       expect(rawJsonLd).toContain(String.raw`\u003C/script>`);
+    });
+  });
+
+  describe('setProductCanonicalMetaData', () => {
+    it('should default the canonical href to the current URL, excluding query parameters, when canonical href is empty', () => {
+      routeRef.fullPath = '/search?term=test';
+      routeRef.path = '/search';
+
+      const { setProductCanonicalMetaData } = useStructuredData();
+      setProductCanonicalMetaData(buildProductWithCanonicalHref(''));
+
+      const canonicalHref = getCapturedCanonicalHref();
+      expect(canonicalHref).toBe('https://shop.example.com/search');
     });
   });
 });

--- a/apps/web/app/composables/useStructuredData/__tests__/useStructuredData.spec.ts
+++ b/apps/web/app/composables/useStructuredData/__tests__/useStructuredData.spec.ts
@@ -267,5 +267,16 @@ describe('useStructuredData', () => {
       const canonicalHref = getCapturedCanonicalHref();
       expect(canonicalHref).toBe('https://shop.example.com/search');
     });
+
+    it('should default the canonical href to the current URL, excluding query parameters, when canonical is missing', () => {
+      routeRef.fullPath = '/search?term=test';
+      routeRef.path = '/search';
+
+      const { setProductCanonicalMetaData } = useStructuredData();
+      setProductCanonicalMetaData(buildProduct());
+
+      const canonicalHref = getCapturedCanonicalHref();
+      expect(canonicalHref).toBe('https://shop.example.com/search');
+    });
   });
 });

--- a/apps/web/app/composables/useStructuredData/useStructuredData.ts
+++ b/apps/web/app/composables/useStructuredData/useStructuredData.ts
@@ -287,7 +287,15 @@ export const useStructuredData: useStructuredDataReturn = () => {
     const canonical = productSeoSettingsGetters.getCanonical(product);
 
     if (canonical) {
-      const canonicalUrl = applyTrailingSlashToUrl(productSeoSettingsGetters.getCanonicalHref(canonical));
+      const runtimeConfig = useRuntimeConfig();
+      const route = useRoute();
+      const localePath = useLocalePath();
+
+      const canonicalHref =
+        productSeoSettingsGetters.getCanonicalHref(canonical) ||
+        `${runtimeConfig.public.domain}${localePath(route.path)}`;
+
+      const canonicalUrl = applyTrailingSlashToUrl(canonicalHref);
       useHead({
         link: [{ rel: 'canonical', href: canonicalUrl }],
       });


### PR DESCRIPTION
## Issue:

It's possible to configure a property for setting items' canonical references. When no property is configured, the ref is empty.

## Describe your changes

- Falls back to item URL if the property isn't set or doesn't provide a canonical
- Extends test suite to cover this case

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
