### PR TITLE
fix: add activation setting for last-seen tracking

### DIFF
--- a/apps/web/app/components/blocks/ProductRecommendedProducts/ProductRecommendedProducts.vue
+++ b/apps/web/app/components/blocks/ProductRecommendedProducts/ProductRecommendedProducts.vue
@@ -1,6 +1,13 @@
 <template>
   <div ref="blockRef" v-bind="$attrs">
     <TextContent data-testid="recommended-block" class="pb-4" :text="props.content.text" :index="props.index" />
+    <EditorAdmonitionWarning
+      v-if="showLastSeenTrackingHint"
+      class="m-4"
+      data-testid="recommended-last-seen-tracking-hint"
+      :title="getEditorTranslation('last-seen-hint-title')"
+      :message="getEditorTranslation('last-seen-tracking-disabled-hint')"
+    />
     <ProductSlider v-if="shouldShowSlider" :items="recommendedProducts" />
   </div>
 </template>
@@ -14,6 +21,8 @@ const props = withDefaults(defineProps<ProductRecommendedProductsProps>(), { sho
 const { locale } = useI18n();
 const { data: categoryTree } = useCategoryTree();
 const { currentProduct } = useProducts();
+const { isEditMode } = useEditorState();
+const { getSetting: isLastSeenTrackingEnabled } = useSiteSettings('enableLastSeenTracking');
 const blockRef = ref<HTMLElement | null>(null);
 const { isNearViewport } = useNearViewport(blockRef, {
   rootMargin: '200px 0px 200px 0px',
@@ -33,15 +42,22 @@ const shouldRenderAfterUpdate = ref(false);
 const { data: recommendedProducts, fetchProductRecommended } = useProductRecommended(props.meta.uuid);
 const { registerBlockVisibility } = useBlocksVisibility();
 
+const isCategory = computed(() => props.content.source?.type === 'category');
+const isProduct = computed(() => props.content.source?.type === 'cross_selling' && itemId.value);
+const isLastSeen = computed(() => props.content.source?.type === 'last_seen');
+
+const showLastSeenTrackingHint = computed(
+  () => isLastSeen.value && isEditMode.value && isLastSeenTrackingEnabled().toString() !== 'true',
+);
+
 const shouldShowSlider = computed(
   () =>
+    showLastSeenTrackingHint.value === false &&
     isNearViewport.value &&
     !!recommendedProducts.value?.length &&
     (shouldRender.value || shouldRenderAfterUpdate.value),
 );
-const isCategory = computed(() => props.content.source?.type === 'category');
-const isProduct = computed(() => props.content.source?.type === 'cross_selling' && itemId.value);
-const isLastSeen = computed(() => props.content.source?.type === 'last_seen');
+
 const shouldRender = computed(() => props.shouldLoad === undefined || props.shouldLoad === true);
 const shouldFetch = computed(() => {
   return isNearViewport.value && shouldRender.value && (isCategory.value || isProduct.value || isLastSeen.value);
@@ -86,3 +102,16 @@ watch(
   },
 );
 </script>
+
+<i18n lang="json">
+{
+  "en": {
+    "last-seen-hint-title": "Last seen products",
+    "last-seen-tracking-disabled-hint": "The \"Track last seen products\" setting is disabled. Enable it under General » Privacy so this block can show recommendations."
+  },
+  "de": {
+    "last-seen-hint-title": "Last seen products",
+    "last-seen-tracking-disabled-hint": "The \"Track last seen products\" setting is disabled. Enable it under General » Privacy so this block can show recommendations."
+  }
+}
+</i18n>

--- a/apps/web/app/components/blocks/ProductRecommendedProducts/ProductRecommendedProductsForm.vue
+++ b/apps/web/app/components/blocks/ProductRecommendedProducts/ProductRecommendedProductsForm.vue
@@ -65,22 +65,6 @@
           data-testid="recommended-form-categories"
         />
       </div>
-
-      <div
-        v-else-if="recommendedBlock.source.type === 'last_seen'"
-        class="bg-warning-200 mx-4 mt-4 mb-4 p-2 text-sm"
-        role="alert"
-        aria-live="polite"
-        data-testid="recommended-form-last-seen-hint"
-      >
-        <div class="flex items-start gap-2 mb-1">
-          <SfIconWarning class="shrink-0 text-yellow-700" aria-hidden="true" />
-          <div class="font-semibold text-neutral-800 typography-text-base">
-            {{ getEditorTranslation('last-seen-hint-title') }}
-          </div>
-        </div>
-        <div class="text-neutral-600">{{ getEditorTranslation('last-seen-hint') }}</div>
-      </div>
     </EditorFormPanel>
 
     <EditorFormPanel
@@ -95,7 +79,7 @@
 
 <script setup lang="ts">
 import type { CrossSellingRelationType, ProductRecommendedProductsContent } from '../ProductRecommendedProducts/types';
-import { SfInput, SfIconWarning } from '@storefront-ui/vue';
+import { SfInput } from '@storefront-ui/vue';
 import { useDebounceFn } from '@vueuse/core';
 import { productGetters } from '@plentymarkets/shop-api';
 import Multiselect from 'vue-multiselect';

--- a/apps/web/app/components/blocks/ProductRecommendedProducts/ProductRecommendedProductsForm.vue
+++ b/apps/web/app/components/blocks/ProductRecommendedProducts/ProductRecommendedProductsForm.vue
@@ -179,8 +179,6 @@ const { sourceTypeModel, sourceTypeOptions } = useEditorOptionsTabs(() => recomm
     "product-id-label": "Product ID",
     "product-id-placeholder": "Enter Product ID",
     "categories-label": "Categories",
-    "last-seen-hint-title": "Legal compliance",
-    "last-seen-hint": "When using this option, you may have to update your privacy policy to comply with GDPR. Products are tracked based on the customer's last seen activity and this information is temporarily stored server-side on the session. Whether legitimate interest (Art. 6(1)(f) GDPR) can serve as the legal basis shall be independently verified.",
 
     "layout-label": "Layout",
     "cross-selling-relation-label": "Cross-selling relation",
@@ -200,8 +198,6 @@ const { sourceTypeModel, sourceTypeOptions } = useEditorOptionsTabs(() => recomm
     "product-id-label": "Product ID",
     "product-id-placeholder": "Enter Product ID",
     "categories-label": "Categories",
-    "last-seen-hint-title": "Legal compliance",
-    "last-seen-hint": "When using this option, you may have to update your privacy policy to comply with GDPR. Products are tracked based on the customer's last seen activity and this information is temporarily stored server-side on the session. Whether legitimate interest (Art. 6(1)(f) GDPR) can serve as the legal basis shall be independently verified.",
 
     "cross-selling-relation-label": "Cross-selling relation",
     "cross-selling-relation-accessory": "Accessory",

--- a/apps/web/app/components/blocks/ProductRecommendedProducts/__tests__/ProductRecommendedProducts.spec.ts
+++ b/apps/web/app/components/blocks/ProductRecommendedProducts/__tests__/ProductRecommendedProducts.spec.ts
@@ -1,4 +1,5 @@
 import { mount } from '@vue/test-utils';
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import ProductRecommendedProducts from '../../../../components/blocks/ProductRecommendedProducts/ProductRecommendedProducts.vue';
 import type { ProductRecommendedProductsProps } from '../types';
 
@@ -7,6 +8,12 @@ vi.mock('@plentymarkets/shop-core', () => ({
   t: vi.fn((key: string) => key),
   useHandleError: vi.fn(),
 }));
+
+const { useEditorStateMock } = vi.hoisted(() => ({ useEditorStateMock: vi.fn() }));
+mockNuxtImport('useEditorState', () => useEditorStateMock);
+
+const { useSiteSettingsMock } = vi.hoisted(() => ({ useSiteSettingsMock: vi.fn() }));
+mockNuxtImport('useSiteSettings', () => useSiteSettingsMock);
 
 // Mock useProductRecommended to prevent async errors after test teardown
 vi.mock('~/composables/useProductRecommended/useProductRecommended', () => ({
@@ -58,9 +65,24 @@ const mockProps: ProductRecommendedProductsProps = {
   index: 0,
 };
 
+const mockLastSeenProps: ProductRecommendedProductsProps = {
+  ...mockProps,
+  content: {
+    ...mockProps.content,
+    source: {
+      type: 'last_seen',
+      categoryId: '',
+      itemId: '',
+      crossSellingRelation: 'Similar',
+    },
+  },
+};
+
 describe('ProductRecommendedProducts', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useEditorStateMock.mockReturnValue({ isEditMode: ref(false) });
+    useSiteSettingsMock.mockReturnValue({ getSetting: vi.fn().mockReturnValue('true') });
   });
 
   it('should render text content even when not visible', () => {
@@ -88,6 +110,61 @@ describe('ProductRecommendedProducts', () => {
   it('should default shouldLoad to false when not provided', () => {
     const wrapper = mount(ProductRecommendedProducts, {
       props: mockProps,
+    });
+
+    expect(wrapper.find('[data-testid="product-slider"]').exists()).toBe(false);
+  });
+
+  it('should show the last-seen tracking hint when source is last_seen, in edit mode, and tracking is disabled', () => {
+    useEditorStateMock.mockReturnValue({ isEditMode: ref(true) });
+    useSiteSettingsMock.mockReturnValue({ getSetting: vi.fn().mockReturnValue('false') });
+
+    const wrapper = mount(ProductRecommendedProducts, {
+      props: mockLastSeenProps,
+    });
+
+    expect(wrapper.find('[data-testid="recommended-last-seen-tracking-hint"]').exists()).toBe(true);
+  });
+
+  it('should not show the last-seen tracking hint when tracking is enabled', () => {
+    useEditorStateMock.mockReturnValue({ isEditMode: ref(true) });
+    useSiteSettingsMock.mockReturnValue({ getSetting: vi.fn().mockReturnValue('true') });
+
+    const wrapper = mount(ProductRecommendedProducts, {
+      props: mockLastSeenProps,
+    });
+
+    expect(wrapper.find('[data-testid="recommended-last-seen-tracking-hint"]').exists()).toBe(false);
+  });
+
+  it('should not show the last-seen tracking hint when not in edit mode', () => {
+    useEditorStateMock.mockReturnValue({ isEditMode: ref(false) });
+    useSiteSettingsMock.mockReturnValue({ getSetting: vi.fn().mockReturnValue('false') });
+
+    const wrapper = mount(ProductRecommendedProducts, {
+      props: mockLastSeenProps,
+    });
+
+    expect(wrapper.find('[data-testid="recommended-last-seen-tracking-hint"]').exists()).toBe(false);
+  });
+
+  it('should not show the last-seen tracking hint when source is not last_seen', () => {
+    useEditorStateMock.mockReturnValue({ isEditMode: ref(true) });
+    useSiteSettingsMock.mockReturnValue({ getSetting: vi.fn().mockReturnValue('false') });
+
+    const wrapper = mount(ProductRecommendedProducts, {
+      props: mockProps,
+    });
+
+    expect(wrapper.find('[data-testid="recommended-last-seen-tracking-hint"]').exists()).toBe(false);
+  });
+
+  it('should not render ProductSlider when the last-seen tracking hint is shown', () => {
+    useEditorStateMock.mockReturnValue({ isEditMode: ref(true) });
+    useSiteSettingsMock.mockReturnValue({ getSetting: vi.fn().mockReturnValue('false') });
+
+    const wrapper = mount(ProductRecommendedProducts, {
+      props: mockLastSeenProps,
     });
 
     expect(wrapper.find('[data-testid="product-slider"]').exists()).toBe(false);

--- a/apps/web/app/components/editor/AdmonitionWarning/AdmonitionWarning.vue
+++ b/apps/web/app/components/editor/AdmonitionWarning/AdmonitionWarning.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="bg-warning-200 p-2" role="alert" aria-live="polite">
+    <div class="flex items-start gap-2 mb-1">
+      <SfIconWarning class="shrink-0 text-yellow-700" aria-hidden="true" />
+      <div class="font-semibold text-neutral-800 typography-text-base">{{ title }}</div>
+    </div>
+    <div class="text-neutral-600 typography-text-sm">{{ message }}</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { SfIconWarning } from '@storefront-ui/vue';
+import type { AdmonitionWarningProps } from './types';
+
+defineProps<AdmonitionWarningProps>();
+</script>

--- a/apps/web/app/components/editor/AdmonitionWarning/types.ts
+++ b/apps/web/app/components/editor/AdmonitionWarning/types.ts
@@ -1,0 +1,4 @@
+export interface AdmonitionWarningProps {
+  title: string;
+  message: string;
+}

--- a/apps/web/app/components/settings/general/privacy/1.last-seen-tracking/EnableLastSeenTracking.vue
+++ b/apps/web/app/components/settings/general/privacy/1.last-seen-tracking/EnableLastSeenTracking.vue
@@ -1,0 +1,49 @@
+<template>
+  <div class="py-2">
+    <p class="mb-4">{{ getEditorTranslation('description') }}</p>
+
+    <EditorAdmonitionWarning
+      class="my-4"
+      data-testid="recommended-last-seen-tracking-hint"
+      :title="getEditorTranslation('hint-title')"
+      :message="getEditorTranslation('hint')"
+    />
+
+    <div class="flex justify-between mb-2">
+      <UiFormLabel class="mb-1">
+        {{ getEditorTranslation('label') }}
+      </UiFormLabel>
+      <SfSwitch
+        v-model="enableLastSeenTracking"
+        class="checked:bg-editor-button checked:before:hover:bg-editor-button checked:border-gray-500 checked:hover:border:bg-gray-700 hover:border-gray-700 hover:before:bg-gray-700 checked:hover:bg-gray-300 checked:hover:border-gray-400"
+      />
+    </div>
+  </div>
+</template>
+<script setup lang="ts">
+import { SfSwitch } from '@storefront-ui/vue';
+
+const { updateSetting, getSetting } = useSiteSettings('enableLastSeenTracking');
+
+const enableLastSeenTracking = computed({
+  get: () => getSetting().toString() === 'true',
+  set: (value) => updateSetting(value.toString()),
+});
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "label": "Track last seen products",
+    "description": "Track products a customer has recently viewed so they can be shown as recommendations in the corresponding product recommendation source.",
+    "hint": "When enabled, products are tracked based on the customer's last seen activity and this information is temporarily stored server-side on the session. Enabling this setting may require updates to the website's privacy policy. Whether legitimate interest (Art. 6(1)(f) GDPR) can serve as the legal basis shall be independently verified.",
+    "hint-title": "Legal compliance"
+  },
+  "de": {
+    "label": "Track last seen products",
+    "description": "Track products a customer has recently viewed so they can be shown as recommendations in the corresponding product recommendation source.",
+    "hint": "When enabled, products are tracked based on the customer's last seen activity and this information is temporarily stored server-side on the session. Enabling this setting may require updates to the website's privacy policy. Whether legitimate interest (Art. 6(1)(f) GDPR) can serve as the legal basis shall be independently verified.",
+    "hint-title": "Legal compliance"
+  }
+}
+</i18n>

--- a/apps/web/app/components/settings/general/privacy/1.last-seen-tracking/EnableLastSeenTracking.vue
+++ b/apps/web/app/components/settings/general/privacy/1.last-seen-tracking/EnableLastSeenTracking.vue
@@ -4,7 +4,7 @@
 
     <EditorAdmonitionWarning
       class="my-4"
-      data-testid="recommended-last-seen-tracking-hint"
+      data-testid="privacy-last-seen-tracking-legal-hint"
       :title="getEditorTranslation('hint-title')"
       :message="getEditorTranslation('hint')"
     />

--- a/apps/web/app/components/settings/general/privacy/View.vue
+++ b/apps/web/app/components/settings/general/privacy/View.vue
@@ -1,0 +1,28 @@
+<template>
+  <SiteConfigurationView>
+    <template #setting-title>{{ getEditorTranslation('groups-title') }}</template>
+
+    <template #setting-description>
+      <div class="flex flex-col px-4 text-sm">
+        <p class="pb-2">
+          <span class="align-middle font-bold">{{ getEditorTranslation('description') }}</span>
+        </p>
+      </div>
+    </template>
+  </SiteConfigurationView>
+</template>
+
+<script setup lang="ts"></script>
+
+<i18n lang="json">
+{
+  "en": {
+    "groups-title": "Privacy",
+    "description": "Configure settings related to customer data tracking and privacy compliance."
+  },
+  "de": {
+    "groups-title": "Privacy",
+    "description": "Configure settings related to customer data tracking and privacy compliance."
+  }
+}
+</i18n>

--- a/apps/web/app/composables/useLastSeen/useLastSeen.ts
+++ b/apps/web/app/composables/useLastSeen/useLastSeen.ts
@@ -25,8 +25,10 @@ export const useLastSeen = () => {
    *
    * @param product - The product to add to the last seen list
    */
+  const { getSetting: isLastSeenTrackingEnabled } = useSiteSettings('enableLastSeenTracking');
+
   const addLastSeen = (product: Product) => {
-    if (import.meta.client) {
+    if (import.meta.client && isLastSeenTrackingEnabled().toString() === 'true') {
       try {
         useSdk().plentysystems.doAddLastSeen(productGetters.getVariationId(product));
       } catch {

--- a/apps/web/app/configuration/settings.config.ts
+++ b/apps/web/app/configuration/settings.config.ts
@@ -123,4 +123,5 @@ export default {
   customAssetsSafeMode: process.env.NUXT_PUBLIC_CUSTOM_ASSETS_SAFE_MODE === 'true',
   enableSingleProductUrlScheme: process.env.NUXT_PUBLIC_ENABLE_SINGLE_PRODUCT_URL_SCHEME === 'true',
   enableOrderChangePaymentMethod: process.env.NUXT_PUBLIC_ENABLE_ORDER_CHANGE_PAYMENT_METHOD !== 'false',
+  enableLastSeenTracking: process.env.NUXT_PUBLIC_ENABLE_LAST_SEEN_TRACKING === 'true',
 };

--- a/apps/web/app/utils/editorTranslations.de.json
+++ b/apps/web/app/utils/editorTranslations.de.json
@@ -33,6 +33,7 @@
   "performance": "Performance",
   "contact-form": "Contact Form",
   "shipping-information-page": "Shipping information page",
+  "privacy": "Privacy",
   "filter.prices.price_asc": "Price ⬆",
   "filter.prices.price_desc": "Price ⬇",
   "filter.position_asc": "Position ⬆",

--- a/apps/web/app/utils/editorTranslations.en.json
+++ b/apps/web/app/utils/editorTranslations.en.json
@@ -33,6 +33,7 @@
   "performance": "Performance",
   "contact-form": "Contact Form",
   "shipping-information-page": "Shipping information page",
+  "privacy": "Privacy",
   "filter.prices.price_asc": "Price ⬆",
   "filter.prices.price_desc": "Price ⬇",
   "filter.position_asc": "Position ⬆",


### PR DESCRIPTION
## Issue:

Follow-up to #2746 

## Describe your changes

- Adds a site setting that controls whether or not products get added to the session
- Updates the flow of legal hints to point users to the setting and displays the hint there
- Adds a utility component to display warnings in the editor in a consistent way

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
