### PR TITLE
chore: enable search results page sorting

### DIFF
--- a/apps/web/app/components/settings/search/ToolbarTrigger.vue
+++ b/apps/web/app/components/settings/search/ToolbarTrigger.vue
@@ -1,6 +1,5 @@
 <template>
   <SfTooltip
-    v-if="isShopSearchEnabled"
     :label="getEditorTranslation('tooltip')"
     placement="right"
     class="inline-grid font-editor"
@@ -25,9 +24,6 @@ import { SfIconSearch, SfTooltip } from '@storefront-ui/vue';
 defineProps({
   active: Boolean,
 });
-
-const runtimeConfig = useRuntimeConfig();
-const isShopSearchEnabled = ref(!runtimeConfig.public.disabledEditorSettings.includes('shop-search'));
 </script>
 
 <i18n lang="json">

--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -97,7 +97,7 @@ export default defineNuxtConfig({
       domain: validateApiUrl(process.env.API_URL) ?? process.env.API_ENDPOINT,
       apiEndpoint: process.env.API_ENDPOINT,
       activeLanguages: process.env.LANGUAGELIST || 'en,de',
-      disabledEditorSettings: process.env?.ENABLE_ALL_EDITOR_SETTINGS === '1' ? [] : ['shop-search'],
+      disabledEditorSettings: process.env?.ENABLE_ALL_EDITOR_SETTINGS === '1' ? [] : [],
       cookieGroups: cookieConfig,
       turnstileSiteKey: process.env?.CLOUDFLARETURNSTILEAPISITEKEY ?? '',
       noCache: process.env.NO_CACHE || '',


### PR DESCRIPTION
## Issue:

Enables a setting that controls the sorting of products on the search results page.

Important: This does not include the sorting of products in the search suggestions. The search suggestions API does not support a sorting parameter at the moment.

## Describe your changes

- Removes shop search from disabled setting properties
- Removes check from component
- Retains Nuxt config, even though it's empty now, for future use

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
