### PR TITLE
feat: hide quantity selector if variation not salable

### DIFF
--- a/apps/web/app/components/ui/PurchaseCard/PurchaseCard.vue
+++ b/apps/web/app/components/ui/PurchaseCard/PurchaseCard.vue
@@ -132,6 +132,7 @@
               <div class="mt-4">
                 <div class="flex flex-col @md:flex-row flex-wrap gap-4">
                   <UiQuantitySelector
+                    v-if="productGetters.isActiveVariationSalable(product)"
                     :min-value="productGetters.getMinimumOrderQuantity(product)"
                     :value="quantitySelectorValue"
                     class="min-w-[145px] flex-grow-0 flex-shrink-0 basis-0"


### PR DESCRIPTION
## Issue:

Closes #2721 

## Describe your changes

From original PR:

> This change adds a condition to the quantity selector so that it is only displayed when the currently selected variation is salable.
> 
> - Prevents displaying quantity controls when a product cannot be added to the cart.
> - Creates a clearer distinction between the Add to Cart flow and the Notify Me flow.
> - Improves the user experience by removing irrelevant quantity selection when only the notification option is available.

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
