### PR TITLE
feat: add undo/redo history for block edits

### DIFF
--- a/apps/web/app/app.vue
+++ b/apps/web/app/app.vue
@@ -97,6 +97,7 @@ const route = useRoute();
 const { disableActions } = useEditor();
 const { siteConfigurationDrawerOpen, blocksConfigurationDrawerOpen, currentFont } = useSiteConfiguration();
 const { drawerOpen, entityKey, resetForCurrentEntity } = useBlockSnapshots();
+const { resetHistory } = useBlockHistory();
 const { setStaticPageMeta } = useUrlPageMeta();
 const { isInEditorClient, isMobilePreview, previewWidth } = useEditorState();
 
@@ -281,6 +282,10 @@ if (import.meta.client) {
     if (drawerOpen.value) {
       resetForCurrentEntity();
     }
+  });
+
+  watch(entityKey, () => {
+    resetHistory();
   });
 }
 

--- a/apps/web/app/components/ui/Toolbar/Toolbar.vue
+++ b/apps/web/app/components/ui/Toolbar/Toolbar.vue
@@ -12,6 +12,28 @@
         <UiToolbarDeviceToggle />
       </div>
       <div class="ml-auto flex space-x-2">
+        <SfTooltip :label="getEditorTranslation('undo')" placement="bottom" :show-arrow="true">
+          <button
+            class="text-editor-button w-8 h-8 rounded-md flex items-center justify-center xl:w-auto xl:h-auto xl:px-1 xl:py-2 disabled:opacity-40 disabled:cursor-not-allowed"
+            data-testid="edit-undo-button"
+            :aria-label="getEditorTranslation('undo')"
+            :disabled="!canUndo"
+            @click="undo"
+          >
+            <SfIconUndo />
+          </button>
+        </SfTooltip>
+        <SfTooltip :label="getEditorTranslation('redo')" placement="bottom" :show-arrow="true">
+          <button
+            class="text-editor-button w-8 h-8 rounded-md flex items-center justify-center xl:w-auto xl:h-auto xl:px-1 xl:py-2 disabled:opacity-40 disabled:cursor-not-allowed"
+            data-testid="edit-redo-button"
+            :aria-label="getEditorTranslation('redo')"
+            :disabled="!canRedo"
+            @click="redo"
+          >
+            <SfIconUndo class="-scale-x-100" />
+          </button>
+        </SfTooltip>
         <button
           class="self-start w-8 h-8 rounded-md font-inter font-medium text-sm leading-5 flex items-center justify-center xl:w-auto xl:h-auto xl:px-4 xl:py-2 xl:text-base xl:leading-6"
           :class="historyDrawerOpen ? 'bg-editor-button/10 text-editor-button' : 'text-editor-button'"
@@ -76,7 +98,7 @@
 </template>
 
 <script setup lang="ts">
-import { SfLoaderCircular, SfIconBase, SfIconVisibility, SfTooltip } from '@storefront-ui/vue';
+import { SfLoaderCircular, SfIconBase, SfIconVisibility, SfIconUndo, SfTooltip } from '@storefront-ui/vue';
 import { editPath } from '~/assets/icons/paths/edit';
 import { savePath } from '~/assets/icons/paths/save';
 import historyBlack from '~/assets/icons/paths/history-black.svg';
@@ -88,6 +110,7 @@ const { hasChanges: localizationHasChanges } = useEditorLocalizationKeys();
 const { isEditing, isEditingEnabled, disableActions } = useEditor();
 
 const { data, cleanData, loading, isSettling } = useBlocks();
+const { canUndo, canRedo, undo, redo } = useBlockHistory();
 
 const { closeDrawer } = useSiteConfiguration();
 const { settingsIsDirty, loading: settingsLoading } = useSiteSettings();
@@ -129,13 +152,17 @@ watch(
     "save-changes": "Save changes",
     "preview": "Preview",
     "edit": "Edit",
-    "history": "History"
+    "history": "History",
+    "undo": "Undo",
+    "redo": "Redo"
   },
   "de": {
     "save-changes": "Save changes",
     "preview": "Preview",
     "edit": "Edit",
-    "history": "History"
+    "history": "History",
+    "undo": "Undo",
+    "redo": "Redo"
   }
 }
 </i18n>

--- a/apps/web/app/composables/index.ts
+++ b/apps/web/app/composables/index.ts
@@ -107,6 +107,7 @@ export * from './useCustomAssets';
 export * from './useItemDataTable';
 export * from './useBlockClasses';
 export * from './useBlockSnapshots';
+export * from './useBlockHistory';
 export * from './useCallisto';
 export * from './useCancellationForm';
 export * from './useLogEvent';

--- a/apps/web/app/composables/useBlockHistory/__tests__/useBlockHistory.spec.ts
+++ b/apps/web/app/composables/useBlockHistory/__tests__/useBlockHistory.spec.ts
@@ -1,0 +1,131 @@
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
+import type { GetBlocksResponse } from '@plentymarkets/shop-api';
+
+const { useBlocks } = vi.hoisted(() => ({
+  useBlocks: vi.fn(),
+}));
+
+mockNuxtImport('useBlocks', () => useBlocks);
+
+const emptyResponse = (): GetBlocksResponse => ({ blocks: [] }) as unknown as GetBlocksResponse;
+
+const withBlock = (title: string): GetBlocksResponse =>
+  ({
+    blocks: [{ name: 'TextCard', type: 'content', meta: { uuid: 'a' }, content: { title } }],
+  }) as unknown as GetBlocksResponse;
+
+describe('useBlockHistory', () => {
+  let data: Ref<GetBlocksResponse>;
+  let restoreBlocks: ReturnType<typeof vi.fn>;
+
+  const importUseBlockHistory = async () => {
+    const mod = await import('../useBlockHistory');
+    return mod.useBlockHistory();
+  };
+
+  const commitChange = async (value: GetBlocksResponse) => {
+    data.value = value;
+    await nextTick();
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetModules();
+
+    data = ref(emptyResponse());
+    restoreBlocks = vi.fn((value: GetBlocksResponse) => {
+      data.value = value;
+    });
+    useBlocks.mockReturnValue({ data, restoreBlocks });
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it('should report canUndo and canRedo as false when nothing has changed yet', async () => {
+    const { canUndo, canRedo } = await importUseBlockHistory();
+
+    expect(canUndo.value).toBe(false);
+    expect(canRedo.value).toBe(false);
+  });
+
+  it('should enable canUndo once a change is committed', async () => {
+    const { canUndo } = await importUseBlockHistory();
+
+    await commitChange(withBlock('first'));
+
+    expect(canUndo.value).toBe(true);
+  });
+
+  it('should restore the previous snapshot when undo is called', async () => {
+    const { canUndo, undo } = await importUseBlockHistory();
+
+    await commitChange(withBlock('first'));
+    expect(canUndo.value).toBe(true);
+
+    undo();
+
+    expect(data.value).toEqual(emptyResponse());
+    expect(restoreBlocks).toHaveBeenCalledWith(emptyResponse());
+  });
+
+  it('should enable canRedo after an undo, and restore the undone state when redo is called', async () => {
+    const { canRedo, undo, redo } = await importUseBlockHistory();
+
+    await commitChange(withBlock('first'));
+    undo();
+    expect(canRedo.value).toBe(true);
+
+    redo();
+
+    expect(data.value).toEqual(withBlock('first'));
+  });
+
+  it('should not resurrect a stale pending snapshot after resetHistory is called', async () => {
+    const { undo, resetHistory } = await importUseBlockHistory();
+
+    // Commits immediately (leading edge of the throttle window).
+    await commitChange(withBlock('page-one-edit'));
+
+    // Within the throttle window — this commit is only scheduled, not yet applied.
+    data.value = withBlock('page-one-edit-pending');
+    await nextTick();
+
+    // Simulate navigating to a new page: blocks are replaced, then history is reset.
+    const newPageData = withBlock('page-two-loaded');
+    data.value = newPageData;
+    await nextTick();
+    resetHistory();
+
+    // Let the still-pending throttled commit from before the reset fire.
+    vi.advanceTimersByTime(1000);
+    await nextTick();
+
+    undo();
+
+    // Undo must not bring back page-one's stale data onto page two.
+    expect(data.value).toEqual(newPageData);
+  });
+
+  it('should cap the undo stack at the configured capacity', async () => {
+    const { canUndo, undo } = await importUseBlockHistory();
+    const capacity = 50;
+
+    for (let i = 0; i < capacity + 5; i++) {
+      data.value = withBlock(`edit-${i}`);
+      await nextTick();
+      vi.advanceTimersByTime(900);
+      await nextTick();
+    }
+
+    let undoCount = 0;
+    while (canUndo.value) {
+      undo();
+      undoCount++;
+    }
+
+    expect(undoCount).toBe(capacity);
+  });
+});

--- a/apps/web/app/composables/useBlockHistory/index.ts
+++ b/apps/web/app/composables/useBlockHistory/index.ts
@@ -1,0 +1,2 @@
+export * from './useBlockHistory';
+export * from './types';

--- a/apps/web/app/composables/useBlockHistory/types.ts
+++ b/apps/web/app/composables/useBlockHistory/types.ts
@@ -1,0 +1,9 @@
+export interface UseBlockHistory {
+  canUndo: Readonly<Ref<boolean>>;
+  canRedo: Readonly<Ref<boolean>>;
+  undo: () => void;
+  redo: () => void;
+  resetHistory: () => void;
+}
+
+export type UseBlockHistoryReturn = () => UseBlockHistory;

--- a/apps/web/app/composables/useBlockHistory/useBlockHistory.ts
+++ b/apps/web/app/composables/useBlockHistory/useBlockHistory.ts
@@ -1,0 +1,71 @@
+import { useThrottledRefHistory } from '@vueuse/core';
+import type { GetBlocksResponse } from '@plentymarkets/shop-api';
+import type { UseBlockHistory, UseBlockHistoryReturn } from './types';
+
+const HISTORY_THROTTLE_MS = 800;
+const HISTORY_CAPACITY = 50;
+
+let instance: UseBlockHistory | null = null;
+
+const createInertHistory = (): UseBlockHistory => ({
+  canUndo: computed(() => false),
+  canRedo: computed(() => false),
+  undo: () => {},
+  redo: () => {},
+  resetHistory: () => {},
+});
+
+const createBlockHistory = (): UseBlockHistory => {
+  const { data, restoreBlocks } = useBlocks();
+
+  const trackedData = computed({
+    get: () => data.value,
+    set: (value: GetBlocksResponse) => restoreBlocks(value),
+  });
+
+  const history = useThrottledRefHistory(trackedData, {
+    deep: true,
+    throttle: HISTORY_THROTTLE_MS,
+    capacity: HISTORY_CAPACITY,
+    clone: deepClone,
+  });
+
+  /**
+   * @description
+   * Resets the block edit history, including the internal baseline snapshot.
+   *
+   * @remarks
+   * `clear()` only empties the undo/redo stacks, not the internal `last` baseline.
+   * Without re-stamping it, a throttled commit still pending from the page we just
+   * navigated away from could later land on the new page's stack.
+   */
+  const resetHistory = () => {
+    history.clear();
+    history.last.value = { snapshot: deepClone(data.value), timestamp: Date.now() };
+  };
+
+  return {
+    canUndo: history.canUndo,
+    canRedo: history.canRedo,
+    undo: history.undo,
+    redo: history.redo,
+    resetHistory,
+  };
+};
+
+/**
+ * Client-side, session-scoped undo/redo for block edits on the current page.
+ * Tracks only `useBlocks().data` (never site settings) and is reset whenever
+ * the merchant navigates to a different page.
+ */
+export const useBlockHistory: UseBlockHistoryReturn = () => {
+  if (!import.meta.client) {
+    return createInertHistory();
+  }
+
+  if (!instance) {
+    instance = createBlockHistory();
+  }
+
+  return instance;
+};


### PR DESCRIPTION
## Issue:

It's not possible to quickly revert changes unless the user saves many snapshots in the history.

## Describe your changes

- Adds Undo/Redo buttons to the editor toolbar.

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
