### PR TITLE
feat: add custom code warnings to editors

### DIFF
--- a/apps/web/app/components/editor/CustomCodeHints/CustomCodeHints.vue
+++ b/apps/web/app/components/editor/CustomCodeHints/CustomCodeHints.vue
@@ -1,0 +1,39 @@
+<template>
+  <output
+    v-if="hints.length"
+    data-testid="custom-code-hints"
+    class="my-2 rounded-md border border-blue-300 bg-blue-50 p-3 text-sm text-blue-800 block"
+  >
+    <div class="font-semibold">{{ getEditorTranslation('custom-code-hint-title') }}</div>
+    <ul class="list-disc ml-5 mt-1">
+      <li v-for="(hint, idx) in hints" :key="idx">
+        {{ getEditorTranslation(hint.message) }}
+      </li>
+    </ul>
+  </output>
+</template>
+
+<script setup lang="ts">
+import { detectCustomCode } from '~/composables/useHtmlEditorMode/helpers/detectCustomCode';
+
+const props = defineProps<{
+  content: string;
+}>();
+
+const hints = computed(() => detectCustomCode(props.content));
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "custom-code-hint-title": "💡 Tip",
+    "customCodeHint.cssDetected": "CSS detected. For better maintainability, consider creating a Custom CSS snippet instead.",
+    "customCodeHint.jsDetected": "JavaScript detected. For better maintainability, consider creating a Custom JavaScript snippet instead."
+  },
+  "de": {
+    "custom-code-hint-title": "💡 Tip",
+    "customCodeHint.cssDetected": "CSS detected. For better maintainability, consider creating a Custom CSS snippet instead.",
+    "customCodeHint.jsDetected": "JavaScript detected. For better maintainability, consider creating a Custom JavaScript snippet instead."
+  }
+}
+</i18n>

--- a/apps/web/app/components/editor/CustomCodeHints/__tests__/CustomCodeHints.spec.ts
+++ b/apps/web/app/components/editor/CustomCodeHints/__tests__/CustomCodeHints.spec.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import CustomCodeHints from '../CustomCodeHints.vue';
+
+const { getEditorTranslationMock } = vi.hoisted(() => ({
+  getEditorTranslationMock: vi.fn((key: string) => key),
+}));
+
+mockNuxtImport('getEditorTranslation', () => getEditorTranslationMock);
 
 describe('CustomCodeHints', () => {
   it('should not render when content has no custom code', () => {
@@ -34,7 +41,7 @@ describe('CustomCodeHints', () => {
     });
 
     const output = wrapper.find('[data-testid="custom-code-hints"]');
-    expect(output.text()).toContain('CSS detected');
+    expect(output.text()).toContain('customCodeHint.cssDetected');
   });
 
   it('should display JS hint when script tag is present', () => {
@@ -45,7 +52,7 @@ describe('CustomCodeHints', () => {
     });
 
     const output = wrapper.find('[data-testid="custom-code-hints"]');
-    expect(output.text()).toContain('JavaScript detected');
+    expect(output.text()).toContain('customCodeHint.jsDetected');
   });
 
   it('should display multiple hints', () => {
@@ -56,8 +63,8 @@ describe('CustomCodeHints', () => {
     });
 
     const output = wrapper.find('[data-testid="custom-code-hints"]');
-    expect(output.text()).toContain('CSS detected');
-    expect(output.text()).toContain('JavaScript detected');
+    expect(output.text()).toContain('customCodeHint.cssDetected');
+    expect(output.text()).toContain('customCodeHint.jsDetected');
   });
 
   it('should have correct styling classes', () => {

--- a/apps/web/app/components/editor/CustomCodeHints/__tests__/CustomCodeHints.spec.ts
+++ b/apps/web/app/components/editor/CustomCodeHints/__tests__/CustomCodeHints.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import CustomCodeHints from '../CustomCodeHints.vue';
+
+describe('CustomCodeHints', () => {
+  it('should not render when content has no custom code', () => {
+    const wrapper = mount(CustomCodeHints, {
+      props: {
+        content: '<div>Hello World</div>',
+      },
+    });
+
+    expect(wrapper.find('[data-testid="custom-code-hints"]').exists()).toBe(false);
+  });
+
+  it('should render with consistent styling', () => {
+    const wrapper = mount(CustomCodeHints, {
+      props: {
+        content: '<style>.test { color: red; }</style>',
+      },
+    });
+
+    const output = wrapper.find('[data-testid="custom-code-hints"]');
+    expect(output.exists()).toBe(true);
+    expect(output.classes()).toContain('my-2');
+    expect(output.classes()).toContain('rounded-md');
+  });
+
+  it('should display CSS hint when style tag is present', () => {
+    const wrapper = mount(CustomCodeHints, {
+      props: {
+        content: '<style>.test { color: red; }</style><div>Content</div>',
+      },
+    });
+
+    const output = wrapper.find('[data-testid="custom-code-hints"]');
+    expect(output.text()).toContain('CSS detected');
+  });
+
+  it('should display JS hint when script tag is present', () => {
+    const wrapper = mount(CustomCodeHints, {
+      props: {
+        content: '<script>console.log("test");</script><div>Content</div>',
+      },
+    });
+
+    const output = wrapper.find('[data-testid="custom-code-hints"]');
+    expect(output.text()).toContain('JavaScript detected');
+  });
+
+  it('should display multiple hints', () => {
+    const wrapper = mount(CustomCodeHints, {
+      props: {
+        content: '<style>.test { color: red; }</style><script>console.log("test");</script>',
+      },
+    });
+
+    const output = wrapper.find('[data-testid="custom-code-hints"]');
+    expect(output.text()).toContain('CSS detected');
+    expect(output.text()).toContain('JavaScript detected');
+  });
+
+  it('should have correct styling classes', () => {
+    const wrapper = mount(CustomCodeHints, {
+      props: {
+        content: '<style>.test { color: red; }</style>',
+      },
+    });
+
+    const output = wrapper.find('[data-testid="custom-code-hints"]');
+    expect(output.classes()).toContain('border');
+    expect(output.classes()).toContain('border-blue-300');
+    expect(output.classes()).toContain('bg-blue-50');
+    expect(output.classes()).toContain('text-blue-800');
+    expect(output.classes()).toContain('block');
+  });
+});

--- a/apps/web/app/components/editor/HtmlEditor/HtmlEditor.vue
+++ b/apps/web/app/components/editor/HtmlEditor/HtmlEditor.vue
@@ -48,6 +48,8 @@
           </ul>
         </div>
 
+        <EditorCustomCodeHints :content="localValue" />
+
         <main class="flex-1 overflow-hidden flex flex-col">
           <div class="flex-1 overflow-y-auto">
             <SfTextarea

--- a/apps/web/app/components/editor/RichTextEditor/RichTextEditor.vue
+++ b/apps/web/app/components/editor/RichTextEditor/RichTextEditor.vue
@@ -90,6 +90,8 @@
     >
       <EditorContent :editor="editor" :style="editorStyle" class="rte__content rte-prose" />
     </div>
+
+    <EditorCustomCodeHints :content="modelValue" />
   </div>
 
   <EditorRichTextEditorRichtextEditorModal
@@ -117,6 +119,7 @@
     :text-color="textColor"
     :toggle-link="toggleLink"
     :undo="undo"
+    :content="modelValue"
     @close="closeModal"
     @switch-to-html="handleSwitchToHtml"
   />

--- a/apps/web/app/components/editor/RichTextEditor/RichTextEditorForm.vue
+++ b/apps/web/app/components/editor/RichTextEditor/RichTextEditorForm.vue
@@ -57,6 +57,8 @@
           <li v-for="(e, idx) in htmlErrors.slice(0, 3)" :key="idx">{{ e }}</li>
         </ul>
       </div>
+
+      <EditorCustomCodeHints :content="htmlDraft" />
     </div>
 
     <EditorHtmlEditor

--- a/apps/web/app/components/editor/RichTextEditor/RichtextEditorModal.vue
+++ b/apps/web/app/components/editor/RichTextEditor/RichtextEditorModal.vue
@@ -49,12 +49,16 @@
             />
           </div>
 
-          <div
-            class="flex-1 overflow-y-auto p-2.5 editor-parent bg-white cursor-text border border-gray-300 rounded-md"
-            data-testid="rte-modal-editor"
-            @mousedown="editor?.chain().focus().run()"
-          >
-            <EditorContent :editor="editor" class="rte__content rte-prose h-full" :style="editorStyle" />
+          <EditorCustomCodeHints :content="content" />
+
+          <div class="flex-1 overflow-y-auto">
+            <div
+              class="p-2.5 editor-parent bg-white cursor-text border border-gray-300 rounded-md"
+              data-testid="rte-modal-editor"
+              @mousedown="editor?.chain().focus().run()"
+            >
+              <EditorContent :editor="editor" class="rte__content rte-prose h-full" :style="editorStyle" />
+            </div>
           </div>
         </main>
       </div>
@@ -68,34 +72,42 @@ import type { RteCommand } from '~/composables/useRichTextEditor/types';
 import { EditorContent } from '@tiptap/vue-3';
 import { SfIconClose } from '@storefront-ui/vue';
 
-defineProps<{
-  editor: Editor | undefined;
-  editorStyle?: {
-    textAlign: globalThis.RteAlign;
-    minHeight: string;
-  };
-  cmd: (name: RteCommand) => void;
-  isActive: (name: string) => boolean;
-  currentBlockType: RteBlockType;
-  onFontSizeChange: (value: string) => void;
-  textColor: string;
-  highlightColor: string;
-  currentFontSize: string;
-  setFontSize: (value: string) => void;
-  setFontColor: (color: string) => void;
-  setHighlightColor: (color: string) => void;
-  setAlign: (align: RteAlign) => void;
-  isActiveAlign: (align: RteAlign) => boolean;
-  canUndo: boolean;
-  canRedo: boolean;
-  undo: () => void;
-  redo: () => void;
-  toggleLink: () => void;
-  clearFormatting: () => void;
-  insertIcon: (name: string) => void;
-  insertEmoji: (name: string) => void;
-  onOpenI18nModal?: () => void;
-}>();
+withDefaults(
+  defineProps<{
+    editor: Editor | undefined;
+    editorStyle?: {
+      textAlign: globalThis.RteAlign;
+      minHeight: string;
+    };
+    cmd: (name: RteCommand) => void;
+    isActive: (name: string) => boolean;
+    currentBlockType: RteBlockType;
+    onFontSizeChange: (value: string) => void;
+    textColor: string;
+    highlightColor: string;
+    currentFontSize: string;
+    setFontSize: (value: string) => void;
+    setFontColor: (color: string) => void;
+    setHighlightColor: (color: string) => void;
+    setAlign: (align: RteAlign) => void;
+    isActiveAlign: (align: RteAlign) => boolean;
+    canUndo: boolean;
+    canRedo: boolean;
+    undo: () => void;
+    redo: () => void;
+    toggleLink: () => void;
+    clearFormatting: () => void;
+    insertIcon: (name: string) => void;
+    insertEmoji: (name: string) => void;
+    onOpenI18nModal?: () => void;
+    content?: string;
+  }>(),
+  {
+    editorStyle: undefined,
+    onOpenI18nModal: undefined,
+    content: '',
+  },
+);
 
 const emit = defineEmits<{
   (e: 'close' | 'switch-to-html'): void;

--- a/apps/web/app/composables/useHtmlEditorMode/__tests__/useHtmlEditorMode.spec.ts
+++ b/apps/web/app/composables/useHtmlEditorMode/__tests__/useHtmlEditorMode.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { useHtmlEditorMode } from '../useHtmlEditorMode';
+
+describe('useHtmlEditorMode', () => {
+  it('should initialize with default values', () => {
+    const content = ref('<div>Hello</div>');
+    const { editorMode, htmlErrors, customCodeHints } = useHtmlEditorMode(content);
+
+    expect(editorMode.value).toBe('wysiwyg');
+    expect(htmlErrors.value).toEqual([]);
+    expect(customCodeHints.value).toEqual([]);
+  });
+
+  it('should detect custom CSS when switching to HTML mode', () => {
+    const content = ref('<style>.test { color: red; }</style><div>Hello</div>');
+    const { customCodeHints, switchToHtmlMode } = useHtmlEditorMode(content);
+
+    switchToHtmlMode();
+
+    expect(customCodeHints.value).toHaveLength(1);
+    expect(customCodeHints.value[0]).toEqual({
+      type: 'css',
+      message: 'customCodeHint.cssDetected',
+    });
+  });
+
+  it('should detect custom JavaScript when switching to HTML mode', () => {
+    const content = ref('<script>console.log("test");</script><div>Hello</div>');
+    const { customCodeHints, switchToHtmlMode } = useHtmlEditorMode(content);
+
+    switchToHtmlMode();
+
+    expect(customCodeHints.value).toHaveLength(1);
+    expect(customCodeHints.value[0]).toEqual({
+      type: 'js',
+      message: 'customCodeHint.jsDetected',
+    });
+  });
+
+  it('should detect both CSS and JS', () => {
+    const content = ref('<style>.test { color: red; }</style><script>console.log("test");</script>');
+    const { customCodeHints, switchToHtmlMode } = useHtmlEditorMode(content);
+
+    switchToHtmlMode();
+
+    expect(customCodeHints.value).toHaveLength(2);
+  });
+
+  it('should detect hints in initial content', () => {
+    const content = ref('<div>Hello</div>');
+    const { customCodeHints, switchToHtmlMode } = useHtmlEditorMode(content);
+
+    expect(customCodeHints.value).toHaveLength(0);
+
+    content.value = '<style>.test { color: red; }</style>';
+    switchToHtmlMode();
+
+    expect(customCodeHints.value).toHaveLength(1);
+  });
+
+  it('should update ariaDescribedBy when hints are present', () => {
+    const content = ref('<style>.test { color: red; }</style>');
+    const { ariaDescribedBy, switchToHtmlMode } = useHtmlEditorMode(content);
+
+    switchToHtmlMode();
+
+    expect(ariaDescribedBy.value).toContain('html-editor-hints');
+  });
+
+  it('should include both errors and hints in ariaDescribedBy', () => {
+    const content = ref('<style>.test { color: red; }</style><div>');
+    const { ariaDescribedBy, switchToHtmlMode } = useHtmlEditorMode(content);
+
+    switchToHtmlMode();
+
+    expect(ariaDescribedBy.value).toContain('html-editor-errors');
+    expect(ariaDescribedBy.value).toContain('html-editor-hints');
+  });
+});

--- a/apps/web/app/composables/useHtmlEditorMode/helpers/__tests__/detectCustomCode.spec.ts
+++ b/apps/web/app/composables/useHtmlEditorMode/helpers/__tests__/detectCustomCode.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { detectCustomCode } from '../detectCustomCode';
+
+describe('detectCustomCode', () => {
+  it('should return empty array for empty content', () => {
+    const hints = detectCustomCode('');
+    expect(hints).toEqual([]);
+  });
+
+  it('should return empty array for content without style or script tags', () => {
+    const html = '<div>Hello World</div><p>Test</p>';
+    const hints = detectCustomCode(html);
+    expect(hints).toEqual([]);
+  });
+
+  it('should detect style tag', () => {
+    const html = '<style>.test { color: red; }</style><div>Content</div>';
+    const hints = detectCustomCode(html);
+    expect(hints).toHaveLength(1);
+    expect(hints[0]).toEqual({
+      type: 'css',
+      message: 'customCodeHint.cssDetected',
+    });
+  });
+
+  it('should detect script tag', () => {
+    const html = '<script>console.log("test");</script><div>Content</div>';
+    const hints = detectCustomCode(html);
+    expect(hints).toHaveLength(1);
+    expect(hints[0]).toEqual({
+      type: 'js',
+      message: 'customCodeHint.jsDetected',
+    });
+  });
+
+  it('should detect both style and script tags', () => {
+    const html = '<style>.test { color: red; }</style><script>console.log("test");</script>';
+    const hints = detectCustomCode(html);
+    expect(hints).toHaveLength(2);
+    expect(hints[0]).toEqual({
+      type: 'css',
+      message: 'customCodeHint.cssDetected',
+    });
+    expect(hints[1]).toEqual({
+      type: 'js',
+      message: 'customCodeHint.jsDetected',
+    });
+  });
+
+  it('should be case-insensitive', () => {
+    const html = '<STYLE>.test { color: red; }</STYLE><SCRIPT>console.log("test");</SCRIPT>';
+    const hints = detectCustomCode(html);
+    expect(hints).toHaveLength(2);
+  });
+
+  it('should detect style tag with attributes', () => {
+    const html = '<style type="text/css" media="screen">.test { color: red; }</style>';
+    const hints = detectCustomCode(html);
+    expect(hints).toHaveLength(1);
+    expect(hints[0]?.type).toBe('css');
+  });
+
+  it('should detect script tag with attributes', () => {
+    const html = '<script type="text/javascript" async>console.log("test");</script>';
+    const hints = detectCustomCode(html);
+    expect(hints).toHaveLength(1);
+    expect(hints[0]?.type).toBe('js');
+  });
+
+  it('should not detect style or script in text content', () => {
+    const html = '<div>This text mentions style and script tags</div>';
+    const hints = detectCustomCode(html);
+    expect(hints).toEqual([]);
+  });
+
+  it('should handle multiple style and script tags', () => {
+    const html = `
+      <style>.a { color: red; }</style>
+      <style>.b { color: blue; }</style>
+      <script>console.log("test1");</script>
+      <script>console.log("test2");</script>
+    `;
+    const hints = detectCustomCode(html);
+    expect(hints).toHaveLength(2);
+  });
+
+  it('should handle newlines and complex HTML', () => {
+    const html = `
+      <div>
+        <style>
+          .test { color: red; }
+        </style>
+        <p>Some content</p>
+        <script>
+          console.log("test");
+        </script>
+      </div>
+    `;
+    const hints = detectCustomCode(html);
+    expect(hints).toHaveLength(2);
+  });
+});

--- a/apps/web/app/composables/useHtmlEditorMode/helpers/detectCustomCode.ts
+++ b/apps/web/app/composables/useHtmlEditorMode/helpers/detectCustomCode.ts
@@ -1,0 +1,37 @@
+import type { CustomCodeHint } from '../types';
+
+/**
+ * Detects custom CSS and JavaScript in HTML content
+ * and returns hints about the custom code settings.
+ *
+ * Detects <style> and <script> tags in HTML content.
+ * Returns informational hints if found.
+ */
+export function detectCustomCode(htmlContent: string): CustomCodeHint[] {
+  const hints: CustomCodeHint[] = [];
+  const trimmedContent = (htmlContent ?? '').trim();
+
+  if (!trimmedContent) {
+    return hints;
+  }
+
+  const lowerContent = trimmedContent.toLowerCase();
+  const hasStyleTag = /<style[\s>]/i.test(lowerContent);
+  const hasScriptTag = /<script[\s>]/i.test(lowerContent);
+
+  if (hasStyleTag) {
+    hints.push({
+      type: 'css',
+      message: 'customCodeHint.cssDetected',
+    });
+  }
+
+  if (hasScriptTag) {
+    hints.push({
+      type: 'js',
+      message: 'customCodeHint.jsDetected',
+    });
+  }
+
+  return hints;
+}

--- a/apps/web/app/composables/useHtmlEditorMode/types.ts
+++ b/apps/web/app/composables/useHtmlEditorMode/types.ts
@@ -10,3 +10,8 @@ export type HtmlToken =
   | { kind: 'tag'; tagName: string; attributesSource: string; isClosing: boolean; isSelfClosing: boolean };
 
 export type QuoteState = 'none' | 'single' | 'double';
+
+export type CustomCodeHint = {
+  type: 'css' | 'js';
+  message: string;
+};

--- a/apps/web/app/composables/useHtmlEditorMode/useHtmlEditorMode.ts
+++ b/apps/web/app/composables/useHtmlEditorMode/useHtmlEditorMode.ts
@@ -1,5 +1,6 @@
-import type { EditorMode, UseHtmlEditorModeOptions } from './types';
+import type { EditorMode, UseHtmlEditorModeOptions, CustomCodeHint } from './types';
 import { validateHtmlSyntax } from './helpers/validations';
+import { detectCustomCode } from './helpers/detectCustomCode';
 
 export function useHtmlEditorMode(contentModel: Ref<string>, options: UseHtmlEditorModeOptions = {}) {
   const { defaultMode = 'wysiwyg', commitOnValid = true, maxErrors = 5 } = options;
@@ -7,12 +8,25 @@ export function useHtmlEditorMode(contentModel: Ref<string>, options: UseHtmlEdi
   const editorMode = ref<EditorMode>(defaultMode);
   const htmlDraft = ref(contentModel.value ?? '');
   const htmlErrors = ref<string[]>([]);
+  const customCodeHints = ref<CustomCodeHint[]>([]);
 
-  const ariaDescribedBy = computed(() => (htmlErrors.value.length ? 'html-editor-errors' : undefined));
+  const ariaDescribedBy = computed(() => {
+    const parts: string[] = [];
+    if (htmlErrors.value.length) {
+      parts.push('html-editor-errors');
+    }
+    if (customCodeHints.value.length) {
+      parts.push('html-editor-hints');
+    }
+    return parts.length ? parts.join(' ') : undefined;
+  });
 
   const validateAndCommitIfAllowed = (nextDraft: string) => {
     const nextErrors = validateHtmlSyntax(nextDraft, maxErrors);
     htmlErrors.value = nextErrors;
+
+    const hints = detectCustomCode(nextDraft);
+    customCodeHints.value = hints;
 
     if (!commitOnValid) return;
     if (nextErrors.length) return;
@@ -31,6 +45,7 @@ export function useHtmlEditorMode(contentModel: Ref<string>, options: UseHtmlEdi
 
     if (!commitOnValid) {
       htmlErrors.value = validateHtmlSyntax(htmlDraft.value, maxErrors);
+      customCodeHints.value = detectCustomCode(htmlDraft.value);
       if (!htmlErrors.value.length) {
         contentModel.value = htmlDraft.value;
       }
@@ -70,6 +85,7 @@ export function useHtmlEditorMode(contentModel: Ref<string>, options: UseHtmlEdi
     editorMode,
     htmlDraft,
     htmlErrors,
+    customCodeHints,
     ariaDescribedBy,
     validateHtmlSyntax: (html: string) => validateHtmlSyntax(html, maxErrors),
     switchToHtmlMode,


### PR DESCRIPTION
## Issue:

Some users seem to be unaware of the Custom CSS/JS code snippets. This leads them to entering styles and scripts directly inside the rich-text editor. TipTap isn't built for this and may parse sections differently as a result. In addition, this approach also makes it more difficult for support to analyse issues because unlike code snippets, these inline sections can not be disabled.

## Describe your changes

- Adds a hint to the rich-text editor that points the user to Custom CSS/JS code snippets when they insert `style` or `script` sections in the rich-text editor

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

<img width="304" height="557" alt="image" src="https://github.com/user-attachments/assets/f3119cbe-8f65-4a83-b1ff-e555f7c219d2" />

<img width="1414" height="349" alt="image" src="https://github.com/user-attachments/assets/84753b99-cf0e-4779-ad63-71266a2990ab" />
