### PR TITLE
Modules disabling prototype - PWA demo 

### DIFF
--- a/apps/web/app/components/CountdownBanner/CountdownBanner.vue
+++ b/apps/web/app/components/CountdownBanner/CountdownBanner.vue
@@ -1,0 +1,30 @@
+<template>
+  <div :class="['bg-red-600 text-white transition-opacity', !enabled && 'opacity-50']">
+    <div class="flex items-center justify-between px-8 py-6">
+      <div>
+        <p class="text-sm font-medium uppercase tracking-widest">
+          Limited time offer<span v-if="!enabled"> — paused</span>
+        </p>
+        <p class="mt-1 font-mono text-4xl font-bold tabular-nums">
+          {{ pad(hours) }}h&nbsp;{{ pad(minutes) }}m&nbsp;{{ pad(seconds) }}s
+        </p>
+      </div>
+      <button
+        class="rounded-md border border-white px-4 py-2 text-sm font-medium transition-colors hover:bg-white hover:text-red-600"
+        @click="reset"
+      >
+        Reset offer
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// useCountdown is auto-imported from the module via addImportsDir.
+// The composable watches useExtensionEnabled internally:
+//   - extension enabled  → timer runs, v-if shows the banner
+//   - extension disabled → timer pauses, v-if hides the banner
+const { hours, minutes, seconds, reset, enabled } = useCountdown();
+
+const pad = (n: number) => String(n).padStart(2, '0');
+</script>

--- a/apps/web/app/components/SettingsToolbar/SettingsToolbar.vue
+++ b/apps/web/app/components/SettingsToolbar/SettingsToolbar.vue
@@ -49,7 +49,7 @@
       </SfTooltip>
       <component
         :is="trigger.component"
-        v-for="trigger in triggersModules"
+        v-for="trigger in filteredTriggers"
         :key="trigger.slug"
         :active="activeSetting === trigger.slug"
         @click="trigger.slug !== activeSetting && setActiveSetting(trigger.slug)"
@@ -73,6 +73,7 @@ const {
   setActiveSetting,
 } = useSiteConfiguration();
 const { drawerOpen: localizationDrawerOpen } = useEditorLocalizationKeys();
+const filteredTriggers = computed(() => getTriggersModules());
 
 const pagesLabel = 'Page and category management: create, update, and organize your content.';
 const localizationLabel = 'Localization settings: manage languages, translations, and regional preferences.';

--- a/apps/web/app/components/settings/modules/ToolbarTrigger.vue
+++ b/apps/web/app/components/settings/modules/ToolbarTrigger.vue
@@ -1,0 +1,36 @@
+<template>
+  <SfTooltip
+    :label="getEditorTranslation('tooltip')"
+    placement="right"
+    class="inline-grid font-editor"
+    :show-arrow="true"
+  >
+    <button
+      type="button"
+      class="editor-button relative py-2 flex justify-center"
+      :class="{ 'bg-editor-button text-white rounded-md': active }"
+      aria-label="Open modules settings drawer"
+      data-testid="open-modules-settings-drawer"
+    >
+      <NuxtImg v-if="active" width="24" height="24px" :src="layersWhite" />
+      <NuxtImg v-else width="24" height="24px" :src="layersBlack" />
+    </button>
+  </SfTooltip>
+</template>
+
+<script setup lang="ts">
+import { SfTooltip } from '@storefront-ui/vue';
+import layersWhite from '~/assets/icons/paths/layers-white.svg';
+import layersBlack from '~/assets/icons/paths/layers-black.svg';
+
+defineProps({
+  active: Boolean,
+});
+</script>
+
+<i18n lang="json">
+{
+  "en": { "tooltip": "Modules: Enable or disable installed modules." },
+  "de": { "tooltip": "Module: Installierte Module aktivieren oder deaktivieren." }
+}
+</i18n>

--- a/apps/web/app/components/settings/modules/View.vue
+++ b/apps/web/app/components/settings/modules/View.vue
@@ -1,0 +1,25 @@
+<template>
+  <SiteConfigurationView>
+    <template #setting-title>{{ getEditorTranslation('title') }}</template>
+    <template #setting-description>
+      <div class="flex flex-col px-4 text-sm">
+        <p class="pb-2">{{ getEditorTranslation('description') }}</p>
+      </div>
+    </template>
+  </SiteConfigurationView>
+</template>
+
+<script setup lang="ts"></script>
+
+<i18n lang="json">
+{
+  "en": {
+    "title": "Modules",
+    "description": "Enable or disable installed modules. Changes take effect immediately without a server restart."
+  },
+  "de": {
+    "title": "Module",
+    "description": "Installierte Module aktivieren oder deaktivieren. Änderungen werden sofort ohne Serverneustart wirksam."
+  }
+}
+</i18n>

--- a/apps/web/app/components/settings/modules/extensions/1.module-list/ModuleToggles.vue
+++ b/apps/web/app/components/settings/modules/extensions/1.module-list/ModuleToggles.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="py-2">
+    <div v-if="loading && !modules.length" class="text-sm text-gray-400 px-1">
+      {{ getEditorTranslation('loading') }}
+    </div>
+    <div v-else-if="!modules.length" class="text-sm text-gray-400 px-1">
+      {{ getEditorTranslation('empty') }}
+    </div>
+    <div v-else class="flex flex-col gap-3">
+      <div
+        v-for="mod in modules"
+        :key="mod.id"
+        class="flex items-center justify-between"
+      >
+        <div class="flex flex-col">
+          <span class="text-sm font-medium">{{ mod.id }}</span>
+          <span v-if="mod.version" class="text-xs text-gray-400">v{{ mod.version }}</span>
+        </div>
+        <SfSwitch
+          :model-value="mod.enabled !== false"
+          :disabled="loading"
+          class="checked:bg-editor-button checked:before:hover:bg-editor-button checked:border-gray-500 checked:hover:border:bg-gray-700 hover:border-gray-700 hover:before:bg-gray-700 checked:hover:bg-gray-300 checked:hover:border-gray-400"
+          @update:model-value="(val) => handleToggle(mod.id, val === true)"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { SfSwitch } from '@storefront-ui/vue';
+
+const { modules, loading, fetchModules, toggleModule } = useModuleManifest();
+const { getBlocksLists } = useBlocksList();
+
+const handleToggle = async (id: string, enabled: boolean) => {
+  await toggleModule(id, enabled);
+  await getBlocksLists();
+};
+
+onMounted(fetchModules);
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "loading": "Loading modules...",
+    "empty": "No modules found."
+  },
+  "de": {
+    "loading": "Module werden geladen...",
+    "empty": "Keine Module gefunden."
+  }
+}
+</i18n>

--- a/apps/web/app/components/settings/modules/extensions/View.vue
+++ b/apps/web/app/components/settings/modules/extensions/View.vue
@@ -1,0 +1,14 @@
+<template>
+  <SiteConfigurationView>
+    <template #setting-title>{{ getEditorTranslation('title') }}</template>
+  </SiteConfigurationView>
+</template>
+
+<script setup lang="ts"></script>
+
+<i18n lang="json">
+{
+  "en": { "title": "Extensions" },
+  "de": { "title": "Erweiterungen" }
+}
+</i18n>

--- a/apps/web/app/components/ui/ExtensionSlot/ExtensionSlot.vue
+++ b/apps/web/app/components/ui/ExtensionSlot/ExtensionSlot.vue
@@ -1,0 +1,21 @@
+<template>
+  <!--
+    Renders every component registered for this slot whose extension is currently enabled.
+    When an extension is toggled off (flags.json → extension.<id>.enabled: false),
+    useExtensionSlot's computed filters it out and Vue removes it from the DOM instantly.
+    No page refresh needed.
+  -->
+  <component
+    :is="getSlotComponent(entry.componentName)"
+    v-for="entry in entries"
+    :key="entry.componentName"
+  />
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ name: string }>();
+
+// entries is a computed ref: it re-evaluates whenever feature-flags state changes.
+const { getSlotEntries, getSlotComponent } = useExtensionSlot();
+const entries = getSlotEntries(props.name);
+</script>

--- a/apps/web/app/composables/useExtensionSlot/types.ts
+++ b/apps/web/app/composables/useExtensionSlot/types.ts
@@ -1,0 +1,1 @@
+export type SlotEntry = { componentName: string; extensionId: string };

--- a/apps/web/app/composables/useExtensionSlot/useExtensionSlot.ts
+++ b/apps/web/app/composables/useExtensionSlot/useExtensionSlot.ts
@@ -46,9 +46,9 @@ export const useExtensionSlot = () => {
    * Default behaviour: if the flag key is absent, the extension is considered enabled.
    */
   const getSlotEntries = (slotName: string) => {
-    return computed(() => {
-      const featureFlags = useState<Record<string, boolean>>('feature-flags', () => ({}));
+    const featureFlags = useState<Record<string, boolean>>('feature-flags', () => ({}));
 
+    return computed(() => {
       return (_slots.value[slotName] ?? []).filter(({ extensionId }) => {
         const flagKey = `extension.${extensionId}.enabled`;
         // Absent key → enabled. Only explicit `false` disables.

--- a/apps/web/app/composables/useExtensionSlot/useExtensionSlot.ts
+++ b/apps/web/app/composables/useExtensionSlot/useExtensionSlot.ts
@@ -1,0 +1,66 @@
+import type { Component } from 'vue';
+import type { SlotEntry } from './types';
+
+// Module-scope Map stores the actual component objects.
+// Not reactive and not in useState — component objects can't be serialized.
+// Plugins run on both server and client, so this Map is populated on both sides.
+const _componentRegistry = new Map<string, Component>();
+
+export const useExtensionSlot = () => {
+  // useState is called inside the composable so it always runs within a Nuxt context.
+  // Calling it with the same key every time is intentional — useState deduplicates by key
+  // and returns the same shared ref, so the registry persists across the app lifetime.
+  const _slots = useState<Record<string, SlotEntry[]>>('extension-slots', () => ({}));
+
+  /**
+   * Called by module plugins at app startup to claim a named slot.
+   * Pass the component object directly — no global registration via addComponent needed.
+   * Deduplicates by componentName so HMR / double-registration is safe.
+   *
+   * @param slotName      - The slot identifier (e.g. 'homepage-top')
+   * @param component     - The imported component object (e.g. `import Foo from './Foo.vue'`)
+   * @param componentName - A unique string key for the component (used for dedup + :key)
+   * @param extensionId   - The extension's npm package name, used to look up the feature flag
+   */
+  const register = (slotName: string, component: Component, componentName: string, extensionId: string) => {
+    _componentRegistry.set(componentName, component);
+
+    if (!_slots.value[slotName]) {
+      _slots.value[slotName] = [];
+    }
+
+    const alreadyRegistered = _slots.value[slotName].some((e) => e.componentName === componentName);
+
+    if (!alreadyRegistered) {
+      _slots.value[slotName].push({ componentName, extensionId });
+    }
+  };
+
+  /**
+   * Returns a computed list of entries for a slot, filtered to only ENABLED extensions.
+   *
+   * This computed reads from useState('feature-flags'), which is updated immediately when
+   * the toggle writes to flags.json (via the PATCH endpoint). That means disabling an
+   * extension makes every slot it registered into disappear reactively — no page refresh.
+   *
+   * Default behaviour: if the flag key is absent, the extension is considered enabled.
+   */
+  const getSlotEntries = (slotName: string) => {
+    return computed(() => {
+      const featureFlags = useState<Record<string, boolean>>('feature-flags', () => ({}));
+
+      return (_slots.value[slotName] ?? []).filter(({ extensionId }) => {
+        const flagKey = `extension.${extensionId}.enabled`;
+        // Absent key → enabled. Only explicit `false` disables.
+        return featureFlags.value[flagKey] !== false;
+      });
+    });
+  };
+
+  /** Resolves the component object for a registered slot entry. */
+  const getSlotComponent = (componentName: string): Component | undefined => {
+    return _componentRegistry.get(componentName);
+  };
+
+  return { register, getSlotEntries, getSlotComponent };
+};

--- a/apps/web/app/composables/useModuleManifest/index.ts
+++ b/apps/web/app/composables/useModuleManifest/index.ts
@@ -1,0 +1,2 @@
+export * from './useModuleManifest';
+export * from './types';

--- a/apps/web/app/composables/useModuleManifest/types.ts
+++ b/apps/web/app/composables/useModuleManifest/types.ts
@@ -1,0 +1,17 @@
+export interface ModuleManifestEntry {
+  id: string;
+  entry: string;
+  version?: string;
+  enabled?: boolean;
+  settings?: Record<string, unknown>;
+  privateSettings?: Record<string, unknown>;
+}
+
+export interface UseModuleManifest {
+  modules: Ref<ModuleManifestEntry[]>;
+  loading: Ref<boolean>;
+  fetchModules: () => Promise<void>;
+  toggleModule: (id: string, enabled: boolean) => Promise<void>;
+}
+
+export type UseModuleManifestReturn = () => UseModuleManifest;

--- a/apps/web/app/composables/useModuleManifest/useModuleManifest.ts
+++ b/apps/web/app/composables/useModuleManifest/useModuleManifest.ts
@@ -1,5 +1,5 @@
 import type { ModuleManifestEntry, UseModuleManifestReturn } from './types';
-
+import type { NuxtError } from '#app';
 const modules = ref<ModuleManifestEntry[]>([]);
 const loading = ref(false);
 
@@ -10,7 +10,7 @@ export const useModuleManifest: UseModuleManifestReturn = () => {
     try {
       modules.value = await $fetch<ModuleManifestEntry[]>('/_shop/modules');
     } catch (error) {
-      useHandleError(error);
+      useHandleError(error as NuxtError<unknown> | null);
     } finally {
       loading.value = false;
     }
@@ -25,7 +25,7 @@ export const useModuleManifest: UseModuleManifestReturn = () => {
         body: { id, enabled },
       });
 
-      const index = modules.value.findIndex((m) => m.id === id);
+      const index = modules.value.findIndex((module) => module.id === id);
 
       if (index !== -1) {
         modules.value[index] = updated;
@@ -34,7 +34,7 @@ export const useModuleManifest: UseModuleManifestReturn = () => {
       const featureFlags = useState<Record<string, boolean>>('feature-flags', () => ({}));
       featureFlags.value = { ...featureFlags.value, [`extension.${id}.enabled`]: enabled };
     } catch (error) {
-      useHandleError(error);
+      useHandleError(error as NuxtError<unknown> | null);
     } finally {
       loading.value = false;
     }

--- a/apps/web/app/composables/useModuleManifest/useModuleManifest.ts
+++ b/apps/web/app/composables/useModuleManifest/useModuleManifest.ts
@@ -1,0 +1,49 @@
+import type { ModuleManifestEntry, UseModuleManifestReturn } from './types';
+
+const modules = ref<ModuleManifestEntry[]>([]);
+const loading = ref(false);
+
+export const useModuleManifest: UseModuleManifestReturn = () => {
+  const fetchModules = async () => {
+    loading.value = true;
+
+    try {
+      modules.value = await $fetch<ModuleManifestEntry[]>('/_shop/modules');
+    } catch (error) {
+      useHandleError(error);
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  const toggleModule = async (id: string, enabled: boolean) => {
+    loading.value = true;
+
+    try {
+      const updated = await $fetch<ModuleManifestEntry>('/_shop/modules', {
+        method: 'PATCH',
+        body: { id, enabled },
+      });
+
+      const index = modules.value.findIndex((m) => m.id === id);
+
+      if (index !== -1) {
+        modules.value[index] = updated;
+      }
+
+      const featureFlags = useState<Record<string, boolean>>('feature-flags', () => ({}));
+      featureFlags.value = { ...featureFlags.value, [`extension.${id}.enabled`]: enabled };
+    } catch (error) {
+      useHandleError(error);
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  return {
+    modules,
+    loading,
+    fetchModules,
+    toggleModule,
+  };
+};

--- a/apps/web/app/pages/index.vue
+++ b/apps/web/app/pages/index.vue
@@ -3,6 +3,9 @@
     <!-- Extension slot: modules can register components here via useExtensionSlot().register().
          Hidden automatically when the extension is disabled — no page refresh needed. -->
     <UiExtensionSlot name="homepage-top" />
+    <!-- Countdown banner injected by plenty-pwa-module-prototype.
+         useCountdown() pauses the timer and hides the banner when the extension is disabled. -->
+    <CountdownBanner />
     <EditableBlocks :identifier="HOMEPAGE_IDENTIFIER" :type="'immutable'" />
   </div>
 </template>

--- a/apps/web/app/pages/index.vue
+++ b/apps/web/app/pages/index.vue
@@ -1,5 +1,8 @@
 <template>
   <div>
+    <!-- Extension slot: modules can register components here via useExtensionSlot().register().
+         Hidden automatically when the extension is disabled — no page refresh needed. -->
+    <UiExtensionSlot name="homepage-top" />
     <EditableBlocks :identifier="HOMEPAGE_IDENTIFIER" :type="'immutable'" />
   </div>
 </template>

--- a/apps/web/app/utils/blocks/blocks-imports.ts
+++ b/apps/web/app/utils/blocks/blocks-imports.ts
@@ -1,4 +1,5 @@
 import type { BlockLoader, DefaultsModule } from './types';
+
 const customerBlocks = import.meta.glob('/node_modules/*/runtime/components/blocks/**/*.vue', {
   import: 'default',
 }) as Record<string, BlockLoader>;
@@ -41,12 +42,39 @@ const normalize = (path: string) => {
   return path;
 };
 
+const extensionIdFromPath = (path: string): string | undefined => {
+  const match = path.match(/node_modules\/(.+?)\/runtime\//);
+  if (match) return match[1];
+  const moduleMatch = path.match(/modules\/(.+?)\/runtime\//);
+  if (moduleMatch) return moduleMatch[1];
+  return undefined;
+};
+
 export const blockLoaders: Record<string, BlockLoader> = {};
+export const blockExtensionIds: Record<string, string> = {};
 
 Object.entries(coreBlocks).forEach(([path, loader]) => (blockLoaders[normalize(path)] = loader));
-Object.entries(nuxtModuleBlocks).forEach(([path, loader]) => (blockLoaders[normalize(path)] = loader));
-Object.entries(customerBlocks).forEach(([path, loader]) => (blockLoaders[normalize(path)] = loader));
-Object.entries(workspaceCustomerBlocks).forEach(([path, loader]) => (blockLoaders[normalize(path)] = loader));
+
+Object.entries(nuxtModuleBlocks).forEach(([path, loader]) => {
+  const name = normalize(path);
+  blockLoaders[name] = loader;
+  const extId = extensionIdFromPath(path);
+  if (extId) blockExtensionIds[name] = extId;
+});
+
+Object.entries(customerBlocks).forEach(([path, loader]) => {
+  const name = normalize(path);
+  blockLoaders[name] = loader;
+  const extId = extensionIdFromPath(path);
+  if (extId) blockExtensionIds[name] = extId;
+});
+
+Object.entries(workspaceCustomerBlocks).forEach(([path, loader]) => {
+  const name = normalize(path);
+  blockLoaders[name] = loader;
+  const extId = extensionIdFromPath(path);
+  if (extId) blockExtensionIds[name] = extId;
+});
 
 export const getBlockLoader = (name: string) => {
   return blockLoaders[name];
@@ -55,6 +83,14 @@ export const getBlockLoader = (name: string) => {
 const asyncComponentCache: Record<string, ReturnType<typeof defineAsyncComponent>> = {};
 
 export const getCachedBlockComponent = (name: string) => {
+  const extId = blockExtensionIds[name];
+  if (extId) {
+    const featureFlags = useState<Record<string, boolean>>('feature-flags', () => ({}));
+    if (featureFlags.value[`extension.${extId}.enabled`] === false) {
+      return null;
+    }
+  }
+
   if (asyncComponentCache[name]) return asyncComponentCache[name];
 
   const loader = blockLoaders[name];
@@ -67,14 +103,6 @@ export const getCachedBlockComponent = (name: string) => {
 
 export const getBlockFormLoader = (name: string) => {
   return blockLoaders[name + 'Form'];
-};
-
-const extensionIdFromPath = (path: string): string | undefined => {
-  const match = path.match(/node_modules\/(.+?)\/runtime\//);
-  if (match) return match[1];
-  const moduleMatch = path.match(/modules\/(.+?)\/runtime\//);
-  if (moduleMatch) return moduleMatch[1];
-  return undefined;
 };
 
 export const resolveBlocksList = async (): Promise<BlocksList> => {

--- a/apps/web/app/utils/blocks/blocks-imports.ts
+++ b/apps/web/app/utils/blocks/blocks-imports.ts
@@ -4,10 +4,9 @@ const customerBlocks = import.meta.glob('/node_modules/*/runtime/components/bloc
 }) as Record<string, BlockLoader>;
 
 // Packages hoisted to the monorepo root node_modules (npm workspaces)
-const workspaceCustomerBlocks = import.meta.glob(
-  '../../../../../node_modules/*/runtime/components/blocks/**/*.vue',
-  { import: 'default' },
-) as Record<string, BlockLoader>;
+const workspaceCustomerBlocks = import.meta.glob('../../../../../node_modules/*/runtime/components/blocks/**/*.vue', {
+  import: 'default',
+}) as Record<string, BlockLoader>;
 
 const nuxtModuleBlocks = import.meta.glob('~~/modules/*/runtime/components/blocks/**/*.vue', {
   import: 'default',
@@ -70,12 +69,12 @@ export const getBlockFormLoader = (name: string) => {
   return blockLoaders[name + 'Form'];
 };
 
-const extensionIdFromPath = (path: string): string | null => {
+const extensionIdFromPath = (path: string): string | undefined => {
   const match = path.match(/node_modules\/(.+?)\/runtime\//);
   if (match) return match[1];
   const moduleMatch = path.match(/modules\/(.+?)\/runtime\//);
   if (moduleMatch) return moduleMatch[1];
-  return null;
+  return undefined;
 };
 
 export const resolveBlocksList = async (): Promise<BlocksList> => {

--- a/apps/web/app/utils/blocks/blocks-imports.ts
+++ b/apps/web/app/utils/blocks/blocks-imports.ts
@@ -3,6 +3,12 @@ const customerBlocks = import.meta.glob('/node_modules/*/runtime/components/bloc
   import: 'default',
 }) as Record<string, BlockLoader>;
 
+// Packages hoisted to the monorepo root node_modules (npm workspaces)
+const workspaceCustomerBlocks = import.meta.glob(
+  '../../../../../node_modules/*/runtime/components/blocks/**/*.vue',
+  { import: 'default' },
+) as Record<string, BlockLoader>;
+
 const nuxtModuleBlocks = import.meta.glob('~~/modules/*/runtime/components/blocks/**/*.vue', {
   import: 'default',
 }) as Record<string, BlockLoader>;
@@ -16,13 +22,19 @@ const coreBlockListLoaders = import.meta.glob('@/components/**/blocks/**/default
 
 const customerBlockListLoaders = import.meta.glob('/node_modules/*/runtime/components/blocks/**/defaults.ts');
 
+// Packages hoisted to the monorepo root node_modules (npm workspaces)
+const workspaceCustomerBlockListLoaders = import.meta.glob(
+  '../../../../../node_modules/*/runtime/components/blocks/**/defaults.ts',
+);
+
 const nuxtModuleBlockListLoaders = import.meta.glob('~~/modules/*/runtime/components/blocks/**/defaults.ts');
 
-const blockListLoadersSources = [
-  ...Object.values(coreBlockListLoaders),
-  ...Object.values(nuxtModuleBlockListLoaders),
-  ...Object.values(customerBlockListLoaders),
-];
+const allBlockListLoaders: Record<string, () => Promise<unknown>> = {
+  ...coreBlockListLoaders,
+  ...nuxtModuleBlockListLoaders,
+  ...customerBlockListLoaders,
+  ...workspaceCustomerBlockListLoaders,
+};
 
 const normalize = (path: string) => {
   const pop = path.split('/').pop();
@@ -35,6 +47,7 @@ export const blockLoaders: Record<string, BlockLoader> = {};
 Object.entries(coreBlocks).forEach(([path, loader]) => (blockLoaders[normalize(path)] = loader));
 Object.entries(nuxtModuleBlocks).forEach(([path, loader]) => (blockLoaders[normalize(path)] = loader));
 Object.entries(customerBlocks).forEach(([path, loader]) => (blockLoaders[normalize(path)] = loader));
+Object.entries(workspaceCustomerBlocks).forEach(([path, loader]) => (blockLoaders[normalize(path)] = loader));
 
 export const getBlockLoader = (name: string) => {
   return blockLoaders[name];
@@ -57,9 +70,25 @@ export const getBlockFormLoader = (name: string) => {
   return blockLoaders[name + 'Form'];
 };
 
+const extensionIdFromPath = (path: string): string | null => {
+  const match = path.match(/node_modules\/(.+?)\/runtime\//);
+  if (match) return match[1];
+  const moduleMatch = path.match(/modules\/(.+?)\/runtime\//);
+  if (moduleMatch) return moduleMatch[1];
+  return null;
+};
+
 export const resolveBlocksList = async (): Promise<BlocksList> => {
   const result: BlocksList = {};
   const overriddenBlocks = new Set<string>();
+  const featureFlags = useState<Record<string, boolean>>('feature-flags', () => ({}));
+
+  const isDisabled = (path: string): boolean => {
+    const extId = extensionIdFromPath(path);
+    if (!extId) return false;
+    const key = `extension.${extId}.enabled`;
+    return key in featureFlags.value && featureFlags.value[key] === false;
+  };
 
   const nameOf = (variation: BlockTemplateVariation) =>
     variation.template?.en?.name ?? variation.template?.de?.name ?? '';
@@ -83,7 +112,8 @@ export const resolveBlocksList = async (): Promise<BlocksList> => {
     });
   };
 
-  const modules = await Promise.all(blockListLoadersSources.map((loader) => loader() as Promise<DefaultsModule>));
+  const entries = Object.entries(allBlockListLoaders).filter(([path]) => !isDisabled(path));
+  const modules = await Promise.all(entries.map(([, loader]) => loader() as Promise<DefaultsModule>));
 
   modules.forEach((mod) => {
     if (mod.getBlocksList) {

--- a/apps/web/app/utils/settings-groups-imports/index.ts
+++ b/apps/web/app/utils/settings-groups-imports/index.ts
@@ -6,6 +6,11 @@ const customer = import.meta.glob('/node_modules/*/runtime/components/settings/*
   import: 'default',
 }) as Record<string, SettingsGroupLoader>;
 
+// Packages hoisted to the monorepo root node_modules (npm workspaces)
+const workspaceCustomer = import.meta.glob('../../../../../node_modules/*/runtime/components/settings/**/*.vue', {
+  import: 'default',
+}) as Record<string, SettingsGroupLoader>;
+
 const nuxtModules = import.meta.glob('~~/modules/*/runtime/components/settings/**/*.vue', {
   import: 'default',
 }) as Record<string, SettingsGroupLoader>;
@@ -14,6 +19,10 @@ const core = import.meta.glob('@/components/**/settings/**/*.vue', { import: 'de
   string,
   SettingsGroupLoader
 >;
+
+const extensionIdFromPath = (path: string): string | undefined => {
+  return path.match(/node_modules\/(.+?)\/runtime\//)?.[1] ?? path.match(/modules\/(.+?)\/runtime\//)?.[1];
+};
 
 const stripPrefix = (raw: string): string => raw.replace(/^(\d+)\./, '');
 
@@ -34,10 +43,34 @@ const normalize = (path: string) => {
 };
 
 const modules: Record<string, SettingsGroupLoader> = {};
+const entryExtensionIds: Record<string, string | undefined> = {};
 
 Object.entries(core).forEach(([path, loader]) => (modules[normalize(path)] = loader));
-Object.entries(nuxtModules).forEach(([path, loader]) => (modules[normalize(path)] = loader));
-Object.entries(customer).forEach(([path, loader]) => (modules[normalize(path)] = loader));
+
+Object.entries(nuxtModules).forEach(([path, loader]) => {
+  const key = normalize(path);
+  modules[key] = loader;
+  entryExtensionIds[key] = extensionIdFromPath(path);
+});
+
+Object.entries(customer).forEach(([path, loader]) => {
+  const key = normalize(path);
+  modules[key] = loader;
+  entryExtensionIds[key] = extensionIdFromPath(path);
+});
+
+Object.entries(workspaceCustomer).forEach(([path, loader]) => {
+  const key = normalize(path);
+  modules[key] = loader;
+  entryExtensionIds[key] = extensionIdFromPath(path);
+});
+
+const isDisabled = (key: string): boolean => {
+  const extId = entryExtensionIds[key];
+  if (!extId) return false;
+  const featureFlags = useState<Record<string, boolean>>('feature-flags', () => ({}));
+  return featureFlags.value[`extension.${extId}.enabled`] === false;
+};
 
 export const getSettingsGroups = (activeSetting: string, subCategory: string = '') => {
   const prefix = subCategory ? `${activeSetting}/${subCategory}/` : `${activeSetting}/`;
@@ -45,6 +78,7 @@ export const getSettingsGroups = (activeSetting: string, subCategory: string = '
 
   for (const [path, loader] of Object.entries(modules)) {
     if (!path.includes(prefix)) continue;
+    if (isDisabled(path)) continue;
 
     const afterPrefix = path.split(prefix)[1];
     if (!afterPrefix) continue;
@@ -74,6 +108,7 @@ export const getSubCategories = (activeSetting: string): string[] => {
 
   Object.keys(modules).forEach((path) => {
     if (!path.startsWith(prefix)) return;
+    if (isDisabled(path)) return;
 
     const remainder = path.slice(prefix.length);
 
@@ -89,7 +124,8 @@ export const getSubCategories = (activeSetting: string): string[] => {
 
 export const getViewComponent = (activeSetting: string, subCategory = '') => {
   const key = Object.keys(modules).find(
-    (path) => path.includes(`${activeSetting}/${subCategory}`) && path.endsWith('View'),
+    (path) =>
+      !isDisabled(path) && path.includes(`${activeSetting}/${subCategory}`) && path.endsWith('View'),
   );
 
   return key ? defineAsyncComponent(modules[key] ?? (() => Promise.resolve({}))) : null;

--- a/apps/web/app/utils/triggers-imports/index.ts
+++ b/apps/web/app/utils/triggers-imports/index.ts
@@ -4,6 +4,12 @@ const customerTriggers = import.meta.glob('/node_modules/*/runtime/components/**
   import: 'default',
 }) as Record<string, TriggerLoader>;
 
+// Packages hoisted to the monorepo root node_modules (npm workspaces)
+const workspaceCustomerTriggers = import.meta.glob(
+  '../../../../../node_modules/*/runtime/components/**/settings/*/*ToolbarTrigger.vue',
+  { import: 'default' },
+) as Record<string, TriggerLoader>;
+
 const nuxtModuleTriggers = import.meta.glob('~~/modules/*/runtime/components/**/settings/*/*ToolbarTrigger.vue', {
   import: 'default',
 }) as Record<string, TriggerLoader>;
@@ -12,6 +18,10 @@ const coreTriggers = import.meta.glob('@/components/**/settings/*/*ToolbarTrigge
   import: 'default',
 }) as Record<string, TriggerLoader>;
 
+const extensionIdFromPath = (path: string): string | undefined => {
+  return path.match(/node_modules\/(.+?)\/runtime\//)?.[1] ?? path.match(/modules\/(.+?)\/runtime\//)?.[1];
+};
+
 function slug(path: string) {
   const norm = path.replace(/\\/g, '/');
   const match = norm.match(/settings\/([^/]+)\//i);
@@ -19,12 +29,35 @@ function slug(path: string) {
 }
 
 const ordered: Record<string, TriggerLoader> = {};
+const slugToExtId: Record<string, string | undefined> = {};
 
 Object.entries(coreTriggers).forEach(([path, loader]) => (ordered[slug(path)] = loader));
-Object.entries(nuxtModuleTriggers).forEach(([path, loader]) => (ordered[slug(path)] = loader));
-Object.entries(customerTriggers).forEach(([path, loader]) => (ordered[slug(path)] = loader));
 
-export const triggersModules = Object.entries(ordered).map(([slug, loader]) => ({
-  slug: slug,
-  component: defineAsyncComponent(loader),
-}));
+Object.entries(nuxtModuleTriggers).forEach(([path, loader]) => {
+  const s = slug(path);
+  ordered[s] = loader;
+  slugToExtId[s] = extensionIdFromPath(path);
+});
+
+Object.entries(customerTriggers).forEach(([path, loader]) => {
+  const s = slug(path);
+  ordered[s] = loader;
+  slugToExtId[s] = extensionIdFromPath(path);
+});
+
+Object.entries(workspaceCustomerTriggers).forEach(([path, loader]) => {
+  const s = slug(path);
+  ordered[s] = loader;
+  slugToExtId[s] = extensionIdFromPath(path);
+});
+
+export const getTriggersModules = () => {
+  const featureFlags = useState<Record<string, boolean>>('feature-flags', () => ({}));
+  return Object.entries(ordered)
+    .filter(([s]) => {
+      const extId = slugToExtId[s];
+      if (!extId) return true;
+      return featureFlags.value[`extension.${extId}.enabled`] !== false;
+    })
+    .map(([s, loader]) => ({ slug: s, component: defineAsyncComponent(loader) }));
+};

--- a/apps/web/flags.json
+++ b/apps/web/flags.json
@@ -1,3 +1,3 @@
 {
-  "extension.plenty-pwa-module-prototype.enabled": true
+  "extension.plenty-pwa-module-prototype.enabled": false
 }

--- a/apps/web/flags.json
+++ b/apps/web/flags.json
@@ -1,0 +1,3 @@
+{
+  "extension.plenty-pwa-module-prototype.enabled": true
+}

--- a/apps/web/module.manifest.json
+++ b/apps/web/module.manifest.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "plenty-pwa-module-prototype",
+    "entry": "plenty-pwa-module-prototype",
+    "version": "0.1.2"
+  }
+]

--- a/apps/web/module.manifest.json
+++ b/apps/web/module.manifest.json
@@ -1,7 +1,0 @@
-[
-  {
-    "id": "plenty-pwa-module-prototype",
-    "entry": "plenty-pwa-module-prototype",
-    "version": "0.1.2"
-  }
-]

--- a/apps/web/server/routes/_shop/modules.get.ts
+++ b/apps/web/server/routes/_shop/modules.get.ts
@@ -1,0 +1,50 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, isAbsolute } from 'node:path';
+
+interface ManifestEntry {
+  id: string;
+  entry: string;
+  version?: string;
+  enabled?: boolean;
+  settings?: Record<string, unknown>;
+  privateSettings?: Record<string, unknown>;
+}
+
+const readManifest = (): ManifestEntry[] => {
+  const path = resolve(process.cwd(), 'module.manifest.json');
+  if (!existsSync(path)) {
+    return [];
+  }
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as ManifestEntry[];
+  } catch {
+    return [];
+  }
+};
+
+const readFlags = (): Record<string, boolean> => {
+  const flagsEnv = process.env.JSON_FEATURE_FLAGS_FILE ?? '/etc/plenty/feature-flags/flags.json';
+  const flagsPath = isAbsolute(flagsEnv) ? flagsEnv : resolve(process.cwd(), flagsEnv);
+  if (!existsSync(flagsPath)) {
+    return {};
+  }
+  try {
+    return JSON.parse(readFileSync(flagsPath, 'utf-8')) as Record<string, boolean>;
+  } catch {
+    return {};
+  }
+};
+
+export default defineEventHandler(() => {
+  const manifest = readManifest();
+  const flags = readFlags();
+
+  return manifest.map((entry) => {
+    const flagKey = `extension.${entry.id}.enabled`;
+    const flagValue = flags[flagKey];
+    return {
+      ...entry,
+      enabled: flagValue !== undefined ? flagValue : entry.enabled !== false,
+    };
+  });
+});

--- a/apps/web/server/routes/_shop/modules.get.ts
+++ b/apps/web/server/routes/_shop/modules.get.ts
@@ -1,27 +1,6 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve, isAbsolute } from 'node:path';
 
-interface ManifestEntry {
-  id: string;
-  entry: string;
-  version?: string;
-  enabled?: boolean;
-  settings?: Record<string, unknown>;
-  privateSettings?: Record<string, unknown>;
-}
-
-const readManifest = (): ManifestEntry[] => {
-  const path = resolve(process.cwd(), 'module.manifest.json');
-  if (!existsSync(path)) {
-    return [];
-  }
-  try {
-    return JSON.parse(readFileSync(path, 'utf-8')) as ManifestEntry[];
-  } catch {
-    return [];
-  }
-};
-
 const readFlags = (): Record<string, boolean> => {
   const flagsEnv = process.env.JSON_FEATURE_FLAGS_FILE ?? '/etc/plenty/feature-flags/flags.json';
   const flagsPath = isAbsolute(flagsEnv) ? flagsEnv : resolve(process.cwd(), flagsEnv);
@@ -35,16 +14,18 @@ const readFlags = (): Record<string, boolean> => {
   }
 };
 
-export default defineEventHandler(() => {
-  const manifest = readManifest();
+export default defineEventHandler((event) => {
+  const runtimeConfig = useRuntimeConfig(event);
+  const extensions = (runtimeConfig.shopCoreExtensions ?? []) as Array<{ id: string; version: string | null }>;
   const flags = readFlags();
 
-  return manifest.map((entry) => {
-    const flagKey = `extension.${entry.id}.enabled`;
+  return extensions.map((ext) => {
+    const flagKey = `extension.${ext.id}.enabled`;
     const flagValue = flags[flagKey];
     return {
-      ...entry,
-      enabled: flagValue !== undefined ? flagValue : entry.enabled !== false,
+      id: ext.id,
+      version: ext.version,
+      enabled: flagValue !== undefined ? flagValue : true,
     };
   });
 });

--- a/apps/web/server/routes/_shop/modules.patch.ts
+++ b/apps/web/server/routes/_shop/modules.patch.ts
@@ -1,0 +1,37 @@
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { resolve, isAbsolute } from 'node:path';
+
+interface PatchBody {
+  id: string;
+  enabled: boolean;
+}
+
+const getFlagsPath = (): string => {
+  const flagsEnv = process.env.JSON_FEATURE_FLAGS_FILE ?? '/etc/plenty/feature-flags/flags.json';
+  return isAbsolute(flagsEnv) ? flagsEnv : resolve(process.cwd(), flagsEnv);
+};
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody<PatchBody>(event);
+
+  if (!body?.id || typeof body.enabled !== 'boolean') {
+    throw createError({ statusCode: 400, statusMessage: 'id and enabled are required' });
+  }
+
+  const flagsPath = getFlagsPath();
+  let flags: Record<string, unknown> = {};
+
+  if (existsSync(flagsPath)) {
+    try {
+      flags = JSON.parse(readFileSync(flagsPath, 'utf-8')) as Record<string, unknown>;
+    } catch {
+      throw createError({ statusCode: 500, statusMessage: 'Failed to read feature flags file' });
+    }
+  }
+
+  flags[`extension.${body.id}.enabled`] = body.enabled;
+
+  writeFileSync(flagsPath, JSON.stringify(flags, null, 2) + '\n');
+
+  return { id: body.id, enabled: body.enabled };
+});

--- a/docs/extension-toggle-diagram.html
+++ b/docs/extension-toggle-diagram.html
@@ -1,0 +1,486 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Extension Toggle System — Architecture</title>
+<script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+<style>
+  :root {
+    --core:    #3b5bdb;
+    --pwa:     #0ca678;
+    --module:  #9c36b5;
+    --flag:    #e67700;
+    --bg:      #f8f9fa;
+    --surface: #ffffff;
+    --border:  #dee2e6;
+    --text:    #1a1a2e;
+    --muted:   #6c757d;
+    --radius:  10px;
+    --shadow:  0 2px 12px rgba(0,0,0,.08);
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    padding: 40px 24px 80px;
+    max-width: 1200px;
+    margin: 0 auto;
+  }
+
+  /* ── Header ───────────────────────────────────────────────────── */
+  header {
+    text-align: center;
+    margin-bottom: 48px;
+  }
+  header h1 {
+    font-size: 2rem;
+    font-weight: 700;
+    letter-spacing: -.02em;
+  }
+  header p {
+    color: var(--muted);
+    margin-top: 8px;
+    font-size: .95rem;
+  }
+
+  /* ── Legend ───────────────────────────────────────────────────── */
+  .legend {
+    display: flex;
+    gap: 24px;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin-bottom: 40px;
+  }
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: .85rem;
+    font-weight: 500;
+  }
+  .legend-dot {
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
+    flex-shrink: 0;
+  }
+
+  /* ── Section wrapper ──────────────────────────────────────────── */
+  section {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    padding: 32px;
+    margin-bottom: 32px;
+  }
+  section h2 {
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  section h2 .tag {
+    font-size: .7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: .06em;
+    padding: 3px 8px;
+    border-radius: 4px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    color: var(--muted);
+  }
+
+  /* ── Mermaid diagrams ─────────────────────────────────────────── */
+  .mermaid {
+    display: flex;
+    justify-content: center;
+    overflow-x: auto;
+  }
+
+  /* ── Three-pattern grid ───────────────────────────────────────── */
+  .patterns {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 20px;
+  }
+  .pattern-card {
+    border-radius: var(--radius);
+    padding: 20px 24px;
+    border: 1.5px solid;
+  }
+  .pattern-card h3 {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 12px;
+  }
+  .pattern-card ul {
+    list-style: none;
+    font-size: .85rem;
+    line-height: 1.7;
+    color: #444;
+  }
+  .pattern-card ul li::before {
+    content: '→ ';
+    opacity: .5;
+  }
+  .pattern-card.slot   { border-color: var(--module); background: #f9f0ff; }
+  .pattern-card.page   { border-color: var(--core);   background: #edf2ff; }
+  .pattern-card.override { border-color: var(--pwa); background: #e6fcf5; }
+
+  /* ── Two-layer disable table ──────────────────────────────────── */
+  .tier-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: .875rem;
+  }
+  .tier-table th {
+    text-align: left;
+    padding: 10px 14px;
+    background: var(--bg);
+    border-bottom: 2px solid var(--border);
+    font-weight: 600;
+    font-size: .8rem;
+    text-transform: uppercase;
+    letter-spacing: .05em;
+    color: var(--muted);
+  }
+  .tier-table td {
+    padding: 11px 14px;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+  }
+  .tier-table tr:last-child td { border-bottom: none; }
+  .tier-table .auto  { color: var(--core); font-weight: 600; }
+  .tier-table .optin { color: var(--module); font-weight: 600; }
+  .badge {
+    display: inline-block;
+    font-size: .7rem;
+    font-weight: 600;
+    padding: 2px 7px;
+    border-radius: 100px;
+    margin-right: 4px;
+  }
+  .badge.core   { background: #dbe4ff; color: var(--core); }
+  .badge.pwa    { background: #c3fae8; color: #087f5b; }
+  .badge.module { background: #f3d9fa; color: var(--module); }
+
+  /* ── Pros/Cons ────────────────────────────────────────────────── */
+  .proscons {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+  }
+  @media (max-width: 640px) { .proscons { grid-template-columns: 1fr; } }
+  .pros, .cons {
+    border-radius: var(--radius);
+    padding: 20px 24px;
+  }
+  .pros { background: #ebfbee; border: 1.5px solid #8ce99a; }
+  .cons { background: #fff5f5; border: 1.5px solid #ffa8a8; }
+  .pros h3 { color: #2b8a3e; margin-bottom: 12px; font-size: .95rem; }
+  .cons h3 { color: #c92a2a; margin-bottom: 12px; font-size: .95rem; }
+  .pros li, .cons li {
+    font-size: .85rem;
+    line-height: 1.7;
+    margin-left: 16px;
+    color: #444;
+  }
+
+  /* ── Flag convention box ──────────────────────────────────────── */
+  .flag-box {
+    background: #fff9db;
+    border: 1.5px solid #ffe066;
+    border-radius: var(--radius);
+    padding: 16px 20px;
+    font-family: 'Menlo', 'Consolas', monospace;
+    font-size: .9rem;
+    margin-top: 0;
+  }
+  .flag-box span { color: var(--flag); font-weight: 600; }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>Extension Toggle System</h1>
+  <p>How PlentyONE PWA enables and disables Nuxt extensions at runtime — no rebuild, no restart.</p>
+</header>
+
+<div class="legend">
+  <div class="legend-item"><div class="legend-dot" style="background:var(--core)"></div> shop-core</div>
+  <div class="legend-item"><div class="legend-dot" style="background:var(--pwa)"></div> plentyshop-pwa</div>
+  <div class="legend-item"><div class="legend-dot" style="background:var(--module)"></div> extension module</div>
+  <div class="legend-item"><div class="legend-dot" style="background:var(--flag)"></div> flags.json (disk)</div>
+</div>
+
+<!-- ── Flag naming convention ──────────────────────────────────── -->
+<section>
+  <h2>Flag naming convention</h2>
+  <div class="flag-box">
+    <span>extension.&lt;extension-id&gt;.enabled</span>
+    &nbsp;→&nbsp;
+    <span>extension.plenty-pwa-module-prototype.enabled: false</span>
+  </div>
+  <p style="font-size:.85rem;color:var(--muted);margin-top:12px;">
+    Absent key = enabled. Only an explicit <code>false</code> disables. Written to and read from
+    <code>flags.json</code> (path set via <code>JSON_FEATURE_FLAGS_FILE</code> env var, same in dev and production).
+  </p>
+</section>
+
+<!-- ── Full system flow ────────────────────────────────────────── -->
+<section>
+  <h2>Full system flow <span class="tag">all repos</span></h2>
+  <div class="mermaid">
+flowchart TD
+    subgraph BT["⚙️  BUILD TIME"]
+        direction LR
+        MF["module.manifest.json\n(apps/web/)"]
+        LE["loadExtensions.ts\nshop-core"]
+        SE["setupExtensions.ts\nshop-core"]
+        RC["runtimeConfig\nbaked into bundle"]
+        PE["pages:extend hook\ntags pages with extensionId"]
+        MF --> LE --> SE --> RC
+        LE --> PE
+    end
+
+    subgraph SSR["🌐  EVERY SSR REQUEST"]
+        direction LR
+        FF["feature-flags\n.server.ts plugin"]
+        ST["useState\n'feature-flags'"]
+        FF -->|"reads flags.json"| ST
+    end
+
+    subgraph CLIENT["🖥️  BROWSER  (reactive)"]
+        direction TB
+        FU["useFeatureFlag()"]
+        EU["useExtensionEnabled()"]
+        EG["extension-guard\nmiddleware"]
+        SL["useExtensionSlot\ngetSlotEntries()"]
+        ST -->|hydrated via SSR payload| FU
+        FU --> EU
+        FU --> EG
+        FU --> SL
+        EG -->|"if disabled → /not-found"| NF["🚫 /not-found"]
+        SL -->|"filters entries"| ESC["&lt;ExtensionSlot /&gt;\nhides component"]
+        EU -->|"v-if / watch"| CMP["component hides\nor timer pauses"]
+    end
+
+    subgraph EDITOR["✏️  EDITOR TOGGLE"]
+        direction LR
+        UI["ModuleToggles.vue\n(SfSwitch)"]
+        UM["useModuleManifest\n.toggleModule()"]
+        PATCH["PATCH /_shop/modules\n(Nitro route)"]
+        DISK["flags.json\non disk"]
+        IMEM["useState\n'feature-flags'\n(in-memory update)"]
+        UI --> UM --> PATCH --> DISK
+        UM -->|"immediate"| IMEM
+        IMEM -->|"reactive cascade"| FU
+    end
+
+    BT -->|"runtimeConfig.shopCoreExtensions\ninjected at build"| SSR
+    BT -->|"extensionId meta\non each page route"| EG
+
+    style BT   fill:#edf2ff,stroke:#3b5bdb,color:#1a1a2e
+    style SSR  fill:#fff9db,stroke:#e67700,color:#1a1a2e
+    style CLIENT fill:#e6fcf5,stroke:#0ca678,color:#1a1a2e
+    style EDITOR fill:#f3d9fa,stroke:#9c36b5,color:#1a1a2e
+  </div>
+</section>
+
+<!-- ── Three patterns ─────────────────────────────────────────── -->
+<section>
+  <h2>Three ways a module can participate</h2>
+  <div class="patterns">
+
+    <div class="pattern-card slot">
+      <h3>Pattern A — Slot injection</h3>
+      <ul>
+        <li>Module calls <code>register()</code> in a plugin at startup</li>
+        <li>PWA places <code>&lt;UiExtensionSlot name="homepage-top" /&gt;</code></li>
+        <li><code>getSlotEntries()</code> filters by feature-flags state</li>
+        <li>Component disappears instantly when toggled off — no refresh</li>
+        <li><strong>Module effort:</strong> one <code>register()</code> call</li>
+      </ul>
+    </div>
+
+    <div class="pattern-card page">
+      <h3>Pattern B — New page</h3>
+      <ul>
+        <li>Module adds route via <code>extendPages</code> (standard Nuxt)</li>
+        <li>shop-core tags the page with <code>extensionId</code> in <code>pages:extend</code></li>
+        <li><code>extension-guard</code> middleware redirects to <code>/not-found</code></li>
+        <li>Page optionally calls <code>showError(404)</code> as SSR guard</li>
+        <li><strong>Module effort:</strong> none for routing — standard <code>pages.push()</code></li>
+      </ul>
+    </div>
+
+    <div class="pattern-card override">
+      <h3>Pattern C — Page override</h3>
+      <ul>
+        <li>Module swaps an existing PWA page file (<code>/checkout</code>, <code>/terms-and-conditions</code>)</li>
+        <li>Original saved as Nuxt alias (<code>#pwa-checkout-original</code>)</li>
+        <li>Replacement uses <code>v-if="isEnabled"</code> to switch between module UI and original</li>
+        <li>Instant switch — <code>v-if</code> reacts to flag change with no refresh</li>
+        <li><strong>Module effort:</strong> set up alias + implement <code>v-if</code> in the page</li>
+      </ul>
+    </div>
+
+  </div>
+</section>
+
+<!-- ── Detailed flow: toggle action ───────────────────────────── -->
+<section>
+  <h2>What happens when you flip the toggle <span class="tag">step by step</span></h2>
+  <div class="mermaid">
+sequenceDiagram
+    actor Dev as Editor user
+    participant UI as ModuleToggles.vue
+    participant CM as useModuleManifest
+    participant API as PATCH /_shop/modules
+    participant DISK as flags.json
+    participant MEM as useState('feature-flags')
+    participant SL as useExtensionSlot
+    participant BL as resolveBlocksList()
+
+    Dev->>UI: flips SfSwitch OFF
+    UI->>CM: handleToggle(id, false)
+    CM->>API: $fetch PATCH { id, enabled: false }
+    API->>DISK: write extension.id.enabled = false
+    API-->>CM: { id, enabled: false }
+    CM->>MEM: featureFlags.value[key] = false
+    Note over MEM,SL: Reactive cascade — immediate, same tab
+    MEM-->>SL: getSlotEntries() recomputes
+    SL-->>UI: ExtensionSlot removes component from DOM
+    CM->>BL: getBlocksLists()
+    BL-->>UI: block palette no longer shows extension blocks
+    Note over DISK: Next SSR request reads disk → new users see disabled state
+  </div>
+</section>
+
+<!-- ── Two-tier responsibility table ──────────────────────────── -->
+<section>
+  <h2>Who does what — responsibility tiers</h2>
+  <table class="tier-table">
+    <thead>
+      <tr>
+        <th>Behavior when disabled</th>
+        <th>Tier</th>
+        <th>Owner</th>
+        <th>File</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>SSR: flags loaded on every request</td>
+        <td class="auto">Automatic</td>
+        <td><span class="badge core">shop-core</span></td>
+        <td><code>feature-flags.server.ts</code></td>
+      </tr>
+      <tr>
+        <td>Client nav to disabled route → <code>/not-found</code></td>
+        <td class="auto">Automatic</td>
+        <td><span class="badge core">shop-core</span></td>
+        <td><code>extension-guard.ts</code></td>
+      </tr>
+      <tr>
+        <td>Extension's blocks hidden from block palette</td>
+        <td class="auto">Automatic</td>
+        <td><span class="badge pwa">PWA</span></td>
+        <td><code>blocks-imports.ts</code></td>
+      </tr>
+      <tr>
+        <td>Toggle UI + flag persistence</td>
+        <td class="auto">Automatic</td>
+        <td><span class="badge pwa">PWA</span></td>
+        <td><code>ModuleToggles.vue</code> + <code>/_shop/modules</code></td>
+      </tr>
+      <tr>
+        <td>Slot-injected component hides reactively</td>
+        <td class="optin">Opt-in</td>
+        <td><span class="badge module">module</span></td>
+        <td><code>slots.ts</code> plugin calls <code>register()</code></td>
+      </tr>
+      <tr>
+        <td>Overridden page falls back to original</td>
+        <td class="optin">Opt-in</td>
+        <td><span class="badge module">module</span></td>
+        <td>Page uses <code>v-if="isEnabled"</code> + alias import</td>
+      </tr>
+      <tr>
+        <td>Timer / side-effect pauses</td>
+        <td class="optin">Opt-in</td>
+        <td><span class="badge module">module</span></td>
+        <td><code>useCountdown.ts</code> watches <code>useExtensionEnabled()</code></td>
+      </tr>
+      <tr>
+        <td>Keyboard shortcut deactivates</td>
+        <td class="optin">Opt-in</td>
+        <td><span class="badge module">module</span></td>
+        <td><code>shortcuts.ts</code> plugin checks <code>enabled.value</code></td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ── Pros / Cons ─────────────────────────────────────────────── -->
+<section>
+  <h2>Pros &amp; Cons</h2>
+  <div class="proscons">
+    <div class="pros">
+      <h3>✓ What works well</h3>
+      <ul>
+        <li>No rebuild or restart required to toggle</li>
+        <li>Reactive in the browser — same tab updates instantly on toggle</li>
+        <li>Route guarding and block filtering are invisible to module authors</li>
+        <li>Extension list is production-safe (baked into server bundle at build time)</li>
+        <li>Single flag file used consistently by all readers/writers</li>
+        <li>Default is always enabled — absent flag never accidentally disables</li>
+      </ul>
+    </div>
+    <div class="cons">
+      <h3>✗ Known limitations</h3>
+      <ul>
+        <li>Route guard is client-side only — direct URL to a disabled page still SSR-renders before redirecting (flash)</li>
+        <li>Module is always compiled into the bundle — flag control does not reduce JS payload</li>
+        <li>Slot injection requires PWA to explicitly place <code>&lt;UiExtensionSlot&gt;</code> — modules can't inject into arbitrary locations</li>
+        <li>Page override fallback requires module author to write <code>v-if</code> — no framework enforcement</li>
+        <li>Component-level reactive behavior (timers, banners) must be wired manually per module</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<script>
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'base',
+    themeVariables: {
+      primaryColor:       '#dbe4ff',
+      primaryTextColor:   '#1a1a2e',
+      primaryBorderColor: '#3b5bdb',
+      lineColor:          '#868e96',
+      secondaryColor:     '#e6fcf5',
+      tertiaryColor:      '#f3d9fa',
+      background:         '#ffffff',
+      mainBkg:            '#ffffff',
+      nodeBorder:         '#adb5bd',
+      clusterBkg:         '#f8f9fa',
+      titleColor:         '#1a1a2e',
+      edgeLabelBackground:'#ffffff',
+      fontFamily:         '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+      fontSize:           '13px',
+    },
+    flowchart: { curve: 'basis', padding: 16 },
+    sequence:  { mirrorActors: false, messageAlign: 'center' },
+  });
+</script>
+</body>
+</html>

--- a/docs/extension-toggle-system.md
+++ b/docs/extension-toggle-system.md
@@ -68,9 +68,9 @@ A JSON file on disk holds boolean flags:
 }
 ```
 
-In production this file lives at `/etc/plenty/feature-flags/flags.json`.
-In development we point to a local copy with the env var `JSON_FEATURE_FLAGS_FILE=./flags.json`
-(i.e. `apps/web/flags.json`).
+In production this file lives at a configured path on the server.
+In development you can point to a local copy by setting the `JSON_FEATURE_FLAGS_FILE` environment
+variable to a path of your choice.
 
 ### The server plugin — `feature-flags.server.ts`
 

--- a/docs/extension-toggle-system.md
+++ b/docs/extension-toggle-system.md
@@ -1,0 +1,386 @@
+# Extension Toggle System — Complete Explanation
+
+This document explains what was built, why it works the way it does, and what each moving part does.
+It assumes no prior knowledge of the implementation.
+
+---
+
+## The Problem We Were Solving
+
+The PWA supports external Nuxt modules (called "extensions") that add new routes, CMS blocks, and
+components to the shop. For example: `plenty-pwa-module-prototype` adds a `/store` page and a
+`StoreHero` CMS block.
+
+These extensions are currently registered at **build time**. Once you build the PWA, the extension's
+routes and components are compiled into the output. If you want to disable an extension, you have to
+rebuild the entire PWA and redeploy it. That's slow and expensive.
+
+**The goal:** be able to turn an extension on or off while the server is running, with no rebuild, no
+redeploy, and no server restart.
+
+---
+
+## Part 1 — How the PWA Already Knows About Extensions
+
+### `module.manifest.json`
+
+There is a file at `apps/web/module.manifest.json`. It lists which extensions are installed:
+
+```json
+[
+  {
+    "id": "plenty-pwa-module-prototype",
+    "entry": "plenty-pwa-module-prototype",
+    "version": "0.1.0"
+  }
+]
+```
+
+- `id` — the unique identifier, used as the key for all flag names
+- `entry` — the npm package name that Node.js will `require()`
+- `version` — informational
+
+When Nuxt starts building, `@plentymarkets/shop-core` reads this file and adds each `entry` as a Nuxt
+module dependency. Nuxt then loads those modules, which register their pages, components, and blocks
+into the build.
+
+This all happens at **build time**. Changing this file after a build does nothing until you rebuild.
+
+### The npm package
+
+The extension lives at `node_modules/plenty-pwa-module-prototype/`. Its `index.ts` file is the Nuxt
+module entry point — it calls `addComponent`, `extendPages`, etc. to register its content.
+
+---
+
+## Part 2 — The Feature Flag System (pre-existing in shop-core)
+
+Before we touched anything, shop-core already had a feature flag system. Here is how it works:
+
+### The flags file
+
+A JSON file on disk holds boolean flags:
+
+```json
+{
+  "some-feature.enabled": true,
+  "another-feature.enabled": false
+}
+```
+
+In production this file lives at `/etc/plenty/feature-flags/flags.json`.
+In development we point to a local copy with the env var `JSON_FEATURE_FLAGS_FILE=./flags.json`
+(i.e. `apps/web/flags.json`).
+
+### The server plugin — `feature-flags.server.ts`
+
+This plugin runs on **every single SSR request**, before the page renders:
+
+```
+User visits page → server receives request → plugin runs → reads flags.json from disk
+→ puts contents into useState('feature-flags') → page renders using those flags
+```
+
+`useState('feature-flags')` is Nuxt's built-in shared state. It is populated on the server and
+sent to the browser as part of the SSR payload. The client picks it up without a second fetch.
+
+Because the file is read fresh on every request, you can edit `flags.json` on disk and the very
+next page request will see the new values. No restart needed.
+
+### `useFeatureFlag()` composable
+
+Any Vue component or composable can call:
+
+```ts
+const isEnabled = useFeatureFlag('some-feature.enabled', true)
+// isEnabled is a computed ref — it reads from useState('feature-flags')
+// the second argument is the default value if the flag is not in the file
+```
+
+Because it is a computed ref over `useState('feature-flags')`, if the state updates, the computed
+ref updates too — reactively.
+
+---
+
+## Part 3 — What We Built on Top of This
+
+We agreed on a naming convention: the flag key for an extension is always:
+
+```
+extension.<extension-id>.enabled
+```
+
+For our test module:
+
+```
+extension.plenty-pwa-module-prototype.enabled
+```
+
+Set this to `false` in `flags.json` and the extension should be disabled. Set it to `true` and it
+should be active. The whole system we built makes this actually do something.
+
+---
+
+## Part 4 — Disabling Blocks in the Editor Palette
+
+### How blocks are discovered (background)
+
+When you open the "Add Block" panel in the editor, the PWA needs to show a list of available blocks.
+The list is built by a function called `resolveBlocksList()` in `blocks-imports.ts`.
+
+This function uses Vite's `import.meta.glob` — a special build-time feature that scans the
+filesystem for files matching a pattern. For extension blocks, it scans:
+
+```
+node_modules/*/runtime/components/blocks/**/defaults.ts
+```
+
+Each `defaults.ts` file exports a `getBlocksList()` function that returns the block definitions for
+that package. `resolveBlocksList()` calls all of them and merges the results.
+
+### The monorepo problem
+
+`import.meta.glob('/node_modules/...')` looks in `apps/web/node_modules/`. But in a monorepo with
+npm workspaces, packages are installed at the root: `plentyshop-pwa/node_modules/`. The pattern
+never finds them.
+
+**Fix:** we added a second glob pattern using a relative path from the source file to the monorepo
+root's node_modules (5 levels up from `blocks-imports.ts`):
+
+```ts
+import.meta.glob('../../../../../node_modules/*/runtime/components/blocks/**/defaults.ts')
+```
+
+This is in `apps/web/app/utils/blocks/blocks-imports.ts`.
+
+### The filter
+
+We updated `resolveBlocksList()` to check the feature flags before loading each `defaults.ts`:
+
+```ts
+const featureFlags = useState('feature-flags', () => ({}))
+
+const isDisabled = (path: string): boolean => {
+  // extract "plenty-pwa-module-prototype" from the file path
+  const extId = path.match(/node_modules\/(.+?)\/runtime\//)?.[1]
+  if (!extId) return false
+  return featureFlags.value[`extension.${extId}.enabled`] === false
+}
+
+// only load defaults.ts files from enabled extensions
+const entries = Object.entries(allBlockListLoaders).filter(([path]) => !isDisabled(path))
+```
+
+The extension ID is extracted **from the file path automatically**. The module does not need to
+declare its own ID anywhere — the path already contains it.
+
+Result: when `extension.plenty-pwa-module-prototype.enabled` is `false` in `useState('feature-flags')`,
+the `StoreHero/defaults.ts` is never loaded, and StoreHero does not appear in the block palette.
+
+---
+
+## Part 5 — Disabling Routes
+
+### The problem
+
+Nuxt bakes page routes into the router at **build time**. The `/store` route always exists in the
+compiled output. You cannot remove it at runtime. What you can do is intercept navigation to it and
+redirect away.
+
+### Nuxt route middleware
+
+Nuxt supports "route middleware" — functions that run before every page navigation. A **global**
+route middleware runs on every navigation to every page.
+
+### What shop-core does automatically
+
+We added two things to `shop-core/src/module.ts`:
+
+**Step 1 — Tag extension pages at build time**
+
+A `pages:extend` hook runs during the build. It looks at every registered page and checks if its
+file path belongs to a known extension:
+
+```ts
+nuxt.hook('pages:extend', (pages) => {
+  for (const page of pages) {
+    // does this page come from an extension's node_modules folder?
+    const match = page.file.match(/node_modules\/(.+?)\/runtime\//)
+    if (match && extensionIds.has(match[1])) {
+      // tag the page with the extension ID
+      page.meta = { ...page.meta, extensionId: match[1] }
+    }
+  }
+})
+```
+
+After this, the `/store` route has `meta.extensionId = 'plenty-pwa-module-prototype'` baked in.
+
+**Step 2 — Guard tagged pages at runtime**
+
+A new plugin (`extension-guard.ts`) is added to shop-core. It runs in the browser and registers a
+global route middleware:
+
+```ts
+addRouteMiddleware('extension-guard', (to) => {
+  const extensionId = to.meta?.extensionId
+  if (!extensionId) return // not an extension page, let it through
+
+  const enabled = useFeatureFlag(`extension.${extensionId}.enabled`, true)
+  if (!enabled.value) {
+    return navigateTo('/not-found', { replace: true })
+  }
+}, { global: true })
+```
+
+Before every navigation, this middleware checks: does the destination page belong to a disabled
+extension? If yes, redirect to `/not-found`.
+
+**The module's `store.vue` does nothing special.** The guard is invisible to the extension author.
+
+---
+
+## Part 6 — The Editor Settings UI
+
+We built a settings panel in the PWA editor that shows a list of installed extensions with toggles.
+
+### File structure
+
+```
+apps/web/app/
+├── components/settings/modules/
+│   ├── ToolbarTrigger.vue                  ← the layers icon in the editor sidebar
+│   ├── View.vue                            ← the panel title and description
+│   └── extensions/
+│       ├── View.vue                        ← "Extensions" subcategory header
+│       └── 1.module-list/
+│           └── ModuleToggles.vue           ← the actual toggle list
+│
+└── composables/useModuleManifest/
+    ├── types.ts
+    ├── useModuleManifest.ts                ← fetches and toggles modules
+    └── index.ts
+```
+
+The settings framework **auto-discovers** these components via `import.meta.glob`. Placing a file
+in the right folder is enough — no registration needed.
+
+### How the toggle works
+
+When you flip a switch in the editor:
+
+1. `ModuleToggles.vue` calls `handleToggle(id, enabled)`
+2. `handleToggle` calls `toggleModule(id, enabled)` from `useModuleManifest`
+3. `toggleModule` sends a `PATCH` request to `/_shop/modules`
+4. The server route writes the new value to `flags.json` on disk
+5. `toggleModule` also updates `useState('feature-flags')` **directly in the browser** so the
+   change is immediate — no page reload needed
+6. `handleToggle` then calls `getBlocksLists()` which re-runs `resolveBlocksList()` with the
+   updated flags — the block palette updates instantly
+
+### The server routes
+
+We created two Nitro server routes in `apps/web/server/routes/_shop/`:
+
+**`modules.get.ts` — GET `/_shop/modules`**
+
+Returns the list of installed extensions with their current enabled state.
+
+- The extension list comes from **`runtimeConfig.shopCoreExtensions`** — this is baked into the
+  server at build time by shop-core, so it works in both dev and production (no filesystem lookup
+  for the manifest at runtime).
+- The enabled state comes from reading `flags.json` directly (since this is a server route running
+  in Node.js, it can read files).
+
+**`modules.patch.ts` — PATCH `/_shop/modules`**
+
+Accepts `{ id, enabled }` and writes the flag to `flags.json`.
+
+```json
+{ "extension.plenty-pwa-module-prototype.enabled": false }
+```
+
+The file path is read from the `JSON_FEATURE_FLAGS_FILE` env var (same env var that
+`feature-flags.server.ts` uses), so both sides always read and write the same file.
+
+---
+
+## Part 7 — Why It Works in Both Dev and Production
+
+The original `GET /_shop/modules` route read `module.manifest.json` at runtime using
+`process.cwd()`. In development this is `apps/web/` and the file is there. In production, the
+compiled server starts from a different directory (`.output/server/`) and the file is not there —
+the list came back empty.
+
+The fix: shop-core injects the extension list into `runtimeConfig` at **build time**:
+
+```ts
+// shop-core/src/module.ts — runs at build time
+nuxt.options.runtimeConfig.shopCoreExtensions = (_cachedExtensions ?? [])
+  .filter((e) => e.enabled !== false)
+  .map((e) => ({ id: e.id, version: e.version ?? null }))
+```
+
+`runtimeConfig` is serialized into the Nitro server bundle. The GET route reads it with
+`useRuntimeConfig(event)` — this works everywhere, regardless of working directory.
+
+---
+
+## Part 8 — The Complete Picture
+
+```
+                        EDITOR
+                           │
+                    flip toggle OFF
+                           │
+              PATCH /_shop/modules
+              { id: "plenty-pwa-module-prototype", enabled: false }
+                           │
+              ┌────────────┴──────────────┐
+              ▼                           ▼
+        flags.json                useState('feature-flags')
+        updated on disk            updated in browser memory
+              │                           │
+              │ next SSR request          │ immediately
+              ▼                           ▼
+    feature-flags.server        resolveBlocksList() re-runs
+    plugin reads file           → StoreHero gone from palette
+    → new SSR requests
+      see flag = false
+
+    extension-guard middleware
+    → /store redirects to /not-found
+    on next navigation
+```
+
+---
+
+## Part 9 — What the Extension Module Does NOT Need to Do
+
+This is important. The extension module (`plenty-pwa-module-prototype`) does not need to:
+
+- Know about `flags.json`
+- Call `useFeatureFlag()`
+- Guard its own routes
+- Register its own ID anywhere special
+- Have any awareness of the toggle system
+
+It just uses standard Nuxt module APIs (`extendPages`, `addComponent`, `getBlocksList`). Everything
+else is handled by shop-core and the PWA automatically.
+
+---
+
+## Summary — What Lives Where
+
+| What | Where | When it runs |
+|------|-------|-------------|
+| Extension manifest | `apps/web/module.manifest.json` | Read at build time |
+| Extension list in bundle | `runtimeConfig.shopCoreExtensions` (set in shop-core) | Build time |
+| Flags storage | `apps/web/flags.json` (dev) or `/etc/plenty/feature-flags/flags.json` (prod) | Runtime, per-request |
+| Flags loaded into state | `shop-core` `feature-flags.server` plugin | Every SSR request |
+| Block palette filter | `apps/web/app/utils/blocks/blocks-imports.ts` | Called when editor opens palette |
+| Route tag | `shop-core` `pages:extend` hook | Build time |
+| Route guard | `shop-core` `extension-guard` plugin | Every client-side navigation |
+| Toggle UI | `apps/web/app/components/settings/modules/` | Editor only |
+| Toggle API | `apps/web/server/routes/_shop/modules.get.ts` + `modules.patch.ts` | Runtime |
+| Client-side instant sync | `useModuleManifest.toggleModule` updates `useState` | After PATCH |

--- a/docs/extension-toggle-system.md
+++ b/docs/extension-toggle-system.md
@@ -1,32 +1,91 @@
-# Extension Toggle System — Complete Explanation
+# Extension Toggle System — Complete Reference
 
-This document explains what was built, why it works the way it does, and what each moving part does.
-It assumes no prior knowledge of the implementation.
+This document covers everything that was built to enable runtime enabling/disabling of extensions
+(Nuxt modules) in the PWA. It includes all changed and added files across three repos, code snippets,
+explanations, and an honest pros/cons assessment.
 
----
-
-## The Problem We Were Solving
-
-The PWA supports external Nuxt modules (called "extensions") that add new routes, CMS blocks, and
-components to the shop. For example: `plenty-pwa-module-prototype` adds a `/store` page and a
-`StoreHero` CMS block.
-
-These extensions are currently registered at **build time**. Once you build the PWA, the extension's
-routes and components are compiled into the output. If you want to disable an extension, you have to
-rebuild the entire PWA and redeploy it. That's slow and expensive.
-
-**The goal:** be able to turn an extension on or off while the server is running, with no rebuild, no
-redeploy, and no server restart.
+**Repos involved:**
+- `plentyshop-pwa` — the PWA frontend
+- `shop-core` (`@plentymarkets/shop-core`) — the core Nuxt module
+- `plenty-pwa-module-prototype` — the test extension used to prove the system works
 
 ---
 
-## Part 1 — How the PWA Already Knows About Extensions
+## The Question This Answers
 
-### `module.manifest.json`
+> *What's the mechanism for disabling a module? Is it a central helper in shop-core? Does each
+> module have to handle this individually? If so, at what scale?*
 
-There is a file at `apps/web/module.manifest.json`. It lists which extensions are installed:
+**Short answer:** There is a central mechanism in shop-core that handles 80% of the work
+automatically. A module author does not need to guard their own routes or know about `flags.json`.
+However, if a module wants reactive behavior at the component level — e.g. hiding a banner, pausing
+a timer, gracefully hiding injected content instead of just redirecting — it must opt in explicitly
+using the composables shop-core exports.
+
+The two tiers:
+
+| Tier | Who does the work | What it covers |
+|------|-------------------|----------------|
+| **Automatic (shop-core)** | The platform | Route navigation guard, block palette filter, SSR flag loading |
+| **Opt-in (module author)** | The module | Component visibility, timer pause, slot registration, page override fallback |
+
+---
+
+## Architecture Overview
+
+```
+                     EDITOR TOGGLE (ModuleToggles.vue)
+                              │
+               PATCH /_shop/modules  { id, enabled }
+                              │
+              ┌───────────────┴────────────────┐
+              ▼                                ▼
+        flags.json (disk)             useState('feature-flags')
+        written by modules.patch.ts   updated in-memory by useModuleManifest
+              │                                │
+              │ every new SSR request          │ immediately, reactively
+              ▼                                ▼
+    feature-flags.server plugin      resolveBlocksList() re-evaluates
+    reads file → populates state     → StoreHero gone from block palette
+
+    extension-guard middleware        useExtensionEnabled() computed ref
+    → /store redirects to /not-found  → CountdownBanner hides, timer pauses
+    on next client navigation         → ExtensionSlot filters entries out
+```
+
+---
+
+## The Flag Convention
+
+Every extension flag follows one naming convention:
+
+```
+extension.<extension-id>.enabled
+```
+
+Example for `plenty-pwa-module-prototype`:
 
 ```json
+{
+  "extension.plenty-pwa-module-prototype.enabled": false
+}
+```
+
+Setting this to `false` disables the extension. Absent key = enabled (default is always on).
+
+---
+
+## Part 1 — shop-core (the platform layer)
+
+### Build time
+
+#### `src/build/loadExtensions.ts`
+
+Reads `module.manifest.json` from the project root. Validates entries — each must have a safe `id`
+string and a valid `entry` (npm package name or `[name, options]` tuple).
+
+```ts
+// apps/web/module.manifest.json
 [
   {
     "id": "plenty-pwa-module-prototype",
@@ -36,351 +95,710 @@ There is a file at `apps/web/module.manifest.json`. It lists which extensions ar
 ]
 ```
 
-- `id` — the unique identifier, used as the key for all flag names
-- `entry` — the npm package name that Node.js will `require()`
-- `version` — informational
+`loadExtensionsSync` is the synchronous variant used in `moduleDependencies()` (which must be sync).
+`loadExtensions` is the async variant used in `setup()`.
 
-When Nuxt starts building, `@plentymarkets/shop-core` reads this file and adds each `entry` as a Nuxt
-module dependency. Nuxt then loads those modules, which register their pages, components, and blocks
-into the build.
+#### `src/build/setupExtensions.ts`
 
-This all happens at **build time**. Changing this file after a build does nothing until you rebuild.
-
-### The npm package
-
-The extension lives at `node_modules/plenty-pwa-module-prototype/`. Its `index.ts` file is the Nuxt
-module entry point — it calls `addComponent`, `extendPages`, etc. to register its content.
-
----
-
-## Part 2 — The Feature Flag System (pre-existing in shop-core)
-
-Before we touched anything, shop-core already had a feature flag system. Here is how it works:
-
-### The flags file
-
-A JSON file on disk holds boolean flags:
-
-```json
-{
-  "some-feature.enabled": true,
-  "another-feature.enabled": false
-}
-```
-
-In production this file lives at a configured path on the server.
-In development you can point to a local copy by setting the `JSON_FEATURE_FLAGS_FILE` environment
-variable to a path of your choice.
-
-### The server plugin — `feature-flags.server.ts`
-
-This plugin runs on **every single SSR request**, before the page renders:
-
-```
-User visits page → server receives request → plugin runs → reads flags.json from disk
-→ puts contents into useState('feature-flags') → page renders using those flags
-```
-
-`useState('feature-flags')` is Nuxt's built-in shared state. It is populated on the server and
-sent to the browser as part of the SSR payload. The client picks it up without a second fetch.
-
-Because the file is read fresh on every request, you can edit `flags.json` on disk and the very
-next page request will see the new values. No restart needed.
-
-### `useFeatureFlag()` composable
-
-Any Vue component or composable can call:
+Takes the loaded entries and injects each enabled extension's settings into
+`runtimeConfig.public[ext.id]` and private settings into `runtimeConfig[ext.id]`.
 
 ```ts
-const isEnabled = useFeatureFlag('some-feature.enabled', true)
-// isEnabled is a computed ref — it reads from useState('feature-flags')
-// the second argument is the default value if the flag is not in the file
+nuxt.options.runtimeConfig.public[ext.id] = {
+  enabled: true,
+  ...(ext.settings ?? {}),
+};
 ```
 
-Because it is a computed ref over `useState('feature-flags')`, if the state updates, the computed
-ref updates too — reactively.
+#### `src/module.ts` (relevant parts)
 
----
+Three things happen in the module setup relevant to this system:
 
-## Part 3 — What We Built on Top of This
-
-We agreed on a naming convention: the flag key for an extension is always:
-
-```
-extension.<extension-id>.enabled
-```
-
-For our test module:
-
-```
-extension.plenty-pwa-module-prototype.enabled
-```
-
-Set this to `false` in `flags.json` and the extension should be disabled. Set it to `true` and it
-should be active. The whole system we built makes this actually do something.
-
----
-
-## Part 4 — Disabling Blocks in the Editor Palette
-
-### How blocks are discovered (background)
-
-When you open the "Add Block" panel in the editor, the PWA needs to show a list of available blocks.
-The list is built by a function called `resolveBlocksList()` in `blocks-imports.ts`.
-
-This function uses Vite's `import.meta.glob` — a special build-time feature that scans the
-filesystem for files matching a pattern. For extension blocks, it scans:
-
-```
-node_modules/*/runtime/components/blocks/**/defaults.ts
-```
-
-Each `defaults.ts` file exports a `getBlocksList()` function that returns the block definitions for
-that package. `resolveBlocksList()` calls all of them and merges the results.
-
-### The monorepo problem
-
-`import.meta.glob('/node_modules/...')` looks in `apps/web/node_modules/`. But in a monorepo with
-npm workspaces, packages are installed at the root: `plentyshop-pwa/node_modules/`. The pattern
-never finds them.
-
-**Fix:** we added a second glob pattern using a relative path from the source file to the monorepo
-root's node_modules (5 levels up from `blocks-imports.ts`):
+**1. Extension list baked into runtimeConfig (for the GET route)**
 
 ```ts
-import.meta.glob('../../../../../node_modules/*/runtime/components/blocks/**/defaults.ts')
+nuxt.options.runtimeConfig.shopCoreExtensions = (_cachedExtensions ?? [])
+  .filter((e) => e.enabled !== false)
+  .map((e) => ({ id: e.id, version: e.version ?? null }));
 ```
 
-This is in `apps/web/app/utils/blocks/blocks-imports.ts`.
+This is what makes `GET /_shop/modules` work in production — the list is in the server bundle,
+not read from the filesystem at runtime.
 
-### The filter
-
-We updated `resolveBlocksList()` to check the feature flags before loading each `defaults.ts`:
-
-```ts
-const featureFlags = useState('feature-flags', () => ({}))
-
-const isDisabled = (path: string): boolean => {
-  // extract "plenty-pwa-module-prototype" from the file path
-  const extId = path.match(/node_modules\/(.+?)\/runtime\//)?.[1]
-  if (!extId) return false
-  return featureFlags.value[`extension.${extId}.enabled`] === false
-}
-
-// only load defaults.ts files from enabled extensions
-const entries = Object.entries(allBlockListLoaders).filter(([path]) => !isDisabled(path))
-```
-
-The extension ID is extracted **from the file path automatically**. The module does not need to
-declare its own ID anywhere — the path already contains it.
-
-Result: when `extension.plenty-pwa-module-prototype.enabled` is `false` in `useState('feature-flags')`,
-the `StoreHero/defaults.ts` is never loaded, and StoreHero does not appear in the block palette.
-
----
-
-## Part 5 — Disabling Routes
-
-### The problem
-
-Nuxt bakes page routes into the router at **build time**. The `/store` route always exists in the
-compiled output. You cannot remove it at runtime. What you can do is intercept navigation to it and
-redirect away.
-
-### Nuxt route middleware
-
-Nuxt supports "route middleware" — functions that run before every page navigation. A **global**
-route middleware runs on every navigation to every page.
-
-### What shop-core does automatically
-
-We added two things to `shop-core/src/module.ts`:
-
-**Step 1 — Tag extension pages at build time**
-
-A `pages:extend` hook runs during the build. It looks at every registered page and checks if its
-file path belongs to a known extension:
+**2. Pages tagged with their extension ID**
 
 ```ts
 nuxt.hook('pages:extend', (pages) => {
+  const extensionIds = new Set(
+    (_cachedExtensions ?? []).filter((e) => e.enabled !== false).map((e) => e.id)
+  );
   for (const page of pages) {
-    // does this page come from an extension's node_modules folder?
-    const match = page.file.match(/node_modules\/(.+?)\/runtime\//)
+    const match =
+      page.file?.match(/node_modules\/(.+?)\/runtime\//) ??
+      page.file?.match(/modules\/(.+?)\/runtime\//);
     if (match && extensionIds.has(match[1])) {
-      // tag the page with the extension ID
-      page.meta = { ...page.meta, extensionId: match[1] }
+      page.meta = { ...page.meta, extensionId: match[1] };
     }
   }
-})
+});
 ```
 
-After this, the `/store` route has `meta.extensionId = 'plenty-pwa-module-prototype'` baked in.
+After this hook, `/store` has `meta.extensionId = 'plenty-pwa-module-prototype'` baked in.
+The module does not set this itself — it is inferred from the file path.
 
-**Step 2 — Guard tagged pages at runtime**
-
-A new plugin (`extension-guard.ts`) is added to shop-core. It runs in the browser and registers a
-global route middleware:
+**3. Feature flags defaults baked into runtimeConfig.public**
 
 ```ts
-addRouteMiddleware('extension-guard', (to) => {
-  const extensionId = to.meta?.extensionId
-  if (!extensionId) return // not an extension page, let it through
+featureFlags: {
+  ...Object.fromEntries(
+    (_cachedExtensions ?? [])
+      .filter((e) => e.enabled !== false)
+      .map((e) => [`extension.${e.id}.enabled`, true]),
+  ),
+  ...(_options.featureFlags ?? {}),
+},
+```
 
-  const enabled = useFeatureFlag(`extension.${extensionId}.enabled`, true)
-  if (!enabled.value) {
-    return navigateTo('/not-found', { replace: true })
+This ensures that even if `flags.json` is missing or doesn't mention the extension, the default is
+`true` (enabled). The runtime plugin reads from file first, then falls back to these defaults.
+
+---
+
+### Runtime (plugins)
+
+#### `src/runtime/plugins/feature-flags.server.ts`
+
+Runs on **every SSR request**, before the page renders. Reads `flags.json` from disk (path
+configurable via `JSON_FEATURE_FLAGS_FILE` env var). Puts the parsed object into
+`useState('feature-flags')`, which Nuxt serializes into the SSR payload and hydrates on the client.
+
+```ts
+export default defineNuxtPlugin({
+  name: 'shop-core:feature-flags',
+  enforce: 'pre',
+  async setup() {
+    const runtimeConfig = useRuntimeConfig();
+    const flags = useState<Record<string, unknown>>('feature-flags', () => ({}));
+    flags.value = await loadFeatureFlags({
+      readFile,
+      filePath: process.env.JSON_FEATURE_FLAGS_FILE ?? '/etc/plenty/feature-flags/flags.json',
+      configFlags: runtimeConfig.public.shopCore.featureFlags,
+    });
+  },
+});
+```
+
+**Key detail:** `configFlags` is the fallback. If the file doesn't exist (first run, no flags set),
+it falls back to the defaults baked in at build time — so all extensions start as enabled.
+
+#### `src/runtime/plugins/extension-guard.ts`
+
+Runs on the client. Registers a global route middleware that checks every navigation target.
+
+```ts
+export default defineNuxtPlugin(() => {
+  addRouteMiddleware(
+    'extension-guard',
+    (to) => {
+      const extensionId = to.meta?.extensionId as string | undefined;
+      if (!extensionId) return;
+
+      const enabled = useFeatureFlag(`extension.${extensionId}.enabled`, true);
+      if (!enabled.value) {
+        return navigateTo('/not-found', { replace: true });
+      }
+    },
+    { global: true },
+  );
+});
+```
+
+Any page tagged with `extensionId` gets automatically guarded. The module author does nothing.
+The redirect is client-side — if a user has `/store` bookmarked and the extension gets disabled,
+the next time they navigate to it (or click a link) they hit `/not-found`.
+
+**Limitation:** This does NOT cover SSR. If someone hits `/store` directly via URL while the server
+is processing the request, the server renders the page. The guard only fires on client-side
+navigation. See Pros/Cons for discussion.
+
+---
+
+### Runtime (composables)
+
+#### `src/runtime/composables/useFeatureFlag.ts`
+
+The primitive. Reads a flag by key from `useState('feature-flags')`. Returns a computed ref.
+
+```ts
+export const useFeatureFlag = (flag: string, defaultValue = false) => {
+  const flags = useState<Record<string, unknown>>('feature-flags');
+  return computed(() => Boolean(flags.value?.[flag] ?? defaultValue));
+};
+```
+
+#### `src/runtime/composables/useExtensionEnabled.ts`
+
+A higher-level composable that combines runtimeConfig (build-time default) with the feature flag
+(runtime override). Both must be truthy for the extension to be considered enabled.
+
+```ts
+export const useExtensionEnabled = (id: string) => {
+  const runtimeConfig = useRuntimeConfig();
+  const flagEnabled = useFeatureFlag(`extension.${id}.enabled`, true);
+  return computed(() => {
+    const rcEnabled = (runtimeConfig.public[id] as { enabled?: boolean } | undefined)?.enabled !== false;
+    return rcEnabled && flagEnabled.value;
+  });
+};
+```
+
+This is what module composables call. It is the single source of truth for a module's enabled state.
+
+#### `src/runtime/composables/useModuleRendering.ts`
+
+Allows a module plugin to register component names into a named rendering area. The PWA then uses
+`<ModuleComponentRendering area="..." />` to render whatever was registered there. This is an
+alternative to the slot system — it works with globally registered components by name.
+
+```ts
+export const useModuleRendering = (area: RenderingAreas) => {
+  const state = useState(`useModuleRendering_${area}`, () => ({ components: [] as string[] }));
+
+  const addComponent = (componentName: string) => {
+    if (state.value.components.includes(componentName)) return;
+    state.value.components.push(componentName);
+  };
+
+  return { addComponent, ...toRefs(state.value) };
+};
+```
+
+---
+
+### Runtime (types)
+
+#### `src/runtime/types/extensions.ts`
+
+```ts
+export const DEFAULT_PRIORITY = 500;
+export const MANIFEST_FILENAME = 'module.manifest.json';
+export const LOG_PREFIX = '[shop-core | extensions]';
+export const DANGEROUS_IDS = new Set(['__proto__', 'constructor', 'prototype']);
+
+export interface ExtensionEntry {
+  id: string;
+  entry: ModuleEntry;        // npm name or [name, options] tuple
+  version?: string;
+  priority?: number;         // lower = loads first
+  settings?: Record<string, unknown>;       // public
+  privateSettings?: Record<string, unknown>; // server-only
+  enabled?: boolean;         // false = skip at build time
+}
+```
+
+---
+
+### Runtime (utils)
+
+#### `src/runtime/utils/featureFlagsHelper.ts`
+
+Pure function — injectable deps for testability.
+
+```ts
+export const loadFeatureFlags = async (deps: LoadFeatureFlagsDeps): Promise<Record<string, unknown>> => {
+  try {
+    const parsed: unknown = JSON.parse(await deps.readFile(deps.filePath, 'utf-8'));
+    if (isRecord(parsed)) return parsed;
+  } catch {}
+  return deps.configFlags ?? {};
+};
+```
+
+---
+
+## Part 2 — PWA server routes
+
+#### `apps/web/server/routes/_shop/modules.get.ts`
+
+Returns the list of installed extensions with their current enabled state, merging the build-time
+list with the runtime flags file.
+
+```ts
+export default defineEventHandler((event) => {
+  const runtimeConfig = useRuntimeConfig(event);
+  // list baked in at build time — works in production
+  const extensions = (runtimeConfig.shopCoreExtensions ?? []) as Array<{ id: string; version: string | null }>;
+  const flags = readFlags(); // reads flags.json from disk
+
+  return extensions.map((ext) => {
+    const flagKey = `extension.${ext.id}.enabled`;
+    const flagValue = flags[flagKey];
+    return {
+      id: ext.id,
+      version: ext.version,
+      enabled: flagValue !== undefined ? flagValue : true, // absent = enabled
+    };
+  });
+});
+```
+
+#### `apps/web/server/routes/_shop/modules.patch.ts`
+
+Writes `extension.<id>.enabled` to `flags.json`. Both routes use the same `JSON_FEATURE_FLAGS_FILE`
+env var, so they always read/write the same file.
+
+```ts
+export default defineEventHandler(async (event) => {
+  const body = await readBody<PatchBody>(event);
+
+  if (!body?.id || typeof body.enabled !== 'boolean') {
+    throw createError({ statusCode: 400, statusMessage: 'id and enabled are required' });
   }
-}, { global: true })
+
+  const flagsPath = getFlagsPath();
+  let flags: Record<string, unknown> = {};
+
+  if (existsSync(flagsPath)) {
+    flags = JSON.parse(readFileSync(flagsPath, 'utf-8'));
+  }
+
+  flags[`extension.${body.id}.enabled`] = body.enabled;
+  writeFileSync(flagsPath, JSON.stringify(flags, null, 2) + '\n');
+
+  return { id: body.id, enabled: body.enabled };
+});
 ```
-
-Before every navigation, this middleware checks: does the destination page belong to a disabled
-extension? If yes, redirect to `/not-found`.
-
-**The module's `store.vue` does nothing special.** The guard is invisible to the extension author.
 
 ---
 
-## Part 6 — The Editor Settings UI
+## Part 3 — PWA composables
 
-We built a settings panel in the PWA editor that shows a list of installed extensions with toggles.
+#### `apps/web/app/composables/useModuleManifest/useModuleManifest.ts`
 
-### File structure
-
-```
-apps/web/app/
-├── components/settings/modules/
-│   ├── ToolbarTrigger.vue                  ← the layers icon in the editor sidebar
-│   ├── View.vue                            ← the panel title and description
-│   └── extensions/
-│       ├── View.vue                        ← "Extensions" subcategory header
-│       └── 1.module-list/
-│           └── ModuleToggles.vue           ← the actual toggle list
-│
-└── composables/useModuleManifest/
-    ├── types.ts
-    ├── useModuleManifest.ts                ← fetches and toggles modules
-    └── index.ts
-```
-
-The settings framework **auto-discovers** these components via `import.meta.glob`. Placing a file
-in the right folder is enough — no registration needed.
-
-### How the toggle works
-
-When you flip a switch in the editor:
-
-1. `ModuleToggles.vue` calls `handleToggle(id, enabled)`
-2. `handleToggle` calls `toggleModule(id, enabled)` from `useModuleManifest`
-3. `toggleModule` sends a `PATCH` request to `/_shop/modules`
-4. The server route writes the new value to `flags.json` on disk
-5. `toggleModule` also updates `useState('feature-flags')` **directly in the browser** so the
-   change is immediate — no page reload needed
-6. `handleToggle` then calls `getBlocksLists()` which re-runs `resolveBlocksList()` with the
-   updated flags — the block palette updates instantly
-
-### The server routes
-
-We created two Nitro server routes in `apps/web/server/routes/_shop/`:
-
-**`modules.get.ts` — GET `/_shop/modules`**
-
-Returns the list of installed extensions with their current enabled state.
-
-- The extension list comes from **`runtimeConfig.shopCoreExtensions`** — this is baked into the
-  server at build time by shop-core, so it works in both dev and production (no filesystem lookup
-  for the manifest at runtime).
-- The enabled state comes from reading `flags.json` directly (since this is a server route running
-  in Node.js, it can read files).
-
-**`modules.patch.ts` — PATCH `/_shop/modules`**
-
-Accepts `{ id, enabled }` and writes the flag to `flags.json`.
-
-```json
-{ "extension.plenty-pwa-module-prototype.enabled": false }
-```
-
-The file path is read from the `JSON_FEATURE_FLAGS_FILE` env var (same env var that
-`feature-flags.server.ts` uses), so both sides always read and write the same file.
-
----
-
-## Part 7 — Why It Works in Both Dev and Production
-
-The original `GET /_shop/modules` route read `module.manifest.json` at runtime using
-`process.cwd()`. In development this is `apps/web/` and the file is there. In production, the
-compiled server starts from a different directory (`.output/server/`) and the file is not there —
-the list came back empty.
-
-The fix: shop-core injects the extension list into `runtimeConfig` at **build time**:
+Fetches the module list and handles toggling. The key detail is step 5: after the PATCH succeeds,
+it writes directly into `useState('feature-flags')` so the change propagates reactively everywhere
+in the same browser tab — without waiting for the next SSR request.
 
 ```ts
-// shop-core/src/module.ts — runs at build time
-nuxt.options.runtimeConfig.shopCoreExtensions = (_cachedExtensions ?? [])
-  .filter((e) => e.enabled !== false)
-  .map((e) => ({ id: e.id, version: e.version ?? null }))
+const toggleModule = async (id: string, enabled: boolean) => {
+  loading.value = true;
+  try {
+    const updated = await $fetch<ModuleManifestEntry>('/_shop/modules', {
+      method: 'PATCH',
+      body: { id, enabled },
+    });
+
+    const index = modules.value.findIndex((module) => module.id === id);
+    if (index !== -1) {
+      modules.value[index] = updated;
+    }
+
+    // Instant reactive update — no page refresh needed
+    const featureFlags = useState<Record<string, boolean>>('feature-flags', () => ({}));
+    featureFlags.value = { ...featureFlags.value, [`extension.${id}.enabled`]: enabled };
+  } catch (error) {
+    useHandleError(error as NuxtError<unknown> | null);
+  } finally {
+    loading.value = false;
+  }
+};
 ```
 
-`runtimeConfig` is serialized into the Nitro server bundle. The GET route reads it with
-`useRuntimeConfig(event)` — this works everywhere, regardless of working directory.
+#### `apps/web/app/composables/useExtensionSlot/useExtensionSlot.ts`
+
+The slot system. Modules register component objects (not names) into named slots. The slot then
+renders them, filtered by `feature-flags` state. The component map is a plain module-level `Map`
+(not reactive, not serialized) because Vue component objects cannot be serialized into SSR state.
+
+```ts
+const _componentRegistry = new Map<string, Component>();
+
+const register = (slotName: string, component: Component, componentName: string, extensionId: string) => {
+  _componentRegistry.set(componentName, component);
+  if (!_slots.value[slotName]) {
+    _slots.value[slotName] = [];
+  }
+  const alreadyRegistered = _slots.value[slotName].some((e) => e.componentName === componentName);
+  if (!alreadyRegistered) {
+    _slots.value[slotName].push({ componentName, extensionId });
+  }
+};
+
+const getSlotEntries = (slotName: string) => {
+  const featureFlags = useState<Record<string, boolean>>('feature-flags', () => ({}));
+  return computed(() => {
+    return (_slots.value[slotName] ?? []).filter(({ extensionId }) => {
+      return featureFlags.value[`extension.${extensionId}.enabled`] !== false;
+    });
+  });
+};
+```
+
+When `toggleModule` updates `useState('feature-flags')`, `getSlotEntries`'s computed re-evaluates,
+and Vue removes the disabled extension's component from the DOM. No page refresh.
 
 ---
 
-## Part 8 — The Complete Picture
+## Part 4 — PWA components
 
+#### `apps/web/app/components/ui/ExtensionSlot/ExtensionSlot.vue`
+
+A thin wrapper around `useExtensionSlot`. Accepts a `name` prop and renders whatever components are
+registered for that slot name and are currently enabled.
+
+```vue
+<template>
+  <component
+    :is="getSlotComponent(entry.componentName)"
+    v-for="entry in entries"
+    :key="entry.componentName"
+  />
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ name: string }>();
+const { getSlotEntries, getSlotComponent } = useExtensionSlot();
+const entries = getSlotEntries(props.name);
+</script>
 ```
-                        EDITOR
-                           │
-                    flip toggle OFF
-                           │
-              PATCH /_shop/modules
-              { id: "plenty-pwa-module-prototype", enabled: false }
-                           │
-              ┌────────────┴──────────────┐
-              ▼                           ▼
-        flags.json                useState('feature-flags')
-        updated on disk            updated in browser memory
-              │                           │
-              │ next SSR request          │ immediately
-              ▼                           ▼
-    feature-flags.server        resolveBlocksList() re-runs
-    plugin reads file           → StoreHero gone from palette
-    → new SSR requests
-      see flag = false
 
-    extension-guard middleware
-    → /store redirects to /not-found
-    on next navigation
+#### `apps/web/app/components/settings/modules/extensions/1.module-list/ModuleToggles.vue`
+
+The editor toggle UI. Uses `SfSwitch` from Storefront UI. Calls `handleToggle` which
+chains `toggleModule` → `getBlocksLists()` to update both the flag and the block palette.
+
+```vue
+<SfSwitch
+  :model-value="mod.enabled !== false"
+  :disabled="loading"
+  @update:model-value="(val) => handleToggle(mod.id, val === true)"
+/>
+```
+
+```ts
+const handleToggle = async (id: string, enabled: boolean) => {
+  await toggleModule(id, enabled);
+  await getBlocksLists(); // refreshes block palette
+};
 ```
 
 ---
 
-## Part 9 — What the Extension Module Does NOT Need to Do
+## Part 5 — PWA pages (modified)
 
-This is important. The extension module (`plenty-pwa-module-prototype`) does not need to:
+#### `apps/web/app/pages/index.vue`
 
-- Know about `flags.json`
-- Call `useFeatureFlag()`
-- Guard its own routes
-- Register its own ID anywhere special
-- Have any awareness of the toggle system
+Two additions to the homepage. First, the slot:
 
-It just uses standard Nuxt module APIs (`extendPages`, `addComponent`, `getBlocksList`). Everything
-else is handled by shop-core and the PWA automatically.
+```vue
+<UiExtensionSlot name="homepage-top" />
+```
+
+Modules register components here. When a module is disabled, its component disappears from this
+slot reactively. Second, the `CountdownBanner` component (added by the module):
+
+```vue
+<CountdownBanner />
+```
+
+The banner checks `useExtensionEnabled` inside its composable and hides itself when disabled.
+
+---
+
+## Part 6 — Module (plenty-pwa-module-prototype)
+
+This is a concrete example of a module using all three patterns.
+
+### Module definition — `index.ts`
+
+```ts
+export default defineNuxtModule({
+  meta: { name: 'plenty-pwa-module-prototype' },
+  setup(_options, _nuxt) {
+    const resolver = createResolver(import.meta.url);
+
+    addComponent({ name: 'PlentyRocks', filePath: resolver.resolve('./runtime/components/PlentyRocks.vue') });
+
+    addPlugin(resolver.resolve('./runtime/plugins/extension-state'));
+    addPlugin(resolver.resolve('./runtime/plugins/slots'));
+    addPlugin({ src: resolver.resolve('./runtime/plugins/shortcuts'), mode: 'client' });
+
+    addImportsDir(resolver.resolve('./runtime/composables'));
+
+    extendPages((pages) => {
+      // New page
+      pages.push({ name: 'store', path: '/store', file: resolver.resolve('./runtime/pages/store.vue') });
+
+      // Page overrides — swap the file, save the original as an alias
+      const checkoutPage = pages.find((p) => p.path === '/checkout');
+      if (checkoutPage?.file) {
+        _nuxt.options.alias['#pwa-checkout-original'] = checkoutPage.file;
+        checkoutPage.file = resolver.resolve('./runtime/pages/checkout.vue');
+      }
+
+      const tacPage = pages.find((p) => p.path === '/terms-and-conditions');
+      if (tacPage?.file) {
+        _nuxt.options.alias['#pwa-tac-original'] = tacPage.file;
+        tacPage.file = resolver.resolve('./runtime/pages/terms-and-conditions.vue');
+      }
+    });
+  },
+});
+```
+
+### Plugin: `runtime/plugins/slots.ts` — Slot registration
+
+```ts
+export default defineNuxtPlugin(() => {
+  const { register } = useExtensionSlot();
+  // Registers PlentyRocks into the 'homepage-top' slot.
+  // The slot filters it out automatically when the extension is disabled.
+  register('homepage-top', PlentyRocks, 'PlentyRocks', 'plenty-pwa-module-prototype');
+});
+```
+
+The module must explicitly call `register`. This is intentional — the slot system cannot auto-
+discover what should go where; the module author decides that.
+
+### Plugin: `runtime/plugins/extension-state.ts` — Cookie sync
+
+```ts
+const EXTENSION_ID = 'plenty-pwa-module-prototype';
+export default defineNuxtPlugin(() => {
+  const flags = useState<Record<string, boolean>>('feature-flags', () => ({}));
+  const cookie = useCookie<boolean>(`ext_${EXTENSION_ID}_enabled`, { default: () => true });
+
+  const enabled = computed(() => flags.value[`extension.${EXTENSION_ID}.enabled`] !== false);
+
+  // Keep a cookie in sync — useful for SSR decisions in server routes.
+  watch(enabled, (val) => { cookie.value = val; }, { immediate: true });
+
+  return { provide: { plentyModulePrototypeEnabled: enabled } };
+});
+```
+
+### Plugin: `runtime/plugins/shortcuts.ts` — Client keyboard shortcut (guarded)
+
+```ts
+export default defineNuxtPlugin(() => {
+  const enabled = useExtensionEnabled(EXTENSION_ID);
+  const router = useRouter();
+
+  window.addEventListener('keydown', (event: KeyboardEvent) => {
+    if (!enabled.value) return; // no-op when disabled
+    if (event.shiftKey && event.key === 'S') {
+      router.push('/store');
+    }
+  });
+});
+```
+
+### Composable: `runtime/composables/usePlentyModuleState.ts`
+
+A module-specific wrapper around `useExtensionEnabled`. Prevents the module's own code from
+hard-coding the extension ID in multiple places.
+
+```ts
+const EXTENSION_ID = 'plenty-pwa-module-prototype';
+
+export const usePlentyModuleState = () => {
+  const isEnabled = useExtensionEnabled(EXTENSION_ID);
+  return { isEnabled };
+};
+```
+
+### Composable: `runtime/composables/useCountdown.ts`
+
+An example of component-level reactive behavior. The timer pauses when disabled, resumes when
+re-enabled. Uses `usePlentyModuleState()` — not `useFeatureFlag` directly.
+
+```ts
+watch(
+  enabled,
+  (isEnabled) => {
+    if (isEnabled) {
+      start();
+    } else {
+      stop(); // timer pauses
+    }
+  },
+  { immediate: true },
+);
+```
+
+### New page: `runtime/pages/store.vue`
+
+A completely new route `/store` added by the module. Guarded by shop-core's `extension-guard`
+(automatic). Additionally, the page itself watches `enabled` and calls `showError({ statusCode: 404 })`
+as an extra safeguard for the case where the guard fires during SSR.
+
+```ts
+const enabled = useExtensionEnabled('plenty-pwa-module-prototype');
+
+watch(
+  enabled,
+  (val) => {
+    if (!val) showError({ statusCode: 404, fatal: true });
+  },
+  { immediate: true },
+);
+```
+
+### Overridden page: `runtime/pages/checkout.vue`
+
+The module replaces `/checkout` entirely. To support graceful degradation when disabled, it imports
+the original PWA checkout via the alias that was set up in `index.ts`, and switches between them
+with `v-if` based on `isEnabled`.
+
+```vue
+<template>
+  <PwaCheckout v-if="!isEnabled" />
+  <div v-else>
+    <!-- Module checkout UI -->
+  </div>
+</template>
+
+<script setup lang="ts">
+import PwaCheckout from '#pwa-checkout-original';
+const { isEnabled } = usePlentyModuleState();
+</script>
+```
+
+### Overridden page: `runtime/pages/terms-and-conditions.vue`
+
+Same pattern as checkout. The alias `#pwa-tac-original` points to the original PWA page.
+
+```vue
+<template>
+  <PwaTaC v-if="!isEnabled" />
+  <div v-else>
+    <!-- Module TaC content -->
+  </div>
+</template>
+
+<script setup lang="ts">
+import PwaTaC from '#pwa-tac-original';
+const { isEnabled } = usePlentyModuleState();
+</script>
+```
+
+---
+
+## Part 7 — The Three Extension Patterns
+
+### Pattern A: Slot injection
+
+The module registers a component into a named slot at app startup. The PWA renders the slot via
+`<UiExtensionSlot name="..." />`. When disabled, the component disappears reactively.
+
+- **Module effort:** call `register()` in a plugin
+- **PWA effort:** place `<UiExtensionSlot>` wherever injection is wanted
+- **Works on disable:** immediately, in same tab, no refresh
+
+### Pattern B: New page
+
+The module adds a new route (`/store`). The route is automatically tagged by shop-core's
+`pages:extend` hook. The `extension-guard` middleware redirects away when the extension is disabled.
+
+- **Module effort:** `pages.push(...)` in `extendPages` — standard Nuxt
+- **PWA effort:** none
+- **Works on disable:** on next client-side navigation; SSR hit of the URL still renders (see Cons)
+
+### Pattern C: Page override
+
+The module swaps an existing PWA page file (`/checkout`, `/terms-and-conditions`). It stores the
+original under a Nuxt alias and imports it back. The replacement page uses `v-if` on `isEnabled`
+to switch between the module UI and the original.
+
+- **Module effort:** set up alias + override in `extendPages`, implement `v-if` in the page
+- **PWA effort:** none (the original page is untouched at the filesystem level)
+- **Works on disable:** immediately — `v-if` reacts to flag change with no refresh
+
+---
+
+## Pros and Cons
+
+### What works well
+
+**No rebuild required.** Flipping a flag in `flags.json` (or via the editor toggle) is reflected
+on the very next page load without touching the compiled server bundle.
+
+**Mostly automatic for module authors.** Route guarding, block palette filtering, and SSR flag
+loading require zero work from the module. A module that does nothing special still gets its routes
+guarded and its blocks hidden automatically.
+
+**Reactive in the browser.** The `useState('feature-flags')` → computed ref chain means that the
+moment `toggleModule` writes the new state, every `useFeatureFlag`, `useExtensionEnabled`,
+`useExtensionSlot`, and any `v-if` reading from them updates immediately. No page refresh.
+
+**Consistent flag storage.** Both the server plugin and the PATCH route use `JSON_FEATURE_FLAGS_FILE`,
+so they always read/write the same file regardless of environment.
+
+**Extension list is production-safe.** `runtimeConfig.shopCoreExtensions` is serialized into the
+Nitro bundle at build time. The GET route works correctly even when the filesystem layout changes
+in production (`.output/server/`).
+
+---
+
+### Known limitations
+
+**Route guarding is client-side only.** `extension-guard` is a client-side Nuxt plugin. If a user
+hits a disabled extension's URL directly (e.g. bookmarked `/store`), the server processes the SSR
+request and renders the page before the guard fires. The guard then redirects, causing a flash or
+a visible redirect after hydration.
+
+Mitigations in place: `store.vue` calls `showError({ statusCode: 404, fatal: true })` on mount so
+the rendered page immediately throws a 404 in the browser. But this is a workaround, not a proper
+solution.
+
+A proper fix would be a Nuxt server middleware that reads `flags.json` and redirects at the edge
+before SSR runs. Not implemented yet.
+
+**Page overrides need module effort.** Pattern C (page override) requires the module to write the
+`v-if` logic and set up the alias. If the module forgets, disabling it leaves the module page
+rendered with no fallback. There is no framework-level enforcement.
+
+**Slots require PWA opt-in.** An extension can only inject into slots that the PWA has explicitly
+placed a `<UiExtensionSlot name="..." />` for. Modules cannot inject into arbitrary places without
+PWA changes.
+
+**Module is still compiled in.** All of this is runtime flag control, not build-time exclusion.
+The extension's JavaScript bundle is always downloaded by the client. You cannot use this to
+reduce bundle size.
+
+**The timer/component pattern is boilerplate.** Any module that has reactive components (timers,
+banners, etc.) needs to wire `useExtensionEnabled` manually. There is no hook or lifecycle the
+platform calls automatically.
 
 ---
 
 ## Summary — What Lives Where
 
-| What | Where | When it runs |
-|------|-------|-------------|
-| Extension manifest | `apps/web/module.manifest.json` | Read at build time |
-| Extension list in bundle | `runtimeConfig.shopCoreExtensions` (set in shop-core) | Build time |
-| Flags storage | `apps/web/flags.json` (dev) or `/etc/plenty/feature-flags/flags.json` (prod) | Runtime, per-request |
-| Flags loaded into state | `shop-core` `feature-flags.server` plugin | Every SSR request |
-| Block palette filter | `apps/web/app/utils/blocks/blocks-imports.ts` | Called when editor opens palette |
-| Route tag | `shop-core` `pages:extend` hook | Build time |
-| Route guard | `shop-core` `extension-guard` plugin | Every client-side navigation |
-| Toggle UI | `apps/web/app/components/settings/modules/` | Editor only |
-| Toggle API | `apps/web/server/routes/_shop/modules.get.ts` + `modules.patch.ts` | Runtime |
-| Client-side instant sync | `useModuleManifest.toggleModule` updates `useState` | After PATCH |
+| File | Repo | When it runs | What it does |
+|------|------|-------------|--------------|
+| `module.manifest.json` | PWA | Build time (read) | Declares which extensions are installed |
+| `src/build/loadExtensions.ts` | shop-core | Build time | Reads + validates the manifest |
+| `src/build/setupExtensions.ts` | shop-core | Build time | Injects settings into runtimeConfig |
+| `src/module.ts` (`pages:extend` hook) | shop-core | Build time | Tags extension pages with extensionId |
+| `src/module.ts` (`runtimeConfig.shopCoreExtensions`) | shop-core | Build time | Bakes extension list into server bundle |
+| `src/runtime/plugins/feature-flags.server.ts` | shop-core | Every SSR request | Reads flags.json → populates useState |
+| `src/runtime/plugins/extension-guard.ts` | shop-core | Every client navigation | Redirects disabled extension routes |
+| `src/runtime/composables/useFeatureFlag.ts` | shop-core | Runtime (Vue) | Primitive computed ref over feature-flags state |
+| `src/runtime/composables/useExtensionEnabled.ts` | shop-core | Runtime (Vue) | Combines runtimeConfig + flag; module composables use this |
+| `src/runtime/composables/useModuleRendering.ts` | shop-core | Runtime (Vue) | Alternative slot system using component names |
+| `src/runtime/utils/featureFlagsHelper.ts` | shop-core | Runtime (Node) | Pure helper for reading flags file |
+| `server/routes/_shop/modules.get.ts` | PWA | Runtime (server) | Returns extension list with current enabled state |
+| `server/routes/_shop/modules.patch.ts` | PWA | Runtime (server) | Writes flag to flags.json |
+| `composables/useModuleManifest/` | PWA | Runtime (Vue) | Fetches list + PATCH toggle; updates useState instantly |
+| `composables/useExtensionSlot/` | PWA | Runtime (Vue) | Slot registry; filters by feature-flags state |
+| `components/ui/ExtensionSlot/` | PWA | Runtime (Vue) | Renders slot entries for a named slot |
+| `components/settings/modules/…/ModuleToggles.vue` | PWA | Runtime (editor) | Toggle UI — the thing humans click |
+| `pages/index.vue` | PWA | Runtime | Places `<UiExtensionSlot name="homepage-top" />` |
+| `runtime/plugins/slots.ts` | module | App startup | Registers PlentyRocks into homepage-top slot |
+| `runtime/plugins/extension-state.ts` | module | App startup | Syncs enabled state to a cookie |
+| `runtime/plugins/shortcuts.ts` | module | App startup (client) | Keyboard shortcut, guarded by enabled state |
+| `runtime/composables/usePlentyModuleState.ts` | module | Runtime (Vue) | Module's own wrapper around useExtensionEnabled |
+| `runtime/composables/useCountdown.ts` | module | Runtime (Vue) | Timer that pauses when extension is disabled |
+| `runtime/pages/store.vue` | module | Runtime | New route; has extra showError guard |
+| `runtime/pages/checkout.vue` | module | Runtime | Overrides /checkout; falls back to original via v-if |
+| `runtime/pages/terms-and-conditions.vue` | module | Runtime | Overrides /terms-and-conditions; same pattern |

--- a/docs/feature-limitations.md
+++ b/docs/feature-limitations.md
@@ -1,0 +1,234 @@
+# Extension Toggle System — Limitations
+
+This document explains why a fully general "disable everything a module does at runtime" is
+architecturally impossible in Nuxt, and what the realistic boundaries of the toggle system are.
+
+---
+
+## The Core Problem
+
+A Nuxt module is a **build-time construct**. When you run `npm run build`, Nuxt calls each
+module's `setup()` function. That function registers things — pages, plugins, components, server
+routes, composables — and Nuxt compiles all of them into the output bundle.
+
+By the time the server is running and a user is browsing the shop, the module's code is already
+inside the compiled output. It is not a separate, removable unit. It is woven into the build
+artifact.
+
+This is not a flaw in our implementation. It is a fundamental property of how Nuxt works.
+
+---
+
+## What "Disabling" Actually Means at Runtime
+
+When we say "disable an extension at runtime," we can mean two very different things:
+
+### Soft disable
+The extension's code is still in the bundle, but we intercept every surface where it would
+appear to the user and hide it or redirect it. The user experiences the extension as if it
+does not exist. The code is just never triggered.
+
+### Hard disable
+The extension's code is genuinely not present. Nothing it registered exists. No routes, no
+plugins, no components, no server routes. This requires the module to not have been included
+in the build at all.
+
+**Tier 3 (flags.json toggle) achieves a soft disable.**
+**Tier 1 (module.manifest.json `enabled: false`) achieves a hard disable, but requires a rebuild.**
+
+---
+
+## What a Module Can Register — and Whether We Can Disable It at Runtime
+
+### 1. Pages / Routes
+
+**What it does:** calls `extendPages()` in `setup()`. Nuxt adds the route to the Nitro router
+and the client-side Vue Router during the build.
+
+**Can we disable at runtime?** Yes, generically.
+
+Shop-core's `pages:extend` hook runs during the build and tags every page that comes from an
+extension with `page.meta.extensionId`. The `extension-guard` plugin then adds a global client-side
+route middleware that checks this tag on every navigation:
+
+```
+user navigates to /store
+→ middleware checks: does this route have meta.extensionId?
+→ yes: "plenty-pwa-module-prototype"
+→ checks useFeatureFlag("extension.plenty-pwa-module-prototype.enabled", true)
+→ flag is false → redirect to /not-found
+```
+
+This works for any extension, for any route, with no cooperation from the extension author.
+The route still exists in the router. We just prevent anyone from reaching it.
+
+**Limitation:** the redirect only fires on client-side navigation. A direct server-side request
+(e.g. someone typing `/store` in the address bar) goes through SSR first. We would need a
+Nitro server middleware to block that too. Currently not implemented.
+
+---
+
+### 2. CMS Blocks (block palette)
+
+**What it does:** the extension ships a `defaults.ts` file with a `getBlocksList()` export.
+The PWA discovers this file via `import.meta.glob` at build time and calls it at runtime to
+populate the "Add Block" palette in the editor.
+
+**Can we disable at runtime?** Yes, generically.
+
+`resolveBlocksList()` in `blocks-imports.ts` extracts the extension ID from the file path of
+each `defaults.ts` (e.g. `node_modules/plenty-pwa-module-prototype/runtime/...` → extracts
+`plenty-pwa-module-prototype`) and checks `useState('feature-flags')` before loading it.
+If the extension is disabled, the `defaults.ts` is never called, and none of its blocks appear
+in the palette.
+
+This works for any extension without any cooperation from the extension author.
+
+**Limitation:** if a block from a disabled extension was already placed on a page, that block
+will still try to render. The block component is in the bundle. The rendered output would either
+show the block (because `getCachedBlockComponent` still finds it) or show nothing (if the
+component gracefully handles missing data). We do not currently hide already-placed blocks
+when their extension is disabled.
+
+---
+
+### 3. Vue Plugins
+
+**What it does:** the extension calls `addPlugin()` in `setup()`. Nuxt adds the plugin to the
+list of plugins that run when the Vue app initializes on every page load.
+
+**Can we disable at runtime?** No, not without cooperation from the module.
+
+Plugins run during app initialization — before any component renders, before any route
+middleware fires. By the time we could check a feature flag, the plugin has already executed.
+
+The only way to prevent a plugin from having side effects is for the plugin itself to check
+the flag at the very start:
+
+```ts
+// inside the module's plugin
+export default defineNuxtPlugin(() => {
+  const enabled = useFeatureFlag('extension.my-module.enabled', true)
+  if (!enabled.value) return  // exit early, do nothing
+  // ... rest of plugin
+})
+```
+
+This requires the module author to write this guard. Shop-core cannot inject it automatically
+because the plugin's internal logic is opaque — we do not know what it does or what side effects
+it has.
+
+**Practical impact:** for most extensions, plugins set up things like SDK clients, event listeners,
+or global state. If the extension is soft-disabled (routes blocked, blocks hidden), the plugin's
+side effects are largely harmless because nothing ever calls the things it set up. But technically
+the code ran.
+
+---
+
+### 4. Registered Components (`addComponent`)
+
+**What it does:** the extension calls `addComponent()` in `setup()`. Nuxt makes the component
+globally available in templates, e.g. `<StoreHero>` and `<StoreCard>`.
+
+**Can we disable at runtime?** Not really — but it does not matter.
+
+The component definitions exist in the compiled bundle. Nuxt has already registered them. You
+cannot un-register a Vue component at runtime.
+
+However, components are passive. A component definition sitting in the bundle does absolutely
+nothing unless something renders it. If the routes that use the component are blocked, and the
+blocks that use the component are hidden from the palette, the component never renders.
+The registration is effectively inert.
+
+---
+
+### 5. Nitro Server Routes
+
+**What it does:** the extension may add files to `server/routes/` or use `addServerHandler()`
+in `setup()`. These become HTTP endpoints in the compiled Nitro server.
+
+**Can we disable at runtime?** Partially, with a Nitro middleware.
+
+A global Nitro middleware could read `flags.json` and return 403 for any request path that
+belongs to a disabled extension. But knowing which paths belong to which extension requires
+a naming convention (e.g. all routes from `plenty-pwa-module-prototype` must be under
+`/_plenty-pwa-module-prototype/`).
+
+Currently not implemented. If the extension does not expose server routes, this is not
+a concern.
+
+---
+
+### 6. Composables and Utilities
+
+**What it does:** the extension calls `addImports()` in `setup()`. Functions become globally
+auto-imported in the PWA — you can call `useStoreProducts()` anywhere without an import statement.
+
+**Can we disable at runtime?** No — and it does not matter.
+
+A composable is just a function. Its definition is in the bundle. It is not "running" until
+something calls it. If no routes render and no components call it, it is simply never invoked.
+
+---
+
+### 7. i18n Translations
+
+**What it does:** the extension may add translation strings via `@nuxtjs/i18n`'s module API.
+
+**Can we disable at runtime?** No.
+
+Translation strings are merged into the i18n message catalog at build time. They exist in
+the compiled output. Removing them at runtime is not possible.
+
+**Practical impact:** if the extension is disabled, the translation keys are still technically
+available in the catalog. Nothing displays them because nothing renders. Having extra unused
+keys in the catalog causes no user-visible problem.
+
+---
+
+## Summary Table
+
+| What the module registers | Runtime disable? | Method | Requires module cooperation? |
+|---|---|---|---|
+| Pages / client routes | ✅ Soft | `pages:extend` tag + global middleware | No |
+| CMS blocks in palette | ✅ Soft | Path-based filter in `resolveBlocksList()` | No |
+| Already-placed CMS blocks | ❌ No | — | — |
+| Vue plugins | ❌ No | Module must check flag at plugin start | Yes |
+| Registered components | ✅ Irrelevant | Never render if routes are blocked | No |
+| Nitro server routes | ⚠️ Partial | Global Nitro middleware (not implemented) | No (with convention) |
+| Composables | ✅ Irrelevant | Never called if routes are blocked | No |
+| i18n translations | ❌ No | — | — |
+| SSR page requests (direct URL) | ⚠️ Not yet | Needs Nitro middleware | No |
+
+---
+
+## The Only Truly General Solution
+
+If you need to guarantee that **none** of a module's code runs — no plugins execute, no server
+routes exist, no components are registered, no translation strings are loaded — the answer is:
+
+**Do not include the module in the build.**
+
+Set `enabled: false` in `module.manifest.json` before building. Shop-core skips the module in
+`moduleDependencies()`. Nuxt never loads it. The compiled output contains nothing from that
+module. This is a hard disable.
+
+This requires a rebuild. In a proper build pipeline, toggling `enabled: false` would trigger an
+automated rebuild and redeploy. That is the correct production workflow for a permanent disable.
+
+The flags.json toggle is the correct solution for **temporary** or **operational** disables — where
+you want to turn something off quickly without waiting for a build pipeline, accepting that the
+compiled code is still in the bundle but nothing surfaces it to the user.
+
+---
+
+## Practical Recommendation
+
+Use Tier 1 (rebuild) and Tier 3 (flags.json) for different purposes:
+
+| Scenario | Use |
+|---|---|
+| Permanently removing an extension from the shop | Tier 1 — set `enabled: false`, rebuild, redeploy |
+| Temporarily hiding an extension during an incident | Tier 3 — flip the flag, instant effect |
+| A/B testing an extension for some users | Tier 3 — flag per request (future work) |
+| Extension causes a critical bug in production | Tier 3 — disable immediately, fix, re-enable |

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@plentymarkets/shop-api": "^0.181.1",
-    "@plentymarkets/shop-core": "file:/Users/alexolteanplenty/workspace/shop-core",
+    "@plentymarkets/shop-core": "^1.35.0",
     "@plentymarkets/shop-module-gtag": "^1.3.0",
     "@plentymarkets/shop-module-mollie": "^1.7.0",
     "@tanstack/vue-virtual": "^3.13.36",
@@ -76,7 +76,7 @@
     "drift-zoom": "^1.5.1",
     "nuxt-color-picker": "^1.2.8",
     "nuxt-swiper": "^1.2.2",
-    "plenty-pwa-module-prototype": "^0.1.3",
+    "plenty-pwa-module-prototype": "^0.3.3",
     "vue-multiselect": "^3.5.0",
     "vue-router": "^5.0.4",
     "vue-tel-input": "^9.8.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@plentymarkets/shop-api": "^0.181.1",
-    "@plentymarkets/shop-core": "^1.35.0",
+    "@plentymarkets/shop-core": "file:/Users/alexolteanplenty/workspace/shop-core",
     "@plentymarkets/shop-module-gtag": "^1.3.0",
     "@plentymarkets/shop-module-mollie": "^1.7.0",
     "@tanstack/vue-virtual": "^3.13.36",
@@ -76,6 +76,7 @@
     "drift-zoom": "^1.5.1",
     "nuxt-color-picker": "^1.2.8",
     "nuxt-swiper": "^1.2.2",
+    "plenty-pwa-module-prototype": "^0.1.3",
     "vue-multiselect": "^3.5.0",
     "vue-router": "^5.0.4",
     "vue-tel-input": "^9.8.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "drift-zoom": "^1.5.1",
     "nuxt-color-picker": "^1.2.8",
     "nuxt-swiper": "^1.2.2",
-    "plenty-pwa-module-prototype": "^0.3.3",
     "vue-multiselect": "^3.5.0",
     "vue-router": "^5.0.4",
     "vue-tel-input": "^9.8.0",

--- a/runtime-module-toggling-report.md
+++ b/runtime-module-toggling-report.md
@@ -1,0 +1,466 @@
+# Runtime Module Toggling — Technical Report
+
+**Date:** 2026-08-26  
+**Repos touched:** `plentyshop-pwa`, `shop-core`, `plenty-pwa-module-prototype` (new)
+
+---
+
+## 1. Goal
+
+Design and implement a system that allows PWA extensions (Nuxt modules published to npm) to be **enabled or disabled at runtime** — no rebuild, no server restart — and surface this as a toggle switch in the editor's settings panel.
+
+The secondary goal was to establish a clean contract: **the module should not need to know about the toggle mechanism**. Shop-core and the PWA own it entirely.
+
+---
+
+## 2. Background — How the PWA Loads Extension Modules
+
+The PWA uses a file called `module.manifest.json` (in `apps/web/`) to declare which extensions are installed:
+
+```json
+[
+  {
+    "id": "plenty-pwa-module-prototype",
+    "entry": "plenty-pwa-module-prototype",
+    "version": "0.1.0"
+  }
+]
+```
+
+At build time, `@plentymarkets/shop-core` reads this file in its `moduleDependencies()` hook and returns each entry's `entry` field as a Nuxt module dependency. Nuxt then loads those modules during the build, registering their components, pages, and plugins. This is **Tier 1** — it requires a full rebuild to enable or disable a module.
+
+---
+
+## 3. Architecture — Three-Tier Toggle System
+
+We designed (and partially implemented) a three-tier hierarchy:
+
+| Tier | Mechanism | Requires |
+|------|-----------|----------|
+| 1 | `enabled: false` in `module.manifest.json` | Rebuild |
+| 2 | `NUXT_PUBLIC_<ID>_ENABLED=false` env var | Server restart |
+| 3 | `extension.<id>.enabled: false` in `flags.json` | **Nothing — live** |
+
+Tier 3 is the primary deliverable. It leverages shop-core's existing `feature-flags.server` plugin which already reads a JSON file **per request** and populates `useState('feature-flags')` — the same mechanism used for feature flags throughout the PWA.
+
+---
+
+## 4. The Test Module — `plenty-pwa-module-prototype`
+
+**Location:** `/Users/alexolteanplenty/workspace/plenty-pwa-module-prototype`
+
+Created entirely from scratch to replace the old broken `plenty-products-module`. The module demonstrates what a third-party PWA extension looks like.
+
+### Structure
+
+```
+plenty-pwa-module-prototype/
+├── index.ts                              # Nuxt module entry point
+├── package.json
+└── runtime/
+    ├── components/
+    │   ├── StoreCard.vue                 # Product card UI component
+    │   └── blocks/
+    │       └── StoreHero/
+    │           ├── StoreHero.vue         # CMS block renderer
+    │           ├── StoreHeroForm.vue     # Editor form panel
+    │           ├── defaults.ts           # Block palette registration
+    │           └── types.ts
+    └── pages/
+        └── store.vue                     # /store route
+```
+
+### `index.ts` — Nuxt Module Entry
+
+```ts
+export default defineNuxtModule({
+  meta: { name: 'plenty-pwa-module-prototype', configKey: 'plentyPwaModulePrototype' },
+  setup(_options, _nuxt) {
+    const resolver = createResolver(import.meta.url)
+    addComponent({ name: 'StoreCard', filePath: resolver.resolve('./runtime/components/StoreCard.vue') })
+    addComponent({ name: 'StoreHero', filePath: resolver.resolve('./runtime/components/blocks/StoreHero/StoreHero.vue') })
+    extendPages((pages) => {
+      pages.push({ name: 'store', path: '/store', file: resolver.resolve('./runtime/pages/store.vue') })
+    })
+  },
+})
+```
+
+### Key External Module Constraint
+
+Files in external npm modules **do not receive Nuxt's auto-import transforms**. This means:
+- `ref`, `computed`, etc. must be explicitly imported from `'vue'`
+- Nuxt composables must be imported from `'#imports'`
+- This applies to `.vue` files in `pages/` and any non-block components
+
+Block components (`StoreHero.vue`, `StoreHeroForm.vue`) loaded via `import.meta.glob` at runtime **do** get transforms, so they can use auto-imported composables normally.
+
+### `defaults.ts` — Block Palette Registration
+
+```ts
+export const getBlocksList = (): BlocksList => ({
+  storeHero: {
+    category: 'storeHero',
+    accessControl: ['content', 'productCategory', 'product'],
+    title: 'Store Hero',
+    blockName: 'StoreHero',
+    variations: [{ ... }],
+  },
+})
+```
+
+This is the contract for CMS blocks. `getBlocksList()` is called by `resolveBlocksList()` in the PWA at runtime to populate the AddBlockPopover palette.
+
+---
+
+## 5. Block Discovery — The Glob Problem
+
+### How Block Discovery Works
+
+The PWA discovers blocks via Vite's `import.meta.glob` in `apps/web/app/utils/blocks/blocks-imports.ts`. At dev server startup, Vite resolves three glob patterns and creates a static map of file paths to lazy import functions:
+
+```ts
+// Core PWA blocks
+const coreBlocks = import.meta.glob('@/components/**/blocks/**/*.vue', ...)
+
+// Local modules (apps/web/modules/*)
+const nuxtModuleBlocks = import.meta.glob('~~/modules/*/runtime/components/blocks/**/*.vue', ...)
+
+// npm packages in apps/web/node_modules/
+const customerBlocks = import.meta.glob('/node_modules/*/runtime/components/blocks/**/*.vue', ...)
+```
+
+### The Problem
+
+In a **npm workspaces monorepo**, packages are hoisted to the root `node_modules/` (`plentyshop-pwa/node_modules/`). Vite's `/node_modules/*/` pattern resolves **relative to the Vite root** (`apps/web/`), so it looks in `apps/web/node_modules/` — the wrong place.
+
+The module is at `plentyshop-pwa/node_modules/plenty-pwa-module-prototype/`, not `apps/web/node_modules/`.
+
+### The Fix
+
+Added a fourth glob pattern using a **relative path** from `blocks-imports.ts` to the monorepo root `node_modules/` (5 levels up):
+
+```ts
+// apps/web/app/utils/blocks/blocks-imports.ts
+const workspaceCustomerBlocks = import.meta.glob(
+  '../../../../../node_modules/*/runtime/components/blocks/**/*.vue',
+  { import: 'default' },
+)
+
+const workspaceCustomerBlockListLoaders = import.meta.glob(
+  '../../../../../node_modules/*/runtime/components/blocks/**/defaults.ts',
+)
+```
+
+The same relative path is used for both the Vue component loaders and the `defaults.ts` loaders. Both are merged into their respective registries.
+
+### Abandoned Approaches
+
+1. **Symlink in `apps/web/modules/`** — Created `apps/web/modules/plenty-pwa-module-prototype → /workspace/plenty-pwa-module-prototype`. This broke because Nuxt 4 **auto-scans the `modules/` directory** and loaded the module a second time (double-load), causing conflicts.
+
+2. **Symlink in `apps/web/node_modules/`** — Technically correct for the existing `/node_modules/*/` glob, but fragile: `npm install` wipes `apps/web/node_modules/` and the symlink is lost.
+
+---
+
+## 6. Feature Flags — The Live Toggle Mechanism
+
+### How shop-core's Feature Flags Work
+
+`shop-core` ships a `feature-flags.server` plugin that runs with `enforce: 'pre'` on every SSR request:
+
+```ts
+// shop-core/src/runtime/plugins/feature-flags.server.ts
+export default defineNuxtPlugin({
+  enforce: 'pre',
+  async setup() {
+    const flags = useState('feature-flags', () => ({}))
+    flags.value = await loadFeatureFlags({
+      filePath: process.env.JSON_FEATURE_FLAGS_FILE ?? '/etc/plenty/feature-flags/flags.json',
+      configFlags: runtimeConfig.public.shopCore.featureFlags,
+    })
+  },
+})
+```
+
+The file is read fresh on **every request**. No caching. This means any change to `flags.json` takes effect on the next page request — no restart needed.
+
+### Local Development Setup
+
+`apps/web/.env`:
+```
+JSON_FEATURE_FLAGS_FILE='./flags.json'
+```
+
+`apps/web/flags.json`:
+```json
+{
+  "extension.plenty-pwa-module-prototype.enabled": true
+}
+```
+
+### shop-core Changes — Seeding Extension Flags
+
+In `shop-core/src/module.ts`, after loading extensions, default flags are seeded into `runtimeConfig.public.shopCore.featureFlags`:
+
+```ts
+featureFlags: {
+  ...Object.fromEntries(
+    (_cachedExtensions ?? [])
+      .filter((e) => e.enabled !== false)
+      .map((e) => [`extension.${e.id}.enabled`, true]),
+  ),
+  ...(_options.featureFlags ?? {}),
+},
+```
+
+This registers `extension.plenty-pwa-module-prototype.enabled = true` as a default. The JSON file can then override it to `false` — the `loadFeatureFlags` utility merges file values over config defaults.
+
+### shop-core Changes — `enabled` in runtimeConfig
+
+`shop-core/src/build/setupExtensions.ts` was updated to inject an `enabled: true` field into `runtimeConfig.public[ext.id]` for every active extension:
+
+```ts
+nuxt.options.runtimeConfig.public[ext.id] = {
+  enabled: true,
+  ...(hasPublicSettings ? ext.settings : {}),
+};
+```
+
+This gives Tier 2: setting `NUXT_PUBLIC_PLENTY_PWA_MODULE_PROTOTYPE_ENABLED=false` as an env var overrides this at server start.
+
+---
+
+## 7. Block Palette Filtering
+
+`resolveBlocksList()` in `blocks-imports.ts` was updated to filter out blocks from disabled extensions **before** loading their `defaults.ts`:
+
+```ts
+const extensionIdFromPath = (path: string): string | null => {
+  const match = path.match(/node_modules\/(.+?)\/runtime\//)
+    || path.match(/modules\/(.+?)\/runtime\//);
+  return match?.[1] ?? null;
+};
+
+export const resolveBlocksList = async (): Promise<BlocksList> => {
+  const featureFlags = useState<Record<string, boolean>>('feature-flags', () => ({}));
+
+  const isDisabled = (path: string): boolean => {
+    const extId = extensionIdFromPath(path);
+    if (!extId) return false;
+    const key = `extension.${extId}.enabled`;
+    return key in featureFlags.value && featureFlags.value[key] === false;
+  };
+
+  const entries = Object.entries(allBlockListLoaders).filter(([path]) => !isDisabled(path));
+  const modules = await Promise.all(entries.map(([, loader]) => loader()));
+  // ... merge and return
+};
+```
+
+The extension ID is extracted **from the file path** (e.g. `../../../../../node_modules/plenty-pwa-module-prototype/runtime/...` → `plenty-pwa-module-prototype`). No cooperation from the module is required.
+
+---
+
+## 8. Route Guarding
+
+### First Attempt — Module-Owned Guard (wrong)
+
+Added `useFeatureFlag` check directly to the module's `store.vue`:
+
+```ts
+const extensionEnabled = useFeatureFlag("extension.plenty-pwa-module-prototype.enabled", true)
+if (!extensionEnabled.value) {
+  await navigateTo("/not-found", { replace: true })
+}
+```
+
+**This was reverted.** The module should not own the toggle mechanism.
+
+### Correct Approach — shop-core Owned Guard
+
+Two additions to shop-core:
+
+**1. `pages:extend` hook in `module.ts`** — tags every page registered by an extension with `meta.extensionId`:
+
+```ts
+nuxt.hook('pages:extend', (pages) => {
+  const extensionIds = new Set((_cachedExtensions ?? [])
+    .filter((e) => e.enabled !== false).map((e) => e.id));
+
+  for (const page of pages) {
+    if (!page.file) continue;
+    const match = page.file.match(/node_modules\/(.+?)\/runtime\//)
+      ?? page.file.match(/modules\/(.+?)\/runtime\//);
+    if (!match?.[1]) continue;
+    if (extensionIds.has(match[1])) {
+      page.meta = { ...page.meta, extensionId: match[1] };
+    }
+  }
+});
+```
+
+**2. `extension-guard.ts` plugin** — registers a global client-side route middleware:
+
+```ts
+// shop-core/src/runtime/plugins/extension-guard.ts
+export default defineNuxtPlugin(() => {
+  addRouteMiddleware('extension-guard', (to) => {
+    const extensionId = to.meta?.extensionId as string | undefined;
+    if (!extensionId) return;
+
+    const enabled = useFeatureFlag(`extension.${extensionId}.enabled`, true);
+    if (!enabled.value) {
+      return navigateTo('/not-found', { replace: true });
+    }
+  }, { global: true });
+});
+```
+
+The module's `store.vue` is clean. The guard fires automatically on every navigation to any route that was contributed by a registered extension.
+
+**Status:** Implemented in shop-core source but not yet verified end-to-end because shop-core's `dist/` needs to be rebuilt (`npm run prepack` in `shop-core/`).
+
+---
+
+## 9. Settings UI — Editor Toggle Panel
+
+A full settings panel was added to the PWA editor following the existing pattern used by General, SEO, and Checkout settings.
+
+### File Structure
+
+```
+apps/web/app/
+├── components/settings/modules/
+│   ├── ToolbarTrigger.vue                        # Layers icon in editor sidebar
+│   ├── View.vue                                  # Main panel description
+│   └── extensions/
+│       ├── View.vue                              # "Extensions" subcategory header
+│       └── 1.module-list/
+│           └── ModuleToggles.vue                 # Toggle list
+│
+└── composables/useModuleManifest/
+    ├── index.ts
+    ├── types.ts
+    └── useModuleManifest.ts
+```
+
+### Auto-Discovery
+
+The settings framework uses `import.meta.glob` to discover panels automatically:
+- `utils/settings-groups-imports/index.ts` discovers `@/components/**/settings/**/*.vue`
+- `utils/triggers-imports/index.ts` discovers `@/components/**/settings/*/*ToolbarTrigger.vue`
+
+No registration is needed — placing files in the right directory is enough.
+
+### `useModuleManifest` Composable
+
+```ts
+// Fetches module list with enabled state from /_shop/modules
+const fetchModules = async () => {
+  modules.value = await $fetch('/_shop/modules')
+}
+
+// Writes to flags.json AND updates useState('feature-flags') client-side
+const toggleModule = async (id: string, enabled: boolean) => {
+  const updated = await $fetch('/_shop/modules', { method: 'PATCH', body: { id, enabled } })
+  modules.value[index] = updated
+
+  // Instant client-side update — no page reload needed
+  const featureFlags = useState('feature-flags', () => ({}))
+  featureFlags.value = { ...featureFlags.value, [`extension.${id}.enabled`]: enabled }
+}
+```
+
+After `toggleModule`, `ModuleToggles.vue` calls `getBlocksLists()` to re-run `resolveBlocksList()` so the block palette updates immediately.
+
+### Server Routes
+
+**`GET /_shop/modules`** (`server/routes/_shop/modules.get.ts`):
+- Reads `module.manifest.json` for the module list
+- Reads `flags.json` (via `JSON_FEATURE_FLAGS_FILE` env var) for the enabled state of each module
+- Merges: if `extension.<id>.enabled` exists in flags, that wins; otherwise falls back to manifest's `enabled` field
+
+**`PATCH /_shop/modules`** (`server/routes/_shop/modules.patch.ts`):
+- Body: `{ id: string, enabled: boolean }`
+- Reads `flags.json`, sets `extension.<id>.enabled`, writes back
+- The next SSR request will pick up the new value via the `feature-flags.server` plugin
+
+---
+
+## 10. Instant Client-Side Update Flow
+
+When the user flips a toggle:
+
+```
+1. SfSwitch @update:model-value fires
+2. handleToggle(id, enabled) called in ModuleToggles.vue
+3. PATCH /_shop/modules → flags.json updated on disk
+4. useState('feature-flags') updated in-memory on the client
+5. getBlocksLists() called → resolveBlocksList() re-runs with new flags
+6. StoreHero disappears from / reappears in AddBlockPopover immediately
+7. useFeatureFlag('extension.<id>.enabled') computed refs update reactively
+   (affects any component currently watching the flag)
+```
+
+For the route guard: the middleware fires on the **next navigation** to a guarded route. If the user is already on `/store` when the toggle is flipped, they are not immediately kicked out. The next time they navigate to `/store`, they are redirected.
+
+---
+
+## 11. What Works
+
+| Feature | Status |
+|---------|--------|
+| StoreHero block appears in AddBlockPopover | ✅ Working |
+| Block palette filtering when extension disabled | ✅ Working |
+| `flags.json` toggle persisted via editor UI | ✅ Working |
+| Instant palette update after toggle | ✅ Working |
+| Module toggle panel in editor sidebar | ✅ Working |
+| `useState('feature-flags')` client-side sync | ✅ Working |
+| `pages:extend` hook tagging extension pages | ✅ Implemented |
+| `extension-guard` global route middleware | ✅ Implemented |
+| Module owns zero toggle logic | ✅ Achieved |
+
+## 12. What Needs Verification
+
+| Feature | Blocker |
+|---------|---------|
+| Route guard via `extension-guard` plugin | shop-core `dist/` must be rebuilt (`npm run prepack` in `shop-core/`) |
+
+---
+
+## 13. Key Files Changed
+
+### `plentyshop-pwa`
+
+| File | Change |
+|------|--------|
+| `apps/web/app/utils/blocks/blocks-imports.ts` | Added workspace root `node_modules` glob patterns; `resolveBlocksList()` now filters disabled extensions via `useState('feature-flags')` |
+| `apps/web/app/components/settings/modules/**` | New: full settings panel (ToolbarTrigger, View, ModuleToggles) |
+| `apps/web/app/composables/useModuleManifest/**` | New: composable for fetching and toggling modules |
+| `apps/web/server/routes/_shop/modules.get.ts` | New: reads manifest + flags, returns merged state |
+| `apps/web/server/routes/_shop/modules.patch.ts` | New: writes `extension.<id>.enabled` to `flags.json` |
+| `apps/web/flags.json` | New: local feature flags file for dev |
+| `apps/web/.env` | Added `JSON_FEATURE_FLAGS_FILE='./flags.json'` |
+
+### `shop-core`
+
+| File | Change |
+|------|--------|
+| `src/build/setupExtensions.ts` | Injects `enabled: true` into `runtimeConfig.public[ext.id]` for each extension |
+| `src/module.ts` | Seeds `extension.<id>.enabled: true` into featureFlags defaults; adds `pages:extend` hook; registers `extension-guard` plugin |
+| `src/runtime/plugins/extension-guard.ts` | New: global route middleware that blocks navigation to pages from disabled extensions |
+
+### `plenty-pwa-module-prototype`
+
+| File | Change |
+|------|--------|
+| `runtime/pages/store.vue` | Reverted — removed the `useFeatureFlag` guard that was incorrectly placed here |
+
+---
+
+## 14. Architecture Invariants
+
+- **The module is passive.** It publishes routes and blocks using standard Nuxt APIs (`extendPages`, `addComponent`, `getBlocksList`). It has no knowledge of the toggle system.
+- **Flag key convention:** `extension.<npm-package-id>.enabled` — derived from the module's `id` in `module.manifest.json`.
+- **Path-based extension detection:** Both `resolveBlocksList()` and the `pages:extend` hook extract the extension ID from file paths (`/node_modules/<id>/runtime/`). No manifest metadata needed in individual block files.
+- **flags.json is the source of truth for runtime state.** `module.manifest.json` declares what is installed. `flags.json` declares what is active.


### PR DESCRIPTION
This branch will be used for DEMO purposes only. A new PR will open with only the necessary JS code for the enabling/disabling for the modules. But this branch contains extra code like the 'UiExtensionSlot' component added randomly for testing purposes. 

The documentation for this live feature can be found at - https://github.com/plentymarkets/plentyshop-pwa/pull/2867