### PR TITLE
feat: add variation number option to price cards

### DIFF
--- a/apps/web/app/components/blocks/PriceCard/PriceCardForm.vue
+++ b/apps/web/app/components/blocks/PriceCard/PriceCardForm.vue
@@ -238,6 +238,7 @@ priceCardBlock.value.fields['itemBundle'] = getSetting() !== '1';
 
 const fieldLabels: Record<PriceCardFieldKey, string> = {
   itemName: getEditorTranslation('field-itemName'),
+  variationNumber: getEditorTranslation('field-variationNumber'),
   price: getEditorTranslation('field-price'),
   tags: getEditorTranslation('field-tags'),
   availability: getEditorTranslation('field-availability'),
@@ -326,6 +327,7 @@ const { wishlistSizeModel, wishlistSizeOptions } = useEditorOptionsTabs(
     "padding-label": "Padding (px)",
 
     "field-itemName": "Item name",
+    "field-variationNumber": "Variation number",
     "field-price": "Price",
     "field-tags": "Tags",
     "field-availability": "Availability",
@@ -383,6 +385,7 @@ const { wishlistSizeModel, wishlistSizeOptions } = useEditorOptionsTabs(
     "padding-label": "Padding (px)",
 
     "field-itemName": "Item name",
+    "field-variationNumber": "Variation number",
     "field-price": "Price",
     "field-tags": "Tags",
     "field-availability": "Availability",

--- a/apps/web/app/components/blocks/PriceCard/__tests__/PriceCardForm.spec.ts
+++ b/apps/web/app/components/blocks/PriceCard/__tests__/PriceCardForm.spec.ts
@@ -30,6 +30,7 @@ mockNuxtImport('useEditorOptionsTabs', () => () => ({
 const createContent = (): PriceCardContent => ({
   fields: {
     itemName: true,
+    variationNumber: false,
     price: true,
     tags: false,
     availability: false,
@@ -46,7 +47,7 @@ const createContent = (): PriceCardContent => ({
     guaranteeLabel: false,
     technicalData: false,
   },
-  fieldsOrder: ['itemName', 'price'] as PriceCardOrderItem[],
+  fieldsOrder: ['itemName', 'variationNumber', 'price'] as PriceCardOrderItem[],
   fieldsDisabled: [],
   wishlistSize: 'small',
   dropShadow: false,
@@ -141,8 +142,8 @@ describe('PriceCardForm', () => {
 
       await wrapper.getByTestId('actions-add-text-block-button').trigger('click');
 
-      expect(content.fieldsOrder).toHaveLength(3);
-      const added = content.fieldsOrder[2] as PriceCardTextBlockItem;
+      expect(content.fieldsOrder).toHaveLength(4);
+      const added = content.fieldsOrder[3] as PriceCardTextBlockItem;
       expect(added.type).toBe('textBlock');
       expect(added.uuid).toBe('test-uuid-123');
       expect(added.content).toBe('');
@@ -221,7 +222,7 @@ describe('PriceCardForm', () => {
 
       await wrapper.getByTestId('price-card-delete-textblock-tb-uuid-1').trigger('click');
 
-      expect(content.fieldsOrder).toHaveLength(2);
+      expect(content.fieldsOrder).toHaveLength(3);
       expect(findTextBlock(content.fieldsOrder, 'tb-uuid-1')).toBeUndefined();
     });
 
@@ -249,6 +250,21 @@ describe('PriceCardForm', () => {
 
       const textBlock = findTextBlock(content.fieldsOrder, 'tb-uuid-1');
       expect(textBlock?.visible).toBe(false);
+    });
+  });
+
+  describe('variation number field', () => {
+    it('should render the variation number field row', () => {
+      const wrapper = mountForm();
+      expect(wrapper.getByTestId('price-card-field-variationNumber')).toBeTruthy();
+    });
+
+    it('should update fields.variationNumber when the switch is toggled', async () => {
+      const wrapper = mountForm();
+
+      await wrapper.getByTestId('price-card-visible-variationNumber').trigger('click');
+
+      expect(content.fields.variationNumber).toBe(true);
     });
   });
 

--- a/apps/web/app/components/blocks/PriceCard/defaults.ts
+++ b/apps/web/app/components/blocks/PriceCard/defaults.ts
@@ -19,6 +19,7 @@ const blocksList = {
             content: {
               fields: {
                 itemName: true,
+                variationNumber: false,
                 price: true,
                 tags: true,
                 availability: true,
@@ -37,6 +38,7 @@ const blocksList = {
               },
               fieldsOrder: [
                 'itemName',
+                'variationNumber',
                 'price',
                 'tags',
                 'availability',
@@ -77,6 +79,7 @@ const blocksList = {
             content: {
               fields: {
                 itemName: true,
+                variationNumber: false,
                 price: true,
                 tags: true,
                 availability: true,
@@ -95,6 +98,7 @@ const blocksList = {
               },
               fieldsOrder: [
                 'itemName',
+                'variationNumber',
                 'price',
                 'tags',
                 'availability',

--- a/apps/web/app/components/ui/PurchaseCard/PurchaseCard.vue
+++ b/apps/web/app/components/ui/PurchaseCard/PurchaseCard.vue
@@ -23,6 +23,15 @@
                 {{ productGetters.getName(product) }}
               </h1>
             </template>
+            <template v-if="key === 'variationNumber' && configuration?.fields.variationNumber">
+              <p
+                v-if="productGetters.getVariationNumber(product)"
+                class="mb-2 typography-text-sm text-neutral-500"
+                data-testid="product-variation-number"
+              >
+                {{ productGetters.getVariationNumber(product) }}
+              </p>
+            </template>
             <template v-if="key === 'price' && configuration?.fields.price">
               <div class="flex space-x-2">
                 <Price :crossed-price="crossedPrice" :price="priceWithProperties" />
@@ -242,6 +251,7 @@ const props = withDefaults(defineProps<PurchaseCardProps>(), {
   configuration: () => ({
     fields: {
       itemName: true,
+      variationNumber: false,
       price: true,
       tags: true,
       availability: true,
@@ -260,6 +270,7 @@ const props = withDefaults(defineProps<PurchaseCardProps>(), {
     },
     fieldsOrder: [
       'itemName',
+      'variationNumber',
       'price',
       'tags',
       'availability',

--- a/apps/web/app/components/ui/PurchaseCard/__tests__/PurchaseCard.spec.ts
+++ b/apps/web/app/components/ui/PurchaseCard/__tests__/PurchaseCard.spec.ts
@@ -58,6 +58,7 @@ const createTextBlock = (overrides?: Partial<PriceCardTextBlockItem>): PriceCard
 const createConfiguration = (extraFields: Partial<PriceCardContent> = {}): PriceCardContent => ({
   fields: {
     itemName: false,
+    variationNumber: false,
     price: false,
     tags: false,
     availability: false,
@@ -201,6 +202,37 @@ describe('<PurchaseCard />', () => {
       });
 
       expect(wrapper.find('[data-uuid="my-text-block"]').exists()).toBe(true);
+    });
+  });
+
+  describe('variation number rendering', () => {
+    it('should render the variation number when the field is enabled', () => {
+      const wrapper = mount(UiPurchaseCard, {
+        props: {
+          product: ProductMock,
+          configuration: createConfiguration({
+            fields: { ...createConfiguration().fields, variationNumber: true },
+            fieldsOrder: ['variationNumber'] as PriceCardOrderItem[],
+          }),
+        },
+        global: { stubs: globalStubs },
+      });
+
+      const rendered = wrapper.find('[data-testid="product-variation-number"]');
+      expect(rendered.exists()).toBe(true);
+      expect(rendered.text()).toBe('1145');
+    });
+
+    it('should not render the variation number when the field is disabled', () => {
+      const wrapper = mount(UiPurchaseCard, {
+        props: {
+          product: ProductMock,
+          configuration: createConfiguration({ fieldsOrder: ['variationNumber'] as PriceCardOrderItem[] }),
+        },
+        global: { stubs: globalStubs },
+      });
+
+      expect(wrapper.find('[data-testid="product-variation-number"]').exists()).toBe(false);
     });
   });
 });

--- a/apps/web/app/components/ui/PurchaseCard/types.ts
+++ b/apps/web/app/components/ui/PurchaseCard/types.ts
@@ -11,6 +11,7 @@ export type PriceCardOrderItem = PriceCardFieldKey | PriceCardTextBlockItem;
 
 export type PriceCardFieldKey =
   | 'itemName'
+  | 'variationNumber'
   | 'price'
   | 'tags'
   | 'availability'

--- a/apps/web/app/utils/facets/fakeProductDE.ts
+++ b/apps/web/app/utils/facets/fakeProductDE.ts
@@ -174,6 +174,7 @@ export const fakeProductDE = {
     availabilityUpdatedAt: '2018-02-28T11:49:53+01:00',
     externalId: '54321',
     model: 'Testmodel',
+    number: '1000.1',
   },
   filter: {
     isSalable: true,

--- a/apps/web/app/utils/facets/fakeProductEN.ts
+++ b/apps/web/app/utils/facets/fakeProductEN.ts
@@ -174,6 +174,7 @@ export const fakeProductEN = {
     availabilityUpdatedAt: '2018-02-28T11:49:53+01:00',
     externalId: '54321',
     model: 'Testmodel',
+    number: '1000.1',
   },
   filter: {
     isSalable: true,

--- a/apps/web/app/utils/migrate-blocks.ts
+++ b/apps/web/app/utils/migrate-blocks.ts
@@ -112,7 +112,11 @@ const migratePriceCardBlock = (block: Block): void => {
     }
     if (!content.fieldsOrder.includes('variationNumber')) {
       const itemNameIndex = content.fieldsOrder.indexOf('itemName');
-      content.fieldsOrder.splice(itemNameIndex + 1, 0, 'variationNumber');
+      if (itemNameIndex >= 0) {
+        content.fieldsOrder.splice(itemNameIndex + 1, 0, 'variationNumber');
+      } else {
+        content.fieldsOrder.push('variationNumber');
+      }
     }
   }
 };

--- a/apps/web/app/utils/migrate-blocks.ts
+++ b/apps/web/app/utils/migrate-blocks.ts
@@ -106,6 +106,14 @@ const migratePriceCardBlock = (block: Block): void => {
     if (!content.fieldsOrder.includes('guaranteeLabel')) {
       content.fieldsOrder.push('guaranteeLabel');
     }
+
+    if (fields['variationNumber'] === undefined) {
+      fields['variationNumber'] = false;
+    }
+    if (!content.fieldsOrder.includes('variationNumber')) {
+      const itemNameIndex = content.fieldsOrder.indexOf('itemName');
+      content.fieldsOrder.splice(itemNameIndex + 1, 0, 'variationNumber');
+    }
   }
 };
 


### PR DESCRIPTION
## Issue:

The variation number isn't accessible in the Price Card.

## Describe your changes

- Adds variation number as configurable field.
- Adds tests.

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
