### PR TITLE
fix: disable empty selection in session lifetime setting

### DIFF
--- a/apps/web/app/components/settings/general/security/session-and-url-lifetime/SessionLifetime.vue
+++ b/apps/web/app/components/settings/general/security/session-and-url-lifetime/SessionLifetime.vue
@@ -23,7 +23,7 @@
       class="cursor-pointer"
       select-label=""
       :deselect-label="getEditorTranslation('deselect-label')"
-      :allow-empty="true"
+      :allow-empty="false"
     />
   </div>
 </template>


### PR DESCRIPTION
## Issue:

Closes: [AB#201968](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/201968)

## Describe your changes

- Disables empty value for session lifetime

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
