### PR TITLE
feat: add image picker option to update all sizes

### DIFF
--- a/apps/web/app/components/blocks/Banner/BannerForm.vue
+++ b/apps/web/app/components/blocks/Banner/BannerForm.vue
@@ -6,19 +6,11 @@
         :title="getEditorTranslation('images-group-label')"
         data-testid="slider-image-group-title"
       >
-        <div class="images">
-          <UiImagePicker
-            v-for="type in imageTypes"
-            :key="type"
-            :label="labels[type]"
-            :image="banner.content.image[type]"
-            :placeholder="placeholderImg"
-            :dimensions="imageDimensions[type]"
-            :selected-image-type="type"
-            @add="(payload) => handleImageAddBanner(payload)"
-            @delete="deleteImage(banner.content.image, type)"
-          />
-        </div>
+        <UiResponsiveImagePicker
+          :image="banner.content.image"
+          @add="handleImageAddBanner"
+          @delete="handleImageDeleteBanner"
+        />
 
         <div class="mb-6">
           <label for="banner-brightness" class="block text-sm font-medium mb-4">Brightness</label>
@@ -210,12 +202,16 @@
 import { clamp } from '@storefront-ui/shared';
 import { SfInput, SfSwitch } from '@storefront-ui/vue';
 import type { BannerFormProps, BannerProps } from './types';
+import type {
+  ResponsiveImagePickerAddPayload,
+  ResponsiveImagePickerDeletePayload,
+} from '~/components/ui/ResponsiveImagePicker/types';
 
 const { blockUuid } = useSiteConfiguration();
 const { activeSlideIndex } = useCarousel();
 const { allBlocks: data } = useBlocks();
 const { findOrDeleteBlockByUuid } = useBlockManager();
-const { placeholderImg, labels, imageDimensions, imageTypes, deleteImage } = usePickerHelper();
+const { imageTypes, deleteImage } = usePickerHelper();
 
 const props = defineProps<BannerFormProps>();
 
@@ -240,9 +236,16 @@ const clampBrightness = (event: Event, type: string) => {
   }
 };
 
-const handleImageAddBanner = ({ image, type }: { image: string; type: string }) => {
-  const { handleImageAdd } = useImageAdd(banner.value?.content?.image);
-  handleImageAdd({ image, type });
+const handleImageAddBanner = ({ image, type, applyToAllSizes }: ResponsiveImagePickerAddPayload) => {
+  const targets = applyToAllSizes ? imageTypes : [type];
+  targets.forEach((sizeType) => {
+    banner.value.content.image[sizeType] = image;
+  });
+};
+
+const handleImageDeleteBanner = ({ type, applyToAllSizes }: ResponsiveImagePickerDeletePayload) => {
+  const targets = applyToAllSizes ? imageTypes : [type];
+  targets.forEach((sizeType) => deleteImage(banner.value.content.image, sizeType));
 };
 const {
   textboxAlignXModel,

--- a/apps/web/app/components/blocks/Image/ImageForm.vue
+++ b/apps/web/app/components/blocks/Image/ImageForm.vue
@@ -4,19 +4,7 @@
     :title="getEditorTranslation('images-group-label')"
     data-testid="image-group"
   >
-    <div class="images">
-      <UiImagePicker
-        v-for="type in imageTypes"
-        :key="type"
-        :label="labels[type]"
-        :image="uiImageTextBlock.image[type]"
-        :placeholder="placeholderImg"
-        :dimensions="imageDimensions[type]"
-        :selected-image-type="type"
-        @add="(payload) => handleImageAddWrapper(payload)"
-        @delete="deleteImage(uiImageTextBlock.image, type)"
-      />
-    </div>
+    <UiResponsiveImagePicker :image="uiImageTextBlock.image" @add="handleImageAddWrapper" @delete="handleImageDelete" />
 
     <div class="py-2">
       <div class="flex justify-between mb-2">
@@ -281,11 +269,15 @@ import {
   SfIconInfo,
 } from '@storefront-ui/vue';
 
-import type { ImageFormProps, ImageTypeKey } from './types';
+import type { ImageFormProps } from './types';
 import type { ImageContent } from '~/components/blocks/Image/types';
+import type {
+  ResponsiveImagePickerAddPayload,
+  ResponsiveImagePickerDeletePayload,
+} from '~/components/ui/ResponsiveImagePicker/types';
 import { clamp } from '@storefront-ui/shared';
 
-const { placeholderImg, labels, imageDimensions, imageTypes, deleteImage } = usePickerHelper();
+const { imageTypes, deleteImage } = usePickerHelper();
 const { allBlocks: data } = useBlocks();
 
 const { blockUuid } = useSiteConfiguration();
@@ -365,10 +357,19 @@ const fillTooltip =
 
 const paddingTooltip = 'Padding is only available in Fit mode.';
 
-const handleImageAddWrapper = ({ image, type }: { image: string; type: string }) => {
-  if (uiImageTextBlock.value.image && ['wideScreen', 'desktop', 'tablet', 'mobile'].includes(type)) {
-    uiImageTextBlock.value.image[type as ImageTypeKey] = image;
+const handleImageAddWrapper = ({ image, type, applyToAllSizes }: ResponsiveImagePickerAddPayload) => {
+  if (!uiImageTextBlock.value.image) {
+    return;
   }
+  const targets = applyToAllSizes ? imageTypes : [type];
+  targets.forEach((sizeType) => {
+    uiImageTextBlock.value.image[sizeType] = image;
+  });
+};
+
+const handleImageDelete = ({ type, applyToAllSizes }: ResponsiveImagePickerDeletePayload) => {
+  const targets = applyToAllSizes ? imageTypes : [type];
+  targets.forEach((sizeType) => deleteImage(uiImageTextBlock.value.image, sizeType));
 };
 
 const clampBrightness = (event: Event, type: string) => {

--- a/apps/web/app/components/ui/ResponsiveImagePicker/ResponsiveImagePicker.vue
+++ b/apps/web/app/components/ui/ResponsiveImagePicker/ResponsiveImagePicker.vue
@@ -1,0 +1,72 @@
+<template>
+  <div class="py-2 flex items-center justify-between gap-3">
+    <UiFormLabel for="configure-individually" class="m-0">
+      {{ getEditorTranslation('configure-individually-label') }}
+    </UiFormLabel>
+    <SfSwitch
+      id="configure-individually"
+      v-model="configureIndividually"
+      data-testid="switch-configure-individually"
+      class="checked:bg-editor-button checked:before:hover:bg-editor-button checked:border-gray-500 checked:hover:border:bg-gray-700 hover:border-gray-700 hover:before:bg-gray-700 checked:hover:bg-gray-300 checked:hover:border-gray-400"
+    />
+  </div>
+
+  <div class="images">
+    <UiImagePicker
+      v-if="!configureIndividually"
+      :label="getEditorTranslation('image-label')"
+      :image="image.wideScreen"
+      :placeholder="placeholderImg"
+      :dimensions="imageDimensions.wideScreen"
+      selected-image-type="wideScreen"
+      @add="(payload) => emit('add', { ...payload, type: 'wideScreen', applyToAllSizes: true })"
+      @delete="emit('delete', { type: 'wideScreen', applyToAllSizes: true })"
+    />
+
+    <template v-else>
+      <UiImagePicker
+        v-for="type in imageTypes"
+        :key="type"
+        :label="labels[type]"
+        :image="image[type]"
+        :placeholder="placeholderImg"
+        :dimensions="imageDimensions[type]"
+        :selected-image-type="type"
+        @add="(payload) => emit('add', { image: payload.image, name: payload.name, type, applyToAllSizes: false })"
+        @delete="emit('delete', { type, applyToAllSizes: false })"
+      />
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { SfSwitch } from '@storefront-ui/vue';
+import type {
+  ResponsiveImagePickerProps,
+  ResponsiveImagePickerAddPayload,
+  ResponsiveImagePickerDeletePayload,
+} from './types';
+
+defineProps<ResponsiveImagePickerProps>();
+const emit = defineEmits<{
+  (e: 'add', payload: ResponsiveImagePickerAddPayload): void;
+  (e: 'delete', payload: ResponsiveImagePickerDeletePayload): void;
+}>();
+
+const { placeholderImg, labels, imageDimensions, imageTypes } = usePickerHelper();
+
+const configureIndividually = useState('responsive-image-picker-configure-individually', () => false);
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "configure-individually-label": "Configure screen sizes individually",
+    "image-label": "Image"
+  },
+  "de": {
+    "configure-individually-label": "Bildschirmgrößen einzeln konfigurieren",
+    "image-label": "Bild"
+  }
+}
+</i18n>

--- a/apps/web/app/components/ui/ResponsiveImagePicker/ResponsiveImagePicker.vue
+++ b/apps/web/app/components/ui/ResponsiveImagePicker/ResponsiveImagePicker.vue
@@ -11,6 +11,17 @@
     />
   </div>
 
+  <div
+    v-if="hasMissingSizes"
+    class="flex items-start gap-2 pb-2 text-sm text-neutral-600"
+    role="alert"
+    aria-live="polite"
+    data-testid="mismatched-sizes-hint"
+  >
+    <SfIconWarning class="mt-0.5 shrink-0 text-yellow-500" aria-hidden="true" />
+    <span class="italic">{{ getEditorTranslation('mismatched-sizes-hint') }}</span>
+  </div>
+
   <div class="images">
     <UiImagePicker
       v-if="!configureIndividually"
@@ -40,14 +51,14 @@
 </template>
 
 <script setup lang="ts">
-import { SfSwitch } from '@storefront-ui/vue';
+import { SfSwitch, SfIconWarning } from '@storefront-ui/vue';
 import type {
   ResponsiveImagePickerProps,
   ResponsiveImagePickerAddPayload,
   ResponsiveImagePickerDeletePayload,
 } from './types';
 
-defineProps<ResponsiveImagePickerProps>();
+const props = defineProps<ResponsiveImagePickerProps>();
 const emit = defineEmits<{
   (e: 'add', payload: ResponsiveImagePickerAddPayload): void;
   (e: 'delete', payload: ResponsiveImagePickerDeletePayload): void;
@@ -56,17 +67,31 @@ const emit = defineEmits<{
 const { placeholderImg, labels, imageDimensions, imageTypes } = usePickerHelper();
 
 const configureIndividually = useState('responsive-image-picker-configure-individually', () => false);
+
+const PLACEHOLDER_IMAGE_FILENAME = 'placeholder-image.png';
+
+const isEmptySize = (value?: string) => !value || value.endsWith(PLACEHOLDER_IMAGE_FILENAME);
+
+const hasMissingSizes = computed(() => {
+  if (configureIndividually.value) {
+    return false;
+  }
+  const emptySizesCount = imageTypes.filter((type) => isEmptySize(props.image[type])).length;
+  return emptySizesCount > 0 && emptySizesCount < imageTypes.length;
+});
 </script>
 
 <i18n lang="json">
 {
   "en": {
     "configure-individually-label": "Configure screen sizes individually",
-    "image-label": "Image"
+    "image-label": "Image",
+    "mismatched-sizes-hint": "Some screen sizes still miss an image. Enable individual configuration to review them."
   },
   "de": {
-    "configure-individually-label": "Bildschirmgrößen einzeln konfigurieren",
-    "image-label": "Bild"
+    "configure-individually-label": "Configure screen sizes individually",
+    "image-label": "Image",
+    "mismatched-sizes-hint": "Some screen sizes still miss an image. Enable individual configuration to review them."
   }
 }
 </i18n>

--- a/apps/web/app/components/ui/ResponsiveImagePicker/types.ts
+++ b/apps/web/app/components/ui/ResponsiveImagePicker/types.ts
@@ -1,0 +1,17 @@
+import type { ImageType } from '~/composables/usePickerHelper/types';
+
+export interface ResponsiveImagePickerProps {
+  image: Partial<Record<ImageType, string>>;
+}
+
+export interface ResponsiveImagePickerAddPayload {
+  image: string;
+  name: string;
+  type: ImageType;
+  applyToAllSizes: boolean;
+}
+
+export interface ResponsiveImagePickerDeletePayload {
+  type: ImageType;
+  applyToAllSizes: boolean;
+}


### PR DESCRIPTION
## Issue:

Users often misconfigure image blocks by not placing images in all sizes.

## Describe your changes

- Displays a single image input by default, which is applied to all sizes in the background.
- Adds a toggle for switching back to the old view. The toggle state persists across blocks in the same session.

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
