### PR TITLE
feat(shop-cli): blocks support

### DIFF
--- a/.claude/skills/code-generation/README.md
+++ b/.claude/skills/code-generation/README.md
@@ -35,17 +35,18 @@ npm run generate:component -- ProductCard --skip-tests --with-form
 
 ## Available Flags
 
-| Flag                      | Description                                                               | Example                            |
-| ------------------------- | ------------------------------------------------------------------------- | ---------------------------------- |
-| `--skip-tests`            | Don't generate test files                                                 | `--skip-tests`                     |
-| `--skip-types`            | Don't generate types.ts                                                   | `--skip-types`                     |
-| `--with-form`             | Create \*Form.vue for CMS editor                                          | `--with-form`                      |
-| `--with-view`             | Create View.vue for settings                                              | `--with-view`                      |
-| `--with-toolbar`          | Create ToolbarTrigger.vue                                                 | `--with-toolbar`                   |
-| `--complex-form`          | With `--with-form`: scaffold `forms/`+`partials/` instead of one Form.vue | `--complex-form`                   |
-| `--category=<value>`      | With `--with-form`: the block's CMS editor category                       | `--category=cards`                 |
-| `--access-control=<list>` | With `--with-form`: comma-separated editor contexts                       | `--access-control=content,product` |
-| `--dry-run`               | Preview planned files without writing anything                            | `--dry-run`                        |
+| Flag                      | Description                                                                   | Example                            |
+| ------------------------- | ----------------------------------------------------------------------------- | ---------------------------------- |
+| `--skip-tests`            | Don't generate test files                                                     | `--skip-tests`                     |
+| `--skip-types`            | Don't generate types.ts                                                       | `--skip-types`                     |
+| `--with-form`             | Create \*Form.vue for CMS editor                                              | `--with-form`                      |
+| `--with-view`             | Create View.vue for settings                                                  | `--with-view`                      |
+| `--with-toolbar`          | Create ToolbarTrigger.vue                                                     | `--with-toolbar`                   |
+| `--complex-form`          | With `--with-form`: scaffold `forms/`+`partials/` instead of one Form.vue     | `--complex-form`                   |
+| `--structure`             | With `--with-form`: scaffold a structure/container block, not a content block | `--structure`                      |
+| `--category=<value>`      | With `--with-form`: the block's CMS editor category                           | `--category=cards`                 |
+| `--access-control=<list>` | With `--with-form`: comma-separated editor contexts                           | `--access-control=content,product` |
+| `--dry-run`               | Preview planned files without writing anything                                | `--dry-run`                        |
 
 ## Examples
 
@@ -64,6 +65,17 @@ npm run generate:block -- VideoPlayer --category=media --access-control=content,
 # Includes VideoPlayerForm.vue, defaults.ts, and icon.svg automatically (--with-form flag)
 # Auto-discovered by the CMS editor via blocks-imports.ts's import.meta.glob - no manual registration needed
 # icon.svg is a generic placeholder - replace with a real icon when convenient (not required)
+```
+
+**Content block vs. structure block:** pick `--structure` only when the block is a container that
+holds _other_ blocks as children (like `MultiGrid`/`Carousel`) — it scaffolds `content` as a
+`Block[]` array instead of a settings object, and `type: 'structure'` instead of `'content'`. Most
+blocks are content blocks (the default, no flag needed).
+
+```bash
+npm run generate:block -- ColumnLayout --structure --category=layout
+# defaults.ts: type: 'structure', content: [] (seed with real child Block instances)
+# types.ts: content: Block[]
 ```
 
 **Settings component:**

--- a/.claude/skills/code-generation/README.md
+++ b/.claude/skills/code-generation/README.md
@@ -42,7 +42,6 @@ npm run generate:component -- ProductCard --skip-tests --with-form
 | `--with-form`        | Create \*Form.vue for CMS editor | `--with-form`                     |
 | `--with-view`        | Create View.vue for settings     | `--with-view`                     |
 | `--with-toolbar`     | Create ToolbarTrigger.vue        | `--with-toolbar`                  |
-| `--output-path=path` | Custom output location           | `--output-path=components/blocks` |
 
 ## Examples
 
@@ -57,9 +56,9 @@ npm run generate:component ProductCard
 
 ```bash
 npm run generate:block VideoPlayer
-# Result: apps/web/app/components/VideoPlayer/
+# Result: apps/web/app/components/blocks/VideoPlayer/
 # Includes VideoPlayerForm.vue automatically (--with-form flag)
-# Remember to register in utils/blocks-imports.ts
+# Auto-discovered by the CMS editor via blocks-imports.ts's import.meta.glob - no manual registration needed
 ```
 
 **Settings component:**
@@ -119,12 +118,6 @@ For advanced usage, call the script directly:
 
 - Components must be PascalCase: `ProductCard` ✅ not `product-card` ❌
 - Composables must start with `use`: `useCart` ✅ not `cart` ❌
-
-**"Invalid output path" error:**
-
-- Use relative paths only
-- Must start with allowed prefix (components, composables, pages, etc.)
-- No directory traversal (`..`) allowed
 
 ## CI/CD
 

--- a/.claude/skills/code-generation/README.md
+++ b/.claude/skills/code-generation/README.md
@@ -35,13 +35,17 @@ npm run generate:component -- ProductCard --skip-tests --with-form
 
 ## Available Flags
 
-| Flag                 | Description                      | Example                           |
-| -------------------- | -------------------------------- | --------------------------------- |
-| `--skip-tests`       | Don't generate test files        | `--skip-tests`                    |
-| `--skip-types`       | Don't generate types.ts          | `--skip-types`                    |
-| `--with-form`        | Create \*Form.vue for CMS editor | `--with-form`                     |
-| `--with-view`        | Create View.vue for settings     | `--with-view`                     |
-| `--with-toolbar`     | Create ToolbarTrigger.vue        | `--with-toolbar`                  |
+| Flag                      | Description                                                               | Example                            |
+| ------------------------- | ------------------------------------------------------------------------- | ---------------------------------- |
+| `--skip-tests`            | Don't generate test files                                                 | `--skip-tests`                     |
+| `--skip-types`            | Don't generate types.ts                                                   | `--skip-types`                     |
+| `--with-form`             | Create \*Form.vue for CMS editor                                          | `--with-form`                      |
+| `--with-view`             | Create View.vue for settings                                              | `--with-view`                      |
+| `--with-toolbar`          | Create ToolbarTrigger.vue                                                 | `--with-toolbar`                   |
+| `--complex-form`          | With `--with-form`: scaffold `forms/`+`partials/` instead of one Form.vue | `--complex-form`                   |
+| `--category=<value>`      | With `--with-form`: the block's CMS editor category                       | `--category=cards`                 |
+| `--access-control=<list>` | With `--with-form`: comma-separated editor contexts                       | `--access-control=content,product` |
+| `--dry-run`               | Preview planned files without writing anything                            | `--dry-run`                        |
 
 ## Examples
 
@@ -55,10 +59,11 @@ npm run generate:component ProductCard
 **Block component for CMS:**
 
 ```bash
-npm run generate:block VideoPlayer
+npm run generate:block -- VideoPlayer --category=media --access-control=content,product
 # Result: apps/web/app/components/blocks/VideoPlayer/
-# Includes VideoPlayerForm.vue automatically (--with-form flag)
+# Includes VideoPlayerForm.vue, defaults.ts, and icon.svg automatically (--with-form flag)
 # Auto-discovered by the CMS editor via blocks-imports.ts's import.meta.glob - no manual registration needed
+# icon.svg is a generic placeholder - replace with a real icon when convenient (not required)
 ```
 
 **Settings component:**
@@ -98,6 +103,22 @@ useFeatureName/
 ├── index.ts
 └── __tests__/useFeatureName.spec.ts
 ```
+
+**Block (`--with-form`):**
+
+```
+BlockName/
+├── BlockName.vue
+├── BlockNameForm.vue
+├── defaults.ts
+├── icon.svg
+├── types.ts
+└── __tests__/BlockName.spec.ts
+```
+
+`--complex-form` replaces the single `BlockNameForm.vue` (orchestrator only) with
+`forms/BlockNameSettingsForm.vue` + `partials/BlockNameSectionEditor.vue` (and matching
+`__tests__/` specs), matching the real `UtilityBar` block's structure.
 
 ## Direct Script Usage
 

--- a/.claude/skills/code-generation/SKILL.md
+++ b/.claude/skills/code-generation/SKILL.md
@@ -50,13 +50,17 @@ npm run generate:settings SettingsName [--options]   # component with --with-vie
 
 ## Available Options
 
-| Option               | Description                            | Example                           |
-| -------------------- | -------------------------------------- | --------------------------------- |
-| `--skip-tests`       | Don't generate test files              | `--skip-tests`                    |
-| `--skip-types`       | Don't generate types.ts                | `--skip-types`                    |
-| `--with-form`        | Add \*Form.vue (for CMS editor blocks) | `--with-form`                     |
-| `--with-view`        | Add View.vue (for settings panels)     | `--with-view`                     |
-| `--with-toolbar`     | Add ToolbarTrigger.vue (for settings)  | `--with-toolbar`                  |
+| Option                    | Description                                                                                 | Example                            |
+| ------------------------- | ------------------------------------------------------------------------------------------- | ---------------------------------- |
+| `--skip-tests`            | Don't generate test files                                                                   | `--skip-tests`                     |
+| `--skip-types`            | Don't generate types.ts                                                                     | `--skip-types`                     |
+| `--with-form`             | Add \*Form.vue (for CMS editor blocks)                                                      | `--with-form`                      |
+| `--with-view`             | Add View.vue (for settings panels)                                                          | `--with-view`                      |
+| `--with-toolbar`          | Add ToolbarTrigger.vue (for settings)                                                       | `--with-toolbar`                   |
+| `--complex-form`          | With `--with-form`: scaffold `forms/`+`partials/` instead of one Form.vue                   | `--complex-form`                   |
+| `--category=<value>`      | With `--with-form`: the block's CMS editor category                                         | `--category=cards`                 |
+| `--access-control=<list>` | With `--with-form`: comma-separated editor contexts (`content`,`productCategory`,`product`) | `--access-control=content,product` |
+| `--dry-run`               | Preview planned files without writing anything                                              | `--dry-run`                        |
 
 ## Examples
 
@@ -70,12 +74,26 @@ npm run generate:composable useShoppingCart
 # Block for CMS editor (includes --with-form automatically)
 npm run generate:block ImageCarousel
 
+# Block with an explicit category and editor contexts (otherwise prompted interactively)
+npm run generate:block -- ImageCarousel --category=media --access-control=content,product
+
+# Block with a multi-file form (forms/ + partials/) instead of one Form.vue
+npm run generate:block -- ImageCarousel --complex-form
+
 # Settings component (includes --with-view --with-toolbar automatically)
 npm run generate:settings ShippingOptions
 
 # Skip tests
 npm run generate:component -- MyWidget --skip-tests
 ```
+
+## After Generating a Block
+
+`--with-form` also scaffolds `defaults.ts` (with a non-empty `accessControl`, so the block is
+never accidentally invisible in the CMS editor) and a generic placeholder `icon.svg` used by the
+"Add Block" picker. Replacing `icon.svg` with a real, block-specific icon is a nice-to-have polish
+step — not required. The block works correctly with the placeholder either way, since the picker
+falls back to a plain box when a block has no icon at all.
 
 ## Output Format
 
@@ -119,3 +137,19 @@ useFeatureName/
 ├── index.ts
 └── __tests__/useFeatureName.spec.ts
 ```
+
+**Block (`--with-form`):**
+
+```
+BlockName/
+├── BlockName.vue
+├── BlockNameForm.vue
+├── defaults.ts
+├── icon.svg
+├── types.ts
+└── __tests__/BlockName.spec.ts
+```
+
+**Block with `--complex-form`** replaces the single `BlockNameForm.vue` (orchestrator only) with
+`forms/BlockNameSettingsForm.vue` + `partials/BlockNameSectionEditor.vue` (and matching
+`__tests__/` specs), matching the real `UtilityBar` block's structure.

--- a/.claude/skills/code-generation/SKILL.md
+++ b/.claude/skills/code-generation/SKILL.md
@@ -58,6 +58,7 @@ npm run generate:settings SettingsName [--options]   # component with --with-vie
 | `--with-view`             | Add View.vue (for settings panels)                                                          | `--with-view`                      |
 | `--with-toolbar`          | Add ToolbarTrigger.vue (for settings)                                                       | `--with-toolbar`                   |
 | `--complex-form`          | With `--with-form`: scaffold `forms/`+`partials/` instead of one Form.vue                   | `--complex-form`                   |
+| `--structure`             | With `--with-form`: scaffold a structure/container block instead of a content block         | `--structure`                      |
 | `--category=<value>`      | With `--with-form`: the block's CMS editor category                                         | `--category=cards`                 |
 | `--access-control=<list>` | With `--with-form`: comma-separated editor contexts (`content`,`productCategory`,`product`) | `--access-control=content,product` |
 | `--dry-run`               | Preview planned files without writing anything                                              | `--dry-run`                        |
@@ -80,12 +81,31 @@ npm run generate:block -- ImageCarousel --category=media --access-control=conten
 # Block with a multi-file form (forms/ + partials/) instead of one Form.vue
 npm run generate:block -- ImageCarousel --complex-form
 
+# Structure/container block (holds other blocks as children, like MultiGrid/Carousel)
+npm run generate:block -- ColumnLayout --structure --category=layout
+
 # Settings component (includes --with-view --with-toolbar automatically)
 npm run generate:settings ShippingOptions
 
 # Skip tests
 npm run generate:component -- MyWidget --skip-tests
 ```
+
+## Content Blocks vs. Structure Blocks
+
+Every CMS block is one of two shapes — pick based on what the block holds:
+
+- **Content block** (default): `content` is a settings object the block itself renders (text, an
+  image, a button link). Most blocks are this shape (e.g. `Image`, `TextCard`).
+- **Structure block** (`--structure`): `content` is an array of _other_ blocks the CMS user arranges
+  as children (e.g. `MultiGrid`, `Carousel`). Use this only when the block is a container whose job
+  is to lay out other blocks, not to render its own settings.
+
+`--structure` changes `defaults.ts`'s `type` (`'structure'` vs `'content'`) and `content`'s shape
+(`content: []` seeded with real child `Block` instances vs `content: {}`), and `types.ts`'s `content`
+type (`Block[]` vs `Record<string, unknown>`). Placement under a `components/blocks/structure/`
+subdirectory is a convention some real blocks follow, not a requirement — discovery works at any
+depth under `blocks/`.
 
 ## After Generating a Block
 

--- a/.claude/skills/code-generation/SKILL.md
+++ b/.claude/skills/code-generation/SKILL.md
@@ -22,8 +22,10 @@ When the user requests code generation, determine:
    - If unsure about correction, ask for confirmation
 
 3. **Optional**: Custom location?
-   - Standard locations: `components/` for components, `composables/` for composables
-   - Use `--output-path` to specify a custom output path
+   - Standard locations: `components/` for components, `composables/` for composables (blocks land under
+     `components/blocks/` automatically when `--with-form` is used)
+   - There is no per-invocation output-path flag; to point the CLI at a different app root entirely, create a
+     `.plentyone/shop-cli.json` config file (see `packages/shop-cli/README.md`)
 
 ## Naming Conventions
 
@@ -50,7 +52,6 @@ npm run generate:settings SettingsName [--options]   # component with --with-vie
 
 | Option               | Description                            | Example                           |
 | -------------------- | -------------------------------------- | --------------------------------- |
-| `--output-path=path` | Custom output location                 | `--output-path=components/blocks` |
 | `--skip-tests`       | Don't generate test files              | `--skip-tests`                    |
 | `--skip-types`       | Don't generate types.ts                | `--skip-types`                    |
 | `--with-form`        | Add \*Form.vue (for CMS editor blocks) | `--with-form`                     |
@@ -72,8 +73,8 @@ npm run generate:block ImageCarousel
 # Settings component (includes --with-view --with-toolbar automatically)
 npm run generate:settings ShippingOptions
 
-# Custom path without tests
-npm run generate:component -- MyWidget --output-path=components/custom --skip-tests
+# Skip tests
+npm run generate:component -- MyWidget --skip-tests
 ```
 
 ## Output Format

--- a/.claude/skills/code-generation/generate.sh
+++ b/.claude/skills/code-generation/generate.sh
@@ -28,18 +28,33 @@ if [ $# -lt 2 ]; then
     exit 1
 fi
 
-# Extract generator type and name
+# Extract generator type and name. The name isn't always "$2" — shortcut scripts like
+# generate:block prepend a flag (e.g. "component --with-form"), pushing the name further out.
 GENERATOR_TYPE="$1"
-NAME="$2"
-shift 2
+shift
+NAME=""
+REMAINING_ARGS=()
+for arg in "$@"; do
+    if [ -z "$NAME" ] && [ "${arg#--}" = "$arg" ]; then
+        NAME="$arg"
+    else
+        REMAINING_ARGS+=("$arg")
+    fi
+done
+
+if [ -z "$NAME" ]; then
+    echo "Error: Usage: ./generate.sh <generator-type> <name> [options]" >&2
+    exit 1
+fi
 
 # Pass all remaining arguments (flags) directly to the CLI
-npx plentyshop generate "$GENERATOR_TYPE" "$NAME" "$@"
+# (the "${arr[@]+...}" form avoids an "unbound variable" error under `set -u` when the array is empty)
+npx plentyshop generate "$GENERATOR_TYPE" "$NAME" "${REMAINING_ARGS[@]+"${REMAINING_ARGS[@]}"}"
 
 # Verify the expected output actually landed on disk, independent of the CLI's own exit code —
 # a swallowed validation/action-building error can otherwise report success with zero files.
 IS_DRY_RUN=false
-for arg in "$@"; do
+for arg in "${REMAINING_ARGS[@]+"${REMAINING_ARGS[@]}"}"; do
     if [ "$arg" = "--dry-run" ]; then
         IS_DRY_RUN=true
     fi

--- a/.claude/skills/code-generation/generate.sh
+++ b/.claude/skills/code-generation/generate.sh
@@ -13,7 +13,6 @@
 #   ./generate.sh component Settings --with-view --with-toolbar
 #
 # Options:
-#   --output-path=path     Custom output path (default: apps/web/app)
 #   --skip-tests           Skip generating test files
 #   --skip-types           Skip generating types.ts file
 #   --with-form            Create additional *Form.vue file (for blocks)

--- a/.claude/skills/code-generation/generate.sh
+++ b/.claude/skills/code-generation/generate.sh
@@ -18,6 +18,7 @@
 #   --with-form            Create additional *Form.vue file (for blocks)
 #   --with-view            Create additional View.vue file (for settings)
 #   --with-toolbar         Create additional ToolbarTrigger.vue file (for settings)
+#   --dry-run              Preview planned files without writing anything
 
 set -euo pipefail
 
@@ -34,3 +35,37 @@ shift 2
 
 # Pass all remaining arguments (flags) directly to the CLI
 npx plentyshop generate "$GENERATOR_TYPE" "$NAME" "$@"
+
+# Verify the expected output actually landed on disk, independent of the CLI's own exit code —
+# a swallowed validation/action-building error can otherwise report success with zero files.
+IS_DRY_RUN=false
+for arg in "$@"; do
+    if [ "$arg" = "--dry-run" ]; then
+        IS_DRY_RUN=true
+    fi
+done
+
+if [ "$IS_DRY_RUN" = false ]; then
+    case "$GENERATOR_TYPE" in
+        component)
+            SEARCH_DIR="apps/web/app/components"
+            MAIN_FILE_NAME="${NAME}.vue"
+            ;;
+        composable)
+            SEARCH_DIR="apps/web/app/composables"
+            MAIN_FILE_NAME="${NAME}.ts"
+            ;;
+        *)
+            SEARCH_DIR=""
+            MAIN_FILE_NAME=""
+            ;;
+    esac
+
+    if [ -n "$SEARCH_DIR" ]; then
+        MATCH=$(find "$SEARCH_DIR" -type f -path "*/${NAME}/${MAIN_FILE_NAME}" 2>/dev/null | head -n 1)
+        if [ -z "$MATCH" ]; then
+            echo "Error: generation reported success but no output file found matching ${SEARCH_DIR}/**/${NAME}/${MAIN_FILE_NAME}" >&2
+            exit 1
+        fi
+    fi
+fi

--- a/.claude/skills/code-generation/generate.sh
+++ b/.claude/skills/code-generation/generate.sh
@@ -10,6 +10,7 @@
 #   ./generate.sh component ProductCard
 #   ./generate.sh composable useShoppingCart --skip-tests
 #   ./generate.sh component ImageBlock --with-form
+#   ./generate.sh block ImageCarousel --category=media --access-control=content,product
 #   ./generate.sh component Settings --with-view --with-toolbar
 #
 # Options:
@@ -62,7 +63,7 @@ done
 
 if [ "$IS_DRY_RUN" = false ]; then
     case "$GENERATOR_TYPE" in
-        component)
+        component | block)
             SEARCH_DIR="apps/web/app/components"
             MAIN_FILE_NAME="${NAME}.vue"
             ;;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ No global store. All state lives in composables via Nuxt's `useState()` (SSR-saf
 
 ### Dynamic Blocks
 
-CMS blocks are loaded lazily by name via `getBlockLoader()` from `utils/blocks/blocks-imports.ts`. Any new block component must be registered there.
+CMS blocks are auto-discovered via `import.meta.glob` in `utils/blocks/blocks-imports.ts` — any `.vue`/`defaults.ts` file under a `blocks/` path segment is picked up automatically, no manual registration needed. The requirement is correct placement: block files must live under `components/blocks/<Name>/` (e.g. via `npm run generate:block <Name>`), not just `components/<Name>/`.
 
 ## Code Style
 

--- a/packages/shop-cli/README.md
+++ b/packages/shop-cli/README.md
@@ -44,17 +44,10 @@ Create `.plentyone/shop-cli.json` in your project root:
 }
 ```
 
-### CLI Flag Override
-
-```bash
-npx plentyshop generate component --web-app-path=src/app
-```
-
 ### Priority Order
 
-1. CLI flags (`--web-app-path`)
-2. Config file (`.plentyone/shop-cli.json`)
-3. Defaults (`apps/web/app`)
+1. Config file (`.plentyone/shop-cli.json`)
+2. Defaults (`apps/web/app`)
 
 ## Available Generators
 

--- a/packages/shop-cli/README.md
+++ b/packages/shop-cli/README.md
@@ -19,11 +19,12 @@ npx @plentymarkets/shop-cli
 ## Quick Start
 
 ```bash
-# Generate code interactively
+# Generate code interactively — "Please choose a generator" lists component, block, and composable
 npx plentyshop generate
 
 # Generate specific types
 npx plentyshop generate component
+npx plentyshop generate block
 npx plentyshop generate composable
 
 # Get help
@@ -54,6 +55,9 @@ Create `.plentyone/shop-cli.json` in your project root:
 ### ✅ Production Ready
 
 - **component** - Generate Vue 3 components with TypeScript, tests, and proper structure
+- **block** - Generate a CMS block (Form.vue, defaults.ts, icon.svg) — same generator as
+  `component --with-form`, registered separately so it appears as its own choice in the
+  interactive picker
 - **composable** - Generate Vue 3 composables with TypeScript, tests, and index files
 
 ## Architecture Overview

--- a/packages/shop-cli/__tests__/integration/cli-execution.test.ts
+++ b/packages/shop-cli/__tests__/integration/cli-execution.test.ts
@@ -52,8 +52,10 @@ describe('CLI Command Execution', () => {
 
       expect(stdout).toContain('Loading PlentyONE Shop generators');
       expect(stdout).toContain('Component generator loaded successfully!');
+      expect(stdout).toContain('Block generator loaded successfully!');
       expect(stdout).toContain('[PLOP] Please choose a generator');
       expect(stdout).toContain('component - Generate a Vue component');
+      expect(stdout).toContain('block - Generate a CMS block component');
     }, 10000); // 10 second timeout for interactive command
   });
 });

--- a/packages/shop-cli/__tests__/integration/dry-run.test.ts
+++ b/packages/shop-cli/__tests__/integration/dry-run.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Integration tests for --dry-run wiring: createDryRunAction against a real filesystem,
+ * driven through a minimal fake plop API (getDestBasePath/getPlopfilePath/renderString).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync } from 'fs';
+import type { NodePlopAPI } from 'plop';
+import { TestDirectory } from '../utils';
+import { dryRunManager, createDryRunAction } from '../../src/utils/dry-run';
+
+const renderString = (template: string, data: Record<string, unknown>): string =>
+  template.replace(/\{\{\s*(\w+)\s*\}\}/g, (_, key: string) => String(data[key] ?? ''));
+
+describe('--dry-run wiring', () => {
+  let testDir: TestDirectory;
+  let plopfileDir: string;
+  let destDir: string;
+
+  beforeEach(async () => {
+    testDir = new TestDirectory('shop-cli-dry-run-test');
+    await testDir.create();
+    plopfileDir = testDir.getPath('cli-root');
+    destDir = testDir.getPath('dest');
+    await testDir.createFile('cli-root/templates/component/component.vue.hbs', '<template>{{name}}</template>');
+
+    dryRunManager.enableDryRun();
+  });
+
+  afterEach(async () => {
+    dryRunManager.disableDryRun();
+    await testDir.cleanup();
+  });
+
+  const fakePlop = {
+    getDestBasePath: () => destDir,
+    getPlopfilePath: () => plopfileDir,
+    renderString,
+  } as unknown as NodePlopAPI;
+
+  it('should log the operation and write nothing to disk for a new file', () => {
+    const addAction = createDryRunAction('add');
+    const result = addAction(
+      { name: 'TestComponent' },
+      { path: '{{name}}/{{name}}.vue', templateFile: 'templates/component/component.vue.hbs' },
+      fakePlop,
+    );
+
+    const expectedPath = `${destDir}/TestComponent/TestComponent.vue`;
+    expect(result).toContain('Planned: add');
+    expect(result).not.toContain('already exists');
+    expect(existsSync(expectedPath)).toBe(false);
+    expect(dryRunManager.operations).toHaveLength(1);
+    expect(dryRunManager.operations[0]).toMatchObject({ type: 'create', exists: false });
+    expect(dryRunManager.hasConflicts()).toBe(false);
+  });
+
+  it('should flag a conflict for a file that already exists, and still write nothing', async () => {
+    const existingRelative = 'dest/Existing/Existing.vue';
+    await testDir.createFile(existingRelative, '<template>already here</template>');
+    const existingPath = testDir.getPath(existingRelative);
+
+    const addAction = createDryRunAction('add');
+    const result = addAction(
+      { name: 'Existing' },
+      { path: '{{name}}/{{name}}.vue', templateFile: 'templates/component/component.vue.hbs' },
+      fakePlop,
+    );
+
+    expect(result).toContain('already exists');
+    expect(dryRunManager.hasConflicts()).toBe(true);
+
+    const contentAfter = await import('fs/promises').then((fs) => fs.readFile(existingPath, 'utf-8'));
+    expect(contentAfter).toBe('<template>already here</template>');
+
+    const summary = dryRunManager.getSummary();
+    expect(summary).toContain('CONFLICTS DETECTED');
+    expect(summary).toContain('Existing/Existing.vue');
+  });
+});

--- a/packages/shop-cli/__tests__/integration/template-rendering.test.ts
+++ b/packages/shop-cli/__tests__/integration/template-rendering.test.ts
@@ -78,6 +78,27 @@ describe('defaults.ts.hbs', () => {
     expect(rendered).toContain('BLOCK_IMAGE');
     expect(rendered).toContain("category: 'cards'");
   });
+
+  it('should scaffold a content block by default: type content, content {}', () => {
+    const rendered = render('defaults.ts.hbs', { name: 'TestBlock', category: 'cards', accessControl: ['content'] });
+
+    expect(rendered).toContain("type: 'content'");
+    expect(rendered).toContain('content: {}');
+    expect(rendered).not.toContain("type: 'structure'");
+  });
+
+  it('should scaffold a structure block when structure is true: type structure, content []', () => {
+    const rendered = render('defaults.ts.hbs', {
+      name: 'TestBlock',
+      category: 'cards',
+      accessControl: ['content'],
+      structure: true,
+    });
+
+    expect(rendered).toContain("type: 'structure'");
+    expect(rendered).toContain('content: []');
+    expect(rendered).not.toContain("type: 'content'");
+  });
 });
 
 describe('icon.svg.hbs', () => {
@@ -103,5 +124,20 @@ describe('types.ts.hbs', () => {
 
     expect(rendered).toContain('export interface TestComponentProps');
     expect(rendered).not.toContain('FormProps');
+  });
+
+  it('should type content as Record<string, unknown> for a content block by default', () => {
+    const rendered = render('types.ts.hbs', { name: 'TestBlock', withForm: true });
+
+    expect(rendered).toContain('content: Record<string, unknown>');
+    expect(rendered).not.toContain("import type { Block } from '@plentymarkets/shop-api'");
+  });
+
+  it('should type content as Block[] and import Block for a structure block', () => {
+    const rendered = render('types.ts.hbs', { name: 'TestBlock', withForm: true, structure: true });
+
+    expect(rendered).toContain("import type { Block } from '@plentymarkets/shop-api'");
+    expect(rendered).toContain('content: Block[]');
+    expect(rendered).not.toContain('content: Record<string, unknown>');
   });
 });

--- a/packages/shop-cli/__tests__/integration/template-rendering.test.ts
+++ b/packages/shop-cli/__tests__/integration/template-rendering.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Renders the actual block-related .hbs templates through the real Handlebars pipeline (same
+ * helpers/partials plopfile.ts registers), the way plop itself does, to catch template bugs unit
+ * tests on generator wiring alone would miss — e.g. a helper that's a no-op, or a raw-block that
+ * silently renders empty.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import { join, basename } from 'path';
+import Handlebars from 'handlebars';
+import type { NodePlopAPI } from 'plop';
+import { registerDefaultHelpers } from '../../src/helpers';
+
+const TEMPLATES_DIR = join(__dirname, '../../templates/component');
+const PARTIALS_DIR = join(__dirname, '../../templates/partials');
+
+const render = (templateFileName: string, data: Record<string, unknown>): string => {
+  const raw = readFileSync(join(TEMPLATES_DIR, templateFileName), 'utf-8');
+  return Handlebars.compile(raw)(data);
+};
+
+beforeAll(() => {
+  const fakePlop = {
+    setHelper: (name: string, fn: (...args: unknown[]) => unknown) => Handlebars.registerHelper(name, fn),
+  } as unknown as NodePlopAPI;
+  registerDefaultHelpers(fakePlop);
+
+  for (const file of readdirSync(PARTIALS_DIR).filter((f) => f.endsWith('.hbs'))) {
+    Handlebars.registerPartial(basename(file, '.hbs'), readFileSync(join(PARTIALS_DIR, file), 'utf-8'));
+  }
+});
+
+describe('component-form.vue.hbs', () => {
+  const rendered = () => render('component-form.vue.hbs', { name: 'TestBlock' });
+
+  it('should render real Vue interpolation, not an empty raw-block artifact', () => {
+    expect(rendered()).toContain("{{ getEditorTranslation('example-setting-label') }}");
+    expect(rendered()).not.toContain('<UiFormLabel></UiFormLabel>');
+  });
+
+  it('should render an <i18n> block with exactly en and de keys', () => {
+    const match = rendered().match(/<i18n lang="json">([\s\S]*?)<\/i18n>/);
+    expect(match).not.toBeNull();
+    const i18n = JSON.parse(match![1]);
+    expect(Object.keys(i18n).sort()).toEqual(['de', 'en']);
+  });
+});
+
+describe('defaults.ts.hbs', () => {
+  it('should render a non-empty accessControl array and the block image constant', () => {
+    const rendered = render('defaults.ts.hbs', {
+      name: 'TestBlock',
+      category: 'cards',
+      accessControl: ['content', 'product'],
+    });
+
+    expect(rendered).toContain("accessControl: ['content', 'product']");
+    expect(rendered).toContain('BLOCK_IMAGE');
+    expect(rendered).toContain("category: 'cards'");
+  });
+});
+
+describe('icon.svg.hbs', () => {
+  it('should render well-formed, non-empty SVG markup', () => {
+    const rendered = render('icon.svg.hbs', {});
+
+    expect(rendered.trim().startsWith('<svg')).toBe(true);
+    expect(rendered).toContain('</svg>');
+  });
+});
+
+describe('types.ts.hbs', () => {
+  it('should render block-shaped Props/FormProps when withForm is true', () => {
+    const rendered = render('types.ts.hbs', { name: 'TestBlock', withForm: true });
+
+    expect(rendered).toContain('export type TestBlockProps');
+    expect(rendered).toContain('export type TestBlockFormProps');
+    expect(rendered).toContain('configuration?: TestBlockStructureConfiguration');
+  });
+
+  it('should render the generic Props interface when withForm is false', () => {
+    const rendered = render('types.ts.hbs', { name: 'TestComponent', withForm: false });
+
+    expect(rendered).toContain('export interface TestComponentProps');
+    expect(rendered).not.toContain('FormProps');
+  });
+});

--- a/packages/shop-cli/__tests__/integration/template-rendering.test.ts
+++ b/packages/shop-cli/__tests__/integration/template-rendering.test.ts
@@ -47,6 +47,25 @@ describe('component-form.vue.hbs', () => {
   });
 });
 
+describe('component-view.vue.hbs', () => {
+  const rendered = () => render('component-view.vue.hbs', { name: 'TestSettings' });
+
+  it('should render real Vue interpolation, not an empty raw-block artifact', () => {
+    expect(rendered()).toContain("{{ getEditorTranslation('title') }}");
+    expect(rendered()).toContain("{{ getEditorTranslation('description') }}");
+    expect(rendered()).not.toContain('<template #setting-title></template>');
+  });
+});
+
+describe('component-toolbar.vue.hbs', () => {
+  it('should import the generic gear icon', () => {
+    const rendered = render('component-toolbar.vue.hbs', { name: 'TestSettings' });
+
+    expect(rendered).toContain("from '~/assets/icons/paths/gear-white.svg'");
+    expect(rendered).toContain("from '~/assets/icons/paths/gear-black.svg'");
+  });
+});
+
 describe('defaults.ts.hbs', () => {
   it('should render a non-empty accessControl array and the block image constant', () => {
     const rendered = render('defaults.ts.hbs', {

--- a/packages/shop-cli/bin/plentyshop.js
+++ b/packages/shop-cli/bin/plentyshop.js
@@ -81,6 +81,7 @@ Usage:
 
 Available generators:
   - component       Generate a new Vue component
+  - block           Generate a CMS block (component --with-form, registered under its own name)
   - composable      Generate a new Vue composable
 
 Options:
@@ -100,6 +101,7 @@ Examples:
   plentyshop generate component ImageBlock --with-form --skip-tests
   plentyshop generate component ProductCard --dry-run
   plentyshop generate component ImageBlock --with-form --category=media --access-control=content,product
+  plentyshop generate block ImageCarousel --category=media --access-control=content,product
   plentyshop generate composable useShoppingCart
 
 To generate into a different app root (e.g. a customer module), create a

--- a/packages/shop-cli/bin/plentyshop.js
+++ b/packages/shop-cli/bin/plentyshop.js
@@ -13,13 +13,6 @@ const command = process.argv[2];
 if (command === 'generate') {
   const plopfilePath = join(__dirname, '..', 'plopfile.ts');
 
-  // Parse --output-path flag and set environment variable
-  const outputPathFlag = process.argv.find((arg) => arg.startsWith('--output-path='));
-  if (outputPathFlag) {
-    const outputPath = outputPathFlag.split('=')[1];
-    process.env.PLENTYSHOP_OUTPUT_PATH = outputPath;
-  }
-
   // Parse optional file generation flags and set environment variables
   const flagMapping = {
     '--skip-tests': 'PLENTYSHOP_SKIP_TESTS',
@@ -49,7 +42,7 @@ if (command === 'generate') {
   }
 
   // Filter out custom flags from plop args (not plop arguments)
-  const customFlags = ['--output-path=', ...Object.keys(flagMapping)];
+  const customFlags = Object.keys(flagMapping);
   const plopArgs = process.argv.slice(3).filter((arg) => {
     return !customFlags.some((flag) => arg.startsWith(flag));
   });
@@ -78,7 +71,6 @@ Available generators:
   - composable      Generate a new Vue composable
 
 Options:
-  --output-path=<path>  Set custom output path (default: apps/web/app)
   --skip-tests          Skip generating test files
   --skip-types          Skip generating types.ts file
   --with-form           Add *Form.vue file (for CMS editor blocks)
@@ -90,6 +82,9 @@ Examples:
   plentyshop generate component ProductCard --skip-tests
   plentyshop generate component ImageBlock --with-form --skip-tests
   plentyshop generate composable useShoppingCart
-  plentyshop generate component --output-path=apps/web/modules/my-module
+
+To generate into a different app root (e.g. a customer module), create a
+.plentyone/shop-cli.json config file in your project root:
+  { "webAppPath": "apps/web/modules/my-module" }
   `);
 }

--- a/packages/shop-cli/bin/plentyshop.js
+++ b/packages/shop-cli/bin/plentyshop.js
@@ -13,6 +13,17 @@ const command = process.argv[2];
 if (command === 'generate') {
   const plopfilePath = join(__dirname, '..', 'plopfile.ts');
 
+  // Parse --category=<value> and --access-control=<comma,separated,list> flags
+  const categoryFlag = process.argv.find((arg) => arg.startsWith('--category='));
+  if (categoryFlag) {
+    process.env.PLENTYSHOP_CATEGORY = categoryFlag.split('=')[1];
+  }
+
+  const accessControlFlag = process.argv.find((arg) => arg.startsWith('--access-control='));
+  if (accessControlFlag) {
+    process.env.PLENTYSHOP_ACCESS_CONTROL = accessControlFlag.split('=')[1];
+  }
+
   // Parse optional file generation flags and set environment variables
   const flagMapping = {
     '--skip-tests': 'PLENTYSHOP_SKIP_TESTS',
@@ -21,6 +32,7 @@ if (command === 'generate') {
     '--with-view': 'PLENTYSHOP_WITH_VIEW',
     '--with-toolbar': 'PLENTYSHOP_WITH_TOOLBAR',
     '--dry-run': 'PLENTYSHOP_DRY_RUN',
+    '--complex-form': 'PLENTYSHOP_COMPLEX_FORM',
   };
 
   // Check if any flags are provided (non-interactive mode)
@@ -43,7 +55,7 @@ if (command === 'generate') {
   }
 
   // Filter out custom flags from plop args (not plop arguments)
-  const customFlags = Object.keys(flagMapping);
+  const customFlags = ['--category=', '--access-control=', ...Object.keys(flagMapping)];
   const plopArgs = process.argv.slice(3).filter((arg) => {
     return !customFlags.some((flag) => arg.startsWith(flag));
   });
@@ -72,18 +84,22 @@ Available generators:
   - composable      Generate a new Vue composable
 
 Options:
-  --skip-tests          Skip generating test files
-  --skip-types          Skip generating types.ts file
-  --with-form           Add *Form.vue file (for CMS editor blocks)
-  --with-view           Add View.vue file (for settings panels)
-  --with-toolbar        Add ToolbarTrigger.vue file (for settings)
-  --dry-run             Preview planned files without writing anything
+  --skip-tests             Skip generating test files
+  --skip-types             Skip generating types.ts file
+  --with-form              Add *Form.vue file (for CMS editor blocks)
+  --with-view              Add View.vue file (for settings panels)
+  --with-toolbar           Add ToolbarTrigger.vue file (for settings)
+  --dry-run                Preview planned files without writing anything
+  --complex-form           With --with-form: scaffold forms/+partials/ instead of one Form.vue
+  --category=<value>       With --with-form: the block's CMS editor category
+  --access-control=<list>  With --with-form: comma-separated contexts (content,productCategory,product)
 
 Examples:
   plentyshop generate component
   plentyshop generate component ProductCard --skip-tests
   plentyshop generate component ImageBlock --with-form --skip-tests
   plentyshop generate component ProductCard --dry-run
+  plentyshop generate component ImageBlock --with-form --category=media --access-control=content,product
   plentyshop generate composable useShoppingCart
 
 To generate into a different app root (e.g. a customer module), create a

--- a/packages/shop-cli/bin/plentyshop.js
+++ b/packages/shop-cli/bin/plentyshop.js
@@ -33,6 +33,7 @@ if (command === 'generate') {
     '--with-toolbar': 'PLENTYSHOP_WITH_TOOLBAR',
     '--dry-run': 'PLENTYSHOP_DRY_RUN',
     '--complex-form': 'PLENTYSHOP_COMPLEX_FORM',
+    '--structure': 'PLENTYSHOP_STRUCTURE',
   };
 
   // Check if any flags are provided (non-interactive mode)
@@ -92,6 +93,8 @@ Options:
   --with-toolbar           Add ToolbarTrigger.vue file (for settings)
   --dry-run                Preview planned files without writing anything
   --complex-form           With --with-form: scaffold forms/+partials/ instead of one Form.vue
+  --structure              With --with-form: scaffold a structure/container block (content: Block[]
+                            children) instead of a content block (content: settings object)
   --category=<value>       With --with-form: the block's CMS editor category
   --access-control=<list>  With --with-form: comma-separated contexts (content,productCategory,product)
 
@@ -102,6 +105,7 @@ Examples:
   plentyshop generate component ProductCard --dry-run
   plentyshop generate component ImageBlock --with-form --category=media --access-control=content,product
   plentyshop generate block ImageCarousel --category=media --access-control=content,product
+  plentyshop generate block ColumnLayout --structure --category=layout --access-control=content
   plentyshop generate composable useShoppingCart
 
 To generate into a different app root (e.g. a customer module), create a

--- a/packages/shop-cli/bin/plentyshop.js
+++ b/packages/shop-cli/bin/plentyshop.js
@@ -20,6 +20,7 @@ if (command === 'generate') {
     '--with-form': 'PLENTYSHOP_WITH_FORM',
     '--with-view': 'PLENTYSHOP_WITH_VIEW',
     '--with-toolbar': 'PLENTYSHOP_WITH_TOOLBAR',
+    '--dry-run': 'PLENTYSHOP_DRY_RUN',
   };
 
   // Check if any flags are provided (non-interactive mode)
@@ -76,11 +77,13 @@ Options:
   --with-form           Add *Form.vue file (for CMS editor blocks)
   --with-view           Add View.vue file (for settings panels)
   --with-toolbar        Add ToolbarTrigger.vue file (for settings)
+  --dry-run             Preview planned files without writing anything
 
 Examples:
   plentyshop generate component
   plentyshop generate component ProductCard --skip-tests
   plentyshop generate component ImageBlock --with-form --skip-tests
+  plentyshop generate component ProductCard --dry-run
   plentyshop generate composable useShoppingCart
 
 To generate into a different app root (e.g. a customer module), create a

--- a/packages/shop-cli/plopfile.ts
+++ b/packages/shop-cli/plopfile.ts
@@ -27,8 +27,7 @@ export default function (plop: NodePlopAPI): void {
     plop.setPartial(partialName, partialContent);
   }
 
-  const cliFlag = process.env.PLENTYSHOP_OUTPUT_PATH ? { webAppPath: process.env.PLENTYSHOP_OUTPUT_PATH } : undefined;
-  const config = resolveConfig(cliFlag);
+  const config = resolveConfig();
 
   if (!validatePath(projectRoot, config.webAppPath)) {
     console.error(`\nError: Cannot find web app directory at: ${config.webAppPath}`);

--- a/packages/shop-cli/plopfile.ts
+++ b/packages/shop-cli/plopfile.ts
@@ -3,6 +3,7 @@ import { registerDefaultHelpers } from './src/helpers';
 import registerGenerators from './src/generators/index';
 import { PathResolver, resolveConfig, validatePath } from './src/core';
 import { validateProjectStructure } from './src/utils/project-validation';
+import { dryRunManager, createDryRunAction } from './src/utils/dry-run';
 import path from 'node:path';
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -17,6 +18,14 @@ const projectRoot = path.resolve(cliRoot, '../../');
  */
 export default function (plop: NodePlopAPI): void {
   registerDefaultHelpers(plop, true);
+
+  if (process.env.PLENTYSHOP_DRY_RUN === 'true') {
+    dryRunManager.enableDryRun();
+  } else {
+    dryRunManager.disableDryRun();
+  }
+  plop.setActionType('dry-run-add', createDryRunAction('add'));
+  plop.setActionType('dry-run-summary', () => dryRunManager.getSummary());
 
   const partialsDir = path.join(__dirname, 'templates/partials');
   const partialFiles = fs.readdirSync(partialsDir).filter((file) => file.endsWith('.hbs'));

--- a/packages/shop-cli/src/core/builders/ActionBuilder.ts
+++ b/packages/shop-cli/src/core/builders/ActionBuilder.ts
@@ -6,6 +6,11 @@
 
 import { PathResolver, type GeneratorAction, type PromptAnswers } from '../index';
 import type { PathOptions } from '../path/types';
+import { dryRunManager } from '../../utils/dry-run';
+
+/** `'add'` in a real run; a dry-run-only action type when `--dry-run` is active, so real writes are never affected. */
+const ADD_ACTION_TYPE = 'add';
+const DRY_RUN_ADD_ACTION_TYPE = 'dry-run-add';
 
 /**
  * Fluent builder for creating PlopJS actions
@@ -62,7 +67,7 @@ export class ActionBuilder {
     } = options;
 
     this.actions.push({
-      type: 'add',
+      type: this.actionType(),
       path: `${this.basePath}/${fileName}`,
       templateFile: `${this.templatePath}/${template}`,
       data: this.data,
@@ -78,7 +83,7 @@ export class ActionBuilder {
     const templateFile = template || `types.ts.hbs`;
 
     this.actions.push({
-      type: 'add',
+      type: this.actionType(),
       path: `${this.basePath}/types.ts`,
       templateFile: `${this.templatePath}/${templateFile}`,
       data: this.data,
@@ -99,7 +104,7 @@ export class ActionBuilder {
     const { template = `${this.generatorType}.spec.ts.hbs`, fileName = this.getTestFileName() } = options;
 
     this.actions.push({
-      type: 'add',
+      type: this.actionType(),
       path: `${this.basePath}/__tests__/${fileName}`,
       templateFile: `${this.templatePath}/${template}`,
       data: this.data,
@@ -115,7 +120,7 @@ export class ActionBuilder {
     const templateFile = template || 'index.ts.hbs';
 
     this.actions.push({
-      type: 'add',
+      type: this.actionType(),
       path: `${this.basePath}/index.ts`,
       templateFile: `${this.templatePath}/${templateFile}`,
       data: this.data,
@@ -129,7 +134,7 @@ export class ActionBuilder {
    */
   addCustomFile(fileName: string, templateFile: string, customData?: PromptAnswers): this {
     this.actions.push({
-      type: 'add',
+      type: this.actionType(),
       path: `${this.basePath}/${fileName}`,
       templateFile: `${this.templatePath}/${templateFile}`,
       data: customData || this.data,
@@ -143,7 +148,7 @@ export class ActionBuilder {
    */
   addFileToPath(fullPath: string, templateFile: string, customData?: PromptAnswers): this {
     this.actions.push({
-      type: 'add',
+      type: this.actionType(),
       path: fullPath,
       templateFile: `${this.templatePath}/${templateFile}`,
       data: customData || this.data,
@@ -153,10 +158,22 @@ export class ActionBuilder {
   }
 
   /**
-   * Build and return the final actions array
+   * Build and return the final actions array.
+   * In dry-run mode, appends a final action that prints the planned-operations summary once all
+   * preceding dry-run-add actions have logged themselves.
    */
   build(): GeneratorAction[] {
+    if (dryRunManager.isDryRun) {
+      return [...this.actions, { type: 'dry-run-summary', path: '' }];
+    }
     return [...this.actions];
+  }
+
+  /**
+   * `'add'` for a real run, or a dry-run-only type when `--dry-run` is active
+   */
+  private actionType(): string {
+    return dryRunManager.isDryRun ? DRY_RUN_ADD_ACTION_TYPE : ADD_ACTION_TYPE;
   }
 
   /**

--- a/packages/shop-cli/src/core/builders/ActionBuilder.ts
+++ b/packages/shop-cli/src/core/builders/ActionBuilder.ts
@@ -144,6 +144,14 @@ export class ActionBuilder {
   }
 
   /**
+   * The component's resolved base directory (relative to `packages/shop-cli`), for callers that
+   * need to place files in a subdirectory (e.g. `forms/`, `partials/`) rather than at its root.
+   */
+  get resolvedBasePath(): string {
+    return this.basePath;
+  }
+
+  /**
    * Add a file to a custom path (outside the base path)
    */
   addFileToPath(fullPath: string, templateFile: string, customData?: PromptAnswers): this {

--- a/packages/shop-cli/src/core/builders/ActionBuilder.ts
+++ b/packages/shop-cli/src/core/builders/ActionBuilder.ts
@@ -39,7 +39,12 @@ export class ActionBuilder {
   /**
    * Create a new ActionBuilder for a specific generator type
    */
-  static forGenerator(type: string, name: string, pathResolver: PathResolver, pathOptions?: PathOptions): ActionBuilder {
+  static forGenerator(
+    type: string,
+    name: string,
+    pathResolver: PathResolver,
+    pathOptions?: PathOptions,
+  ): ActionBuilder {
     return new ActionBuilder(name, type, pathResolver, pathOptions);
   }
 

--- a/packages/shop-cli/src/core/builders/ActionBuilder.ts
+++ b/packages/shop-cli/src/core/builders/ActionBuilder.ts
@@ -5,6 +5,7 @@
  */
 
 import { PathResolver, type GeneratorAction, type PromptAnswers } from '../index';
+import type { PathOptions } from '../path/types';
 
 /**
  * Fluent builder for creating PlopJS actions
@@ -22,6 +23,7 @@ export class ActionBuilder {
     name: string,
     generatorType: string,
     private readonly pathResolver: PathResolver,
+    private readonly pathOptions?: PathOptions,
   ) {
     this.name = name;
     this.generatorType = generatorType;
@@ -32,8 +34,8 @@ export class ActionBuilder {
   /**
    * Create a new ActionBuilder for a specific generator type
    */
-  static forGenerator(type: string, name: string, pathResolver: PathResolver): ActionBuilder {
-    return new ActionBuilder(name, type, pathResolver);
+  static forGenerator(type: string, name: string, pathResolver: PathResolver, pathOptions?: PathOptions): ActionBuilder {
+    return new ActionBuilder(name, type, pathResolver, pathOptions);
   }
 
   /**
@@ -161,7 +163,7 @@ export class ActionBuilder {
    * Resolve base path using PathResolver
    */
   private resolveBasePath(): string {
-    const result = this.pathResolver.resolve(this.generatorType, this.name);
+    const result = this.pathResolver.resolve(this.generatorType, this.name, this.pathOptions);
     return result.basePath;
   } /**
    * Get default file extension based on generator type

--- a/packages/shop-cli/src/core/builders/ActionBuilder.ts
+++ b/packages/shop-cli/src/core/builders/ActionBuilder.ts
@@ -177,9 +177,6 @@ export class ActionBuilder {
     return [...this.actions];
   }
 
-  /**
-   * `'add'` for a real run, or a dry-run-only type when `--dry-run` is active
-   */
   private actionType(): string {
     return dryRunManager.isDryRun ? DRY_RUN_ADD_ACTION_TYPE : ADD_ACTION_TYPE;
   }

--- a/packages/shop-cli/src/core/generators/BaseGenerator.ts
+++ b/packages/shop-cli/src/core/generators/BaseGenerator.ts
@@ -82,16 +82,24 @@ export abstract class BaseGenerator {
 
   /**
    * Generate actions with error handling wrapper
+   *
+   * A failed run (missing/invalid data, or an error thrown while building actions) throws
+   * instead of returning an empty array, so plop surfaces a non-zero exit and a clear error
+   * rather than silently reporting success with zero files created.
    */
   private generateWithErrorHandling(data: PromptAnswers | undefined): GeneratorAction[] {
     const result = this.errorHandler.wrapGeneratorExecution(this.name, () => {
       const validatedData = this.ensureData(data);
       if (!validatedData) {
-        return [];
+        throw new Error(`${this.name} generation aborted: invalid or missing input data`);
       }
       return this.createActions(validatedData);
     });
 
-    return result.success ? (result.data as GeneratorAction[]) : [];
+    if (!result.success) {
+      throw new Error(result.error.message);
+    }
+
+    return result.data as GeneratorAction[];
   }
 }

--- a/packages/shop-cli/src/core/generators/__tests__/BaseGenerator.test.ts
+++ b/packages/shop-cli/src/core/generators/__tests__/BaseGenerator.test.ts
@@ -104,8 +104,7 @@ describe('BaseGenerator', () => {
 
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    const emptyResult = actionsFunction(undefined);
-    expect(emptyResult).toEqual([]);
+    expect(() => actionsFunction(undefined)).toThrow();
 
     consoleErrorSpy.mockRestore();
 
@@ -113,5 +112,58 @@ describe('BaseGenerator', () => {
     const actions = actionsFunction(validData);
     expect(actions).toHaveLength(1);
     expect(actions[0].path).toBe('test/TestComponent.txt');
+  });
+
+  it('should throw instead of silently returning an empty array on missing data', () => {
+    const generator = new TestGenerator(pathResolver);
+    const mockPlop = {
+      setGenerator: vi.fn(),
+    };
+
+    generator.register(mockPlop as unknown as Parameters<typeof generator.register>[0]);
+
+    const registeredConfig = mockPlop.setGenerator.mock.calls[0][1];
+    const actionsFunction = registeredConfig.actions;
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => actionsFunction(undefined)).toThrow(/invalid or missing input data/);
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('should throw instead of silently returning an empty array when createActions() throws', () => {
+    class ThrowingGenerator extends BaseGenerator {
+      readonly name = 'throwing';
+      readonly description = 'Generator that always fails while building actions';
+
+      getPrompts(): GeneratorPrompt[] {
+        return [];
+      }
+
+      validateInput(): string | true {
+        return true;
+      }
+
+      createActions(): GeneratorAction[] {
+        throw new Error('boom: template rendering failed');
+      }
+    }
+
+    const generator = new ThrowingGenerator(pathResolver);
+    const mockPlop = {
+      setGenerator: vi.fn(),
+    };
+
+    generator.register(mockPlop as unknown as Parameters<typeof generator.register>[0]);
+
+    const registeredConfig = mockPlop.setGenerator.mock.calls[0][1];
+    const actionsFunction = registeredConfig.actions;
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => actionsFunction({ name: 'TestComponent' })).toThrow(/boom: template rendering failed/);
+
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/packages/shop-cli/src/core/path/PathStrategies.ts
+++ b/packages/shop-cli/src/core/path/PathStrategies.ts
@@ -80,7 +80,7 @@ abstract class BasePathStrategy implements PathStrategy {
  */
 export class ComponentPathStrategy extends BasePathStrategy {
   resolve(name: string, options: PathOptions = {}): PathResult {
-    const basePath = join(this.config.webAppRoot, 'components', name);
+    const basePath = join(this.config.webAppRoot, 'components', ...(options.isBlock ? ['blocks'] : []), name);
     const mainFileName = options.fileName || `{{pascalCase name}}`;
     const extension = options.extension || 'vue';
 

--- a/packages/shop-cli/src/core/path/__tests__/PathResolver.test.ts
+++ b/packages/shop-cli/src/core/path/__tests__/PathResolver.test.ts
@@ -51,6 +51,19 @@ describe('PathResolver', () => {
 
       expect(result.mainFile).toBe('../../apps/web/app/components/TestComponent/CustomName.jsx');
     });
+
+    it('should insert a blocks/ segment when isBlock is set', () => {
+      const result = pathResolver.resolve('component', 'TestComponent', { isBlock: true });
+
+      expect(result.basePath).toBe('../../apps/web/app/components/blocks/TestComponent');
+      expect(result.mainFile).toBe('../../apps/web/app/components/blocks/TestComponent/{{pascalCase name}}.vue');
+    });
+
+    it('should not insert a blocks/ segment when isBlock is not set', () => {
+      const result = pathResolver.resolve('component', 'TestComponent', {});
+
+      expect(result.basePath).toBe('../../apps/web/app/components/TestComponent');
+    });
   });
 
   describe('Composable Strategy', () => {

--- a/packages/shop-cli/src/core/path/types.ts
+++ b/packages/shop-cli/src/core/path/types.ts
@@ -16,6 +16,8 @@ export interface PathOptions {
   isDynamic?: boolean;
   /** Custom web app path */
   webAppPath?: string;
+  /** Whether this generation is a CMS block (adds a `blocks/` path segment) */
+  isBlock?: boolean;
 }
 
 /**

--- a/packages/shop-cli/src/generators/component/__tests__/__snapshots__/component.test.ts.snap
+++ b/packages/shop-cli/src/generators/component/__tests__/__snapshots__/component.test.ts.snap
@@ -1,0 +1,16 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`componentGenerator > block scaffolding (--with-form) > should match the expected --with-form --complex-form directory shape > component-with-form-complex-form-structure 1`] = `
+[
+  "components/blocks/TestBlock/TestBlockForm.vue",
+  "components/blocks/TestBlock/__tests__/{{pascalCase name}}.spec.ts",
+  "components/blocks/TestBlock/defaults.ts",
+  "components/blocks/TestBlock/forms/TestBlockSettingsForm.vue",
+  "components/blocks/TestBlock/forms/__tests__/TestBlockSettingsForm.spec.ts",
+  "components/blocks/TestBlock/icon.svg",
+  "components/blocks/TestBlock/partials/TestBlockSectionEditor.vue",
+  "components/blocks/TestBlock/partials/__tests__/TestBlockSectionEditor.spec.ts",
+  "components/blocks/TestBlock/types.ts",
+  "components/blocks/TestBlock/{{pascalCase name}}.vue",
+]
+`;

--- a/packages/shop-cli/src/generators/component/__tests__/block.test.ts
+++ b/packages/shop-cli/src/generators/component/__tests__/block.test.ts
@@ -12,10 +12,7 @@ const getBlockActionsFunction = () => {
   const pathResolver = new PathResolver();
   let name = '';
   let actionsFunction!: (data?: PromptAnswers) => GeneratorAction[];
-  const setGenerator = (
-    generatorName: string,
-    config: { actions: (data?: PromptAnswers) => GeneratorAction[] },
-  ) => {
+  const setGenerator = (generatorName: string, config: { actions: (data?: PromptAnswers) => GeneratorAction[] }) => {
     name = generatorName;
     actionsFunction = config.actions;
   };

--- a/packages/shop-cli/src/generators/component/__tests__/block.test.ts
+++ b/packages/shop-cli/src/generators/component/__tests__/block.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for the standalone "block" generator (registered so it shows up in `npx plentyshop
+ * generate`'s interactive generator picker, alongside "component" and "composable").
+ */
+
+import { describe, it, expect } from 'vitest';
+import blockGenerator from '../block';
+import { PathResolver } from '../../../core/path/PathResolver';
+import type { GeneratorAction, PromptAnswers } from '../../../core/generators/types';
+
+const getBlockActionsFunction = () => {
+  const pathResolver = new PathResolver();
+  let name = '';
+  let actionsFunction!: (data?: PromptAnswers) => GeneratorAction[];
+  const setGenerator = (
+    generatorName: string,
+    config: { actions: (data?: PromptAnswers) => GeneratorAction[] },
+  ) => {
+    name = generatorName;
+    actionsFunction = config.actions;
+  };
+
+  blockGenerator({ setGenerator } as unknown as Parameters<typeof blockGenerator>[0], pathResolver);
+
+  return { name, actionsFunction };
+};
+
+describe('blockGenerator', () => {
+  it('should register itself under the name "block", distinct from "component"', () => {
+    const { name } = getBlockActionsFunction();
+    expect(name).toBe('block');
+  });
+
+  it('should always scaffold Form.vue, defaults.ts, and icon.svg without a withForm answer', () => {
+    const { actionsFunction } = getBlockActionsFunction();
+    const actions = actionsFunction({ name: 'TestBlock', category: 'cards' });
+
+    expect(actions.some((action) => action.path.endsWith('TestBlockForm.vue'))).toBe(true);
+    expect(actions.some((action) => action.path.endsWith('/defaults.ts'))).toBe(true);
+    expect(actions.some((action) => action.path.endsWith('/icon.svg'))).toBe(true);
+  });
+
+  it('should resolve into components/blocks/<Name>/, same as component --with-form', () => {
+    const { actionsFunction } = getBlockActionsFunction();
+    const actions = actionsFunction({ name: 'TestBlock', category: 'cards' });
+
+    const mainFile = actions.find((action) => action.path.endsWith('{{pascalCase name}}.vue'));
+    expect(mainFile?.path).toContain('components/blocks/TestBlock');
+  });
+
+  it('should never resolve accessControl to an empty array', () => {
+    const { actionsFunction } = getBlockActionsFunction();
+    const actions = actionsFunction({ name: 'TestBlock', category: 'cards' });
+
+    const defaultsAction = actions.find((action) => action.path.endsWith('/defaults.ts'));
+    expect(defaultsAction?.data?.accessControl).toEqual(['content']);
+  });
+
+  it('should scaffold the complex-form file set when complexForm is set', () => {
+    const { actionsFunction } = getBlockActionsFunction();
+    const actions = actionsFunction({ name: 'TestBlock', category: 'cards', complexForm: true });
+
+    expect(actions.some((action) => action.path.endsWith('/forms/TestBlockSettingsForm.vue'))).toBe(true);
+    expect(actions.some((action) => action.path.endsWith('/partials/TestBlockSectionEditor.vue'))).toBe(true);
+  });
+
+  it('should not add View.vue or ToolbarTrigger.vue — those are for settings panels, not blocks', () => {
+    const { actionsFunction } = getBlockActionsFunction();
+    const actions = actionsFunction({ name: 'TestBlock', category: 'cards' });
+
+    expect(actions.some((action) => action.path.endsWith('View.vue'))).toBe(false);
+    expect(actions.some((action) => action.path.endsWith('ToolbarTrigger.vue'))).toBe(false);
+  });
+});

--- a/packages/shop-cli/src/generators/component/__tests__/block.test.ts
+++ b/packages/shop-cli/src/generators/component/__tests__/block.test.ts
@@ -61,6 +61,16 @@ describe('blockGenerator', () => {
     expect(actions.some((action) => action.path.endsWith('/partials/TestBlockSectionEditor.vue'))).toBe(true);
   });
 
+  it('should pass structure through to the defaults.ts/types.ts template data', () => {
+    const { actionsFunction } = getBlockActionsFunction();
+    const actions = actionsFunction({ name: 'TestBlock', category: 'cards', structure: true });
+
+    const defaultsAction = actions.find((action) => action.path.endsWith('/defaults.ts'));
+    const typesAction = actions.find((action) => action.path.endsWith('/types.ts'));
+    expect(defaultsAction?.data?.structure).toBe(true);
+    expect(typesAction?.data?.structure).toBe(true);
+  });
+
   it('should not add View.vue or ToolbarTrigger.vue — those are for settings panels, not blocks', () => {
     const { actionsFunction } = getBlockActionsFunction();
     const actions = actionsFunction({ name: 'TestBlock', category: 'cards' });

--- a/packages/shop-cli/src/generators/component/__tests__/component-prompts.test.ts
+++ b/packages/shop-cli/src/generators/component/__tests__/component-prompts.test.ts
@@ -20,6 +20,7 @@ const getPrompt = (name: string): PromptConfig => {
 const ENV_KEYS = [
   'PLENTYSHOP_WITH_FORM',
   'PLENTYSHOP_COMPLEX_FORM',
+  'PLENTYSHOP_STRUCTURE',
   'PLENTYSHOP_CATEGORY',
   'PLENTYSHOP_ACCESS_CONTROL',
 ];
@@ -80,6 +81,24 @@ describe('accessControl prompt', () => {
     process.env.PLENTYSHOP_WITH_FORM = 'true';
     process.env.PLENTYSHOP_ACCESS_CONTROL = 'content';
     expect(accessControl.when?.({})).toBe(false);
+  });
+});
+
+describe('structure prompt', () => {
+  const structure = getPrompt('structure');
+
+  it('should not prompt for a plain component (no withForm)', () => {
+    expect(structure.when?.({ withForm: false })).toBe(false);
+  });
+
+  it('should prompt when withForm answer is true', () => {
+    expect(structure.when?.({ withForm: true })).toBe(true);
+  });
+
+  it('should not prompt when PLENTYSHOP_STRUCTURE is already set', () => {
+    process.env.PLENTYSHOP_WITH_FORM = 'true';
+    process.env.PLENTYSHOP_STRUCTURE = 'true';
+    expect(structure.when?.({})).toBe(false);
   });
 });
 

--- a/packages/shop-cli/src/generators/component/__tests__/component-prompts.test.ts
+++ b/packages/shop-cli/src/generators/component/__tests__/component-prompts.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for the component generator's block-related prompts (category, accessControl, complexForm)
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { componentPrompts } from '../component-prompts';
+
+type PromptConfig = {
+  name: string;
+  validate?: (input: unknown) => string | boolean;
+  when?: (answers: Record<string, unknown>) => boolean;
+};
+
+const getPrompt = (name: string): PromptConfig => {
+  const prompt = (componentPrompts as PromptConfig[]).find((p) => p.name === name);
+  if (!prompt) throw new Error(`No prompt named ${name}`);
+  return prompt;
+};
+
+const ENV_KEYS = ['PLENTYSHOP_WITH_FORM', 'PLENTYSHOP_COMPLEX_FORM', 'PLENTYSHOP_CATEGORY', 'PLENTYSHOP_ACCESS_CONTROL'];
+
+afterEach(() => {
+  for (const key of ENV_KEYS) delete process.env[key];
+});
+
+describe('category prompt', () => {
+  const category = getPrompt('category');
+
+  it('should reject an empty or whitespace-only value', () => {
+    expect(category.validate?.('')).not.toBe(true);
+    expect(category.validate?.('   ')).not.toBe(true);
+  });
+
+  it('should accept a non-empty value', () => {
+    expect(category.validate?.('cards')).toBe(true);
+  });
+
+  it('should not prompt when withForm answer is falsy and PLENTYSHOP_WITH_FORM is unset', () => {
+    expect(category.when?.({ withForm: false })).toBe(false);
+  });
+
+  it('should prompt when withForm answer is true', () => {
+    expect(category.when?.({ withForm: true })).toBe(true);
+  });
+
+  it('should prompt when PLENTYSHOP_WITH_FORM=true even if the withForm prompt itself was skipped', () => {
+    process.env.PLENTYSHOP_WITH_FORM = 'true';
+    expect(category.when?.({})).toBe(true);
+  });
+
+  it('should not prompt when PLENTYSHOP_CATEGORY is already set', () => {
+    process.env.PLENTYSHOP_WITH_FORM = 'true';
+    process.env.PLENTYSHOP_CATEGORY = 'cards';
+    expect(category.when?.({})).toBe(false);
+  });
+});
+
+describe('accessControl prompt', () => {
+  const accessControl = getPrompt('accessControl');
+
+  it('should reject an empty selection — an empty accessControl makes a block permanently invisible', () => {
+    expect(accessControl.validate?.([])).not.toBe(true);
+  });
+
+  it('should accept a non-empty selection', () => {
+    expect(accessControl.validate?.(['content'])).toBe(true);
+  });
+
+  it('should prompt when PLENTYSHOP_WITH_FORM=true even if the withForm prompt itself was skipped', () => {
+    process.env.PLENTYSHOP_WITH_FORM = 'true';
+    expect(accessControl.when?.({})).toBe(true);
+  });
+
+  it('should not prompt when PLENTYSHOP_ACCESS_CONTROL is already set', () => {
+    process.env.PLENTYSHOP_WITH_FORM = 'true';
+    process.env.PLENTYSHOP_ACCESS_CONTROL = 'content';
+    expect(accessControl.when?.({})).toBe(false);
+  });
+});
+
+describe('complexForm prompt', () => {
+  const complexForm = getPrompt('complexForm');
+
+  it('should not prompt for a plain component (no withForm)', () => {
+    expect(complexForm.when?.({ withForm: false })).toBe(false);
+  });
+
+  it('should prompt when withForm answer is true', () => {
+    expect(complexForm.when?.({ withForm: true })).toBe(true);
+  });
+
+  it('should not prompt when PLENTYSHOP_COMPLEX_FORM is already set', () => {
+    process.env.PLENTYSHOP_WITH_FORM = 'true';
+    process.env.PLENTYSHOP_COMPLEX_FORM = 'true';
+    expect(complexForm.when?.({})).toBe(false);
+  });
+});

--- a/packages/shop-cli/src/generators/component/__tests__/component-prompts.test.ts
+++ b/packages/shop-cli/src/generators/component/__tests__/component-prompts.test.ts
@@ -17,7 +17,12 @@ const getPrompt = (name: string): PromptConfig => {
   return prompt;
 };
 
-const ENV_KEYS = ['PLENTYSHOP_WITH_FORM', 'PLENTYSHOP_COMPLEX_FORM', 'PLENTYSHOP_CATEGORY', 'PLENTYSHOP_ACCESS_CONTROL'];
+const ENV_KEYS = [
+  'PLENTYSHOP_WITH_FORM',
+  'PLENTYSHOP_COMPLEX_FORM',
+  'PLENTYSHOP_CATEGORY',
+  'PLENTYSHOP_ACCESS_CONTROL',
+];
 
 afterEach(() => {
   for (const key of ENV_KEYS) delete process.env[key];

--- a/packages/shop-cli/src/generators/component/__tests__/component.test.ts
+++ b/packages/shop-cli/src/generators/component/__tests__/component.test.ts
@@ -83,9 +83,9 @@ describe('componentGenerator', () => {
       expect(actions.some((action) => action.path.endsWith('/forms/__tests__/TestBlockSettingsForm.spec.ts'))).toBe(
         true,
       );
-      expect(
-        actions.some((action) => action.path.endsWith('/partials/__tests__/TestBlockSectionEditor.spec.ts')),
-      ).toBe(true);
+      expect(actions.some((action) => action.path.endsWith('/partials/__tests__/TestBlockSectionEditor.spec.ts'))).toBe(
+        true,
+      );
 
       const orchestrator = actions.find((action) => action.path.endsWith('TestBlockForm.vue'));
       expect(orchestrator?.templateFile).toContain('component-form-orchestrator.vue.hbs');

--- a/packages/shop-cli/src/generators/component/__tests__/component.test.ts
+++ b/packages/shop-cli/src/generators/component/__tests__/component.test.ts
@@ -116,4 +116,22 @@ describe('componentGenerator', () => {
       expect(relativePaths).toMatchSnapshot('component-with-form-complex-form-structure');
     });
   });
+
+  describe('structure blocks (--structure)', () => {
+    it('should pass structure=true through to the defaults.ts and types.ts template data', () => {
+      const actions = getActionsFunction()({ name: 'TestBlock', withForm: true, structure: true, category: 'cards' });
+
+      const defaultsAction = actions.find((action) => action.path.endsWith('/defaults.ts'));
+      const typesAction = actions.find((action) => action.path.endsWith('/types.ts'));
+      expect(defaultsAction?.data?.structure).toBe(true);
+      expect(typesAction?.data?.structure).toBe(true);
+    });
+
+    it('should default structure to false when unset', () => {
+      const actions = getActionsFunction()({ name: 'TestBlock', withForm: true, category: 'cards' });
+
+      const defaultsAction = actions.find((action) => action.path.endsWith('/defaults.ts'));
+      expect(defaultsAction?.data?.structure).toBe(false);
+    });
+  });
 });

--- a/packages/shop-cli/src/generators/component/__tests__/component.test.ts
+++ b/packages/shop-cli/src/generators/component/__tests__/component.test.ts
@@ -34,4 +34,86 @@ describe('componentGenerator', () => {
     expect(mainFile?.path).toContain('components/TestComponent');
     expect(mainFile?.path).not.toContain('components/blocks');
   });
+
+  describe('block scaffolding (--with-form)', () => {
+    it('should always include defaults.ts and icon.svg actions', () => {
+      const actions = getActionsFunction()({ name: 'TestBlock', withForm: true, category: 'cards' });
+
+      expect(actions.some((action) => action.path.endsWith('/defaults.ts'))).toBe(true);
+      expect(actions.some((action) => action.path.endsWith('/icon.svg'))).toBe(true);
+    });
+
+    it('should never resolve accessControl to an empty array, even with no answer/env var', () => {
+      const actions = getActionsFunction()({ name: 'TestBlock', withForm: true, category: 'cards' });
+
+      const defaultsAction = actions.find((action) => action.path.endsWith('/defaults.ts'));
+      expect(defaultsAction?.data?.accessControl).toEqual(['content']);
+    });
+
+    it('should pass through an explicit accessControl selection unchanged', () => {
+      const actions = getActionsFunction()({
+        name: 'TestBlock',
+        withForm: true,
+        category: 'cards',
+        accessControl: ['content', 'product'],
+      });
+
+      const defaultsAction = actions.find((action) => action.path.endsWith('/defaults.ts'));
+      expect(defaultsAction?.data?.accessControl).toEqual(['content', 'product']);
+    });
+
+    it('should add a single Form.vue by default, not the complex-form file set', () => {
+      const actions = getActionsFunction()({ name: 'TestBlock', withForm: true, category: 'cards' });
+
+      expect(actions.some((action) => action.path.endsWith('TestBlockForm.vue'))).toBe(true);
+      expect(actions.some((action) => action.path.includes('/forms/'))).toBe(false);
+      expect(actions.some((action) => action.path.includes('/partials/'))).toBe(false);
+    });
+
+    it('should add the forms/ + partials/ file set instead of a single Form.vue when complexForm is set', () => {
+      const actions = getActionsFunction()({
+        name: 'TestBlock',
+        withForm: true,
+        complexForm: true,
+        category: 'cards',
+      });
+
+      expect(actions.some((action) => action.path.endsWith('/forms/TestBlockSettingsForm.vue'))).toBe(true);
+      expect(actions.some((action) => action.path.endsWith('/partials/TestBlockSectionEditor.vue'))).toBe(true);
+      expect(actions.some((action) => action.path.endsWith('/forms/__tests__/TestBlockSettingsForm.spec.ts'))).toBe(
+        true,
+      );
+      expect(
+        actions.some((action) => action.path.endsWith('/partials/__tests__/TestBlockSectionEditor.spec.ts')),
+      ).toBe(true);
+
+      const orchestrator = actions.find((action) => action.path.endsWith('TestBlockForm.vue'));
+      expect(orchestrator?.templateFile).toContain('component-form-orchestrator.vue.hbs');
+    });
+
+    it('should skip the forms/partials __tests__ specs when skipTests is set', () => {
+      const actions = getActionsFunction()({
+        name: 'TestBlock',
+        withForm: true,
+        complexForm: true,
+        skipTests: true,
+        category: 'cards',
+      });
+
+      expect(actions.some((action) => action.path.includes('__tests__'))).toBe(false);
+    });
+
+    it('should match the expected --with-form --complex-form directory shape', () => {
+      const actions = getActionsFunction()({
+        name: 'TestBlock',
+        withForm: true,
+        complexForm: true,
+        category: 'cards',
+      });
+
+      const relativePaths = actions.map((action) => action.path.replace(/^.*apps\/web\/app\//, '')).sort();
+
+      expect(relativePaths).toMatchSnapshot('component-with-form-complex-form-structure');
+    });
+  });
 });

--- a/packages/shop-cli/src/generators/component/__tests__/component.test.ts
+++ b/packages/shop-cli/src/generators/component/__tests__/component.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Tests for the component generator's action/path wiring
+ */
+
+import { describe, it, expect } from 'vitest';
+import componentGenerator from '../component';
+import { PathResolver } from '../../../core/path/PathResolver';
+import type { GeneratorAction, PromptAnswers } from '../../../core/generators/types';
+
+const getActionsFunction = () => {
+  const pathResolver = new PathResolver();
+  const setGenerator = (_name: string, config: { actions: (data?: PromptAnswers) => GeneratorAction[] }) => {
+    actionsFunction = config.actions;
+  };
+  let actionsFunction!: (data?: PromptAnswers) => GeneratorAction[];
+
+  componentGenerator({ setGenerator } as unknown as Parameters<typeof componentGenerator>[0], pathResolver);
+
+  return actionsFunction;
+};
+
+describe('componentGenerator', () => {
+  it('should resolve a block (--with-form) into components/blocks/<Name>/', () => {
+    const actions = getActionsFunction()({ name: 'TestBlock', withForm: true });
+
+    const mainFile = actions.find((action) => action.path.endsWith('{{pascalCase name}}.vue'));
+    expect(mainFile?.path).toContain('components/blocks/TestBlock');
+  });
+
+  it('should resolve a plain component (no --with-form) into components/<Name>/, unaffected', () => {
+    const actions = getActionsFunction()({ name: 'TestComponent', withForm: false });
+
+    const mainFile = actions.find((action) => action.path.endsWith('{{pascalCase name}}.vue'));
+    expect(mainFile?.path).toContain('components/TestComponent');
+    expect(mainFile?.path).not.toContain('components/blocks');
+  });
+});

--- a/packages/shop-cli/src/generators/component/block-prompts.ts
+++ b/packages/shop-cli/src/generators/component/block-prompts.ts
@@ -1,0 +1,60 @@
+/**
+ * Block generator prompts configuration
+ *
+ * A block is a component with its form always on (`withForm` is forced by `BlockGenerator`, see
+ * `block.ts`), so unlike `componentPrompts` there's no "Include Form.vue?" question — choosing the
+ * "block" generator already means yes — and no `withView`/`withToolbar` (those are for admin
+ * settings panels, not CMS blocks).
+ */
+
+import { validateComponentName, validateNotEmpty } from '../../utils/validation';
+import { BLOCK_ACCESS_CONTROL_CHOICES } from './component-prompts';
+
+export const blockPrompts = [
+  {
+    type: 'input',
+    name: 'name',
+    message: 'What is the block name?',
+    validate: validateComponentName,
+  },
+  {
+    type: 'confirm',
+    name: 'skipTests',
+    message: 'Skip test files?',
+    default: false,
+    when: () => process.env.PLENTYSHOP_SKIP_TESTS === undefined,
+  },
+  {
+    type: 'confirm',
+    name: 'skipTypes',
+    message: 'Skip types.ts?',
+    default: false,
+    when: () => process.env.PLENTYSHOP_SKIP_TYPES === undefined,
+  },
+  {
+    type: 'confirm',
+    name: 'complexForm',
+    message: 'Use a complex multi-file form (forms/ + partials/) instead of a single Form.vue?',
+    default: false,
+    when: () => process.env.PLENTYSHOP_COMPLEX_FORM === undefined,
+  },
+  {
+    type: 'input',
+    name: 'category',
+    message: 'Block category (used for CMS editor grouping, e.g. "tabs", "banners")?',
+    validate: validateNotEmpty,
+    when: () => process.env.PLENTYSHOP_CATEGORY === undefined,
+  },
+  {
+    type: 'checkbox',
+    name: 'accessControl',
+    message: 'Where should this block be selectable? (space to toggle, at least one required)',
+    choices: BLOCK_ACCESS_CONTROL_CHOICES,
+    default: ['content'],
+    validate: (input: unknown) =>
+      Array.isArray(input) && input.length > 0
+        ? true
+        : 'Select at least one context — an empty selection makes the block permanently invisible.',
+    when: () => process.env.PLENTYSHOP_ACCESS_CONTROL === undefined,
+  },
+];

--- a/packages/shop-cli/src/generators/component/block-prompts.ts
+++ b/packages/shop-cli/src/generators/component/block-prompts.ts
@@ -33,6 +33,13 @@ export const blockPrompts = [
   },
   {
     type: 'confirm',
+    name: 'structure',
+    message: 'Is this a structure/container block that holds other blocks as children (like MultiGrid/Carousel)?',
+    default: false,
+    when: () => process.env.PLENTYSHOP_STRUCTURE === undefined,
+  },
+  {
+    type: 'confirm',
     name: 'complexForm',
     message: 'Use a complex multi-file form (forms/ + partials/) instead of a single Form.vue?',
     default: false,

--- a/packages/shop-cli/src/generators/component/block.ts
+++ b/packages/shop-cli/src/generators/component/block.ts
@@ -21,8 +21,13 @@ class BlockGenerator extends ComponentGenerator {
     return blockPrompts as GeneratorPrompt[];
   }
 
+  /**
+   * Forces `withForm` on and `withView`/`withToolbar` off, regardless of flags/env vars a caller
+   * might have set (e.g. `PLENTYSHOP_WITH_VIEW=true` from an unrelated prior invocation in the
+   * same shell) — View.vue/ToolbarTrigger.vue are for admin settings panels, never CMS blocks.
+   */
   protected resolveOptions(data: PromptAnswers): ReturnType<ComponentGenerator['resolveOptions']> {
-    return { ...super.resolveOptions(data), withForm: true };
+    return { ...super.resolveOptions(data), withForm: true, withView: false, withToolbar: false };
   }
 }
 

--- a/packages/shop-cli/src/generators/component/block.ts
+++ b/packages/shop-cli/src/generators/component/block.ts
@@ -1,0 +1,32 @@
+/**
+ * Block Generator for PlentyONE Shop
+ *
+ * A CMS block is a component with its form always on — this is `ComponentGenerator` registered
+ * under its own name so it shows up as its own choice in `npx plentyshop generate`'s interactive
+ * generator picker (previously only reachable via `component --with-form` / `npm run
+ * generate:block`, never listed there directly). All actual file-generation logic
+ * (`createActions()`, defaults.ts/icon.svg/complex-form wiring) is inherited unchanged.
+ */
+
+import type { NodePlopAPI } from 'plop';
+import type { PromptAnswers, GeneratorPrompt, PathResolver } from '../../core';
+import { ComponentGenerator } from './component';
+import { blockPrompts } from './block-prompts';
+
+class BlockGenerator extends ComponentGenerator {
+  readonly name = 'block';
+  readonly description = 'Generate a CMS block component (with Form.vue, defaults.ts, icon.svg)';
+
+  getPrompts(): GeneratorPrompt[] {
+    return blockPrompts as GeneratorPrompt[];
+  }
+
+  protected resolveOptions(data: PromptAnswers): ReturnType<ComponentGenerator['resolveOptions']> {
+    return { ...super.resolveOptions(data), withForm: true };
+  }
+}
+
+export default function blockGenerator(plop: NodePlopAPI, pathResolver: PathResolver): void {
+  const generator = new BlockGenerator(pathResolver);
+  generator.register(plop);
+}

--- a/packages/shop-cli/src/generators/component/component-prompts.ts
+++ b/packages/shop-cli/src/generators/component/component-prompts.ts
@@ -57,6 +57,13 @@ export const componentPrompts = [
   },
   {
     type: 'confirm',
+    name: 'structure',
+    message: 'Is this a structure/container block that holds other blocks as children (like MultiGrid/Carousel)?',
+    default: false,
+    when: (answers: Record<string, unknown>) => isWithForm(answers) && process.env.PLENTYSHOP_STRUCTURE === undefined,
+  },
+  {
+    type: 'confirm',
     name: 'complexForm',
     message: 'Use a complex multi-file form (forms/ + partials/) instead of a single Form.vue?',
     default: false,

--- a/packages/shop-cli/src/generators/component/component-prompts.ts
+++ b/packages/shop-cli/src/generators/component/component-prompts.ts
@@ -2,7 +2,16 @@
  * Component generator prompts configuration
  */
 
-import { validateComponentName } from '../../utils/validation';
+import { validateComponentName, validateNotEmpty } from '../../utils/validation';
+
+/**
+ * `withForm` may come from the prompt answers (interactive mode) or, when the `--with-form` flag
+ * skipped the prompt entirely, from the env var `bin/plentyshop.js` set before plop started.
+ */
+const isWithForm = (answers: Record<string, unknown>): boolean =>
+  Boolean(answers.withForm) || process.env.PLENTYSHOP_WITH_FORM === 'true';
+
+const BLOCK_ACCESS_CONTROL_CHOICES = ['content', 'productCategory', 'product'];
 
 export const componentPrompts = [
   {
@@ -45,5 +54,32 @@ export const componentPrompts = [
     message: 'Include ToolbarTrigger.vue?',
     default: false,
     when: () => process.env.PLENTYSHOP_WITH_TOOLBAR === undefined,
+  },
+  {
+    type: 'confirm',
+    name: 'complexForm',
+    message: 'Use a complex multi-file form (forms/ + partials/) instead of a single Form.vue?',
+    default: false,
+    when: (answers: Record<string, unknown>) => isWithForm(answers) && process.env.PLENTYSHOP_COMPLEX_FORM === undefined,
+  },
+  {
+    type: 'input',
+    name: 'category',
+    message: 'Block category (used for CMS editor grouping, e.g. "tabs", "banners")?',
+    validate: validateNotEmpty,
+    when: (answers: Record<string, unknown>) => isWithForm(answers) && process.env.PLENTYSHOP_CATEGORY === undefined,
+  },
+  {
+    type: 'checkbox',
+    name: 'accessControl',
+    message: 'Where should this block be selectable? (space to toggle, at least one required)',
+    choices: BLOCK_ACCESS_CONTROL_CHOICES,
+    default: ['content'],
+    validate: (input: unknown) =>
+      Array.isArray(input) && input.length > 0
+        ? true
+        : 'Select at least one context — an empty selection makes the block permanently invisible.',
+    when: (answers: Record<string, unknown>) =>
+      isWithForm(answers) && process.env.PLENTYSHOP_ACCESS_CONTROL === undefined,
   },
 ];

--- a/packages/shop-cli/src/generators/component/component-prompts.ts
+++ b/packages/shop-cli/src/generators/component/component-prompts.ts
@@ -11,7 +11,7 @@ import { validateComponentName, validateNotEmpty } from '../../utils/validation'
 const isWithForm = (answers: Record<string, unknown>): boolean =>
   Boolean(answers.withForm) || process.env.PLENTYSHOP_WITH_FORM === 'true';
 
-const BLOCK_ACCESS_CONTROL_CHOICES = ['content', 'productCategory', 'product'];
+export const BLOCK_ACCESS_CONTROL_CHOICES = ['content', 'productCategory', 'product'];
 
 export const componentPrompts = [
   {

--- a/packages/shop-cli/src/generators/component/component-prompts.ts
+++ b/packages/shop-cli/src/generators/component/component-prompts.ts
@@ -60,7 +60,8 @@ export const componentPrompts = [
     name: 'complexForm',
     message: 'Use a complex multi-file form (forms/ + partials/) instead of a single Form.vue?',
     default: false,
-    when: (answers: Record<string, unknown>) => isWithForm(answers) && process.env.PLENTYSHOP_COMPLEX_FORM === undefined,
+    when: (answers: Record<string, unknown>) =>
+      isWithForm(answers) && process.env.PLENTYSHOP_COMPLEX_FORM === undefined,
   },
   {
     type: 'input',

--- a/packages/shop-cli/src/generators/component/component.ts
+++ b/packages/shop-cli/src/generators/component/component.ts
@@ -32,6 +32,7 @@ export class ComponentGenerator extends BaseGenerator {
     withForm: boolean;
     withView: boolean;
     withToolbar: boolean;
+    structure: boolean;
     complexForm: boolean;
     category: string;
     accessControl: string[];
@@ -42,6 +43,7 @@ export class ComponentGenerator extends BaseGenerator {
       withForm: Boolean(data.withForm ?? process.env.PLENTYSHOP_WITH_FORM === 'true'),
       withView: Boolean(data.withView ?? process.env.PLENTYSHOP_WITH_VIEW === 'true'),
       withToolbar: Boolean(data.withToolbar ?? process.env.PLENTYSHOP_WITH_TOOLBAR === 'true'),
+      structure: Boolean(data.structure ?? process.env.PLENTYSHOP_STRUCTURE === 'true'),
       complexForm: Boolean(data.complexForm ?? process.env.PLENTYSHOP_COMPLEX_FORM === 'true'),
       category: this.resolveCategory(data),
       accessControl: this.resolveAccessControl(data),

--- a/packages/shop-cli/src/generators/component/component.ts
+++ b/packages/shop-cli/src/generators/component/component.ts
@@ -9,6 +9,8 @@ import type { GeneratorAction, PromptAnswers, GeneratorPrompt, PathResolver } fr
 import { componentPrompts } from './component-prompts';
 import { validateComponentName } from '../../utils/validation';
 
+const BLOCK_DEFAULT_ACCESS_CONTROL = ['content'];
+
 /**
  * Component Generator using BaseGenerator pattern
  */
@@ -26,6 +28,9 @@ class ComponentGenerator extends BaseGenerator {
     withForm: boolean;
     withView: boolean;
     withToolbar: boolean;
+    complexForm: boolean;
+    category: string;
+    accessControl: string[];
   } {
     return {
       skipTests: Boolean(data.skipTests ?? process.env.PLENTYSHOP_SKIP_TESTS === 'true'),
@@ -33,22 +38,91 @@ class ComponentGenerator extends BaseGenerator {
       withForm: Boolean(data.withForm ?? process.env.PLENTYSHOP_WITH_FORM === 'true'),
       withView: Boolean(data.withView ?? process.env.PLENTYSHOP_WITH_VIEW === 'true'),
       withToolbar: Boolean(data.withToolbar ?? process.env.PLENTYSHOP_WITH_TOOLBAR === 'true'),
+      complexForm: Boolean(data.complexForm ?? process.env.PLENTYSHOP_COMPLEX_FORM === 'true'),
+      category: this.resolveCategory(data),
+      accessControl: this.resolveAccessControl(data),
     };
+  }
+
+  private resolveCategory(data: PromptAnswers): string {
+    if (typeof data.category === 'string' && data.category.trim().length > 0) {
+      return data.category;
+    }
+    return process.env.PLENTYSHOP_CATEGORY ?? '';
+  }
+
+  /**
+   * Never returns an empty array — an empty `accessControl` makes a block permanently
+   * unselectable in the CMS editor with no error anywhere (`pageHasAccessToCategory()`).
+   */
+  private resolveAccessControl(data: PromptAnswers): string[] {
+    if (Array.isArray(data.accessControl) && data.accessControl.length > 0) {
+      return data.accessControl as string[];
+    }
+
+    const envValue = process.env.PLENTYSHOP_ACCESS_CONTROL;
+    if (envValue) {
+      const parsed = envValue
+        .split(',')
+        .map((value) => value.trim())
+        .filter(Boolean);
+      if (parsed.length > 0) {
+        return parsed;
+      }
+    }
+
+    return BLOCK_DEFAULT_ACCESS_CONTROL;
   }
 
   createActions(data: PromptAnswers): GeneratorAction[] {
     const options = this.resolveOptions(data);
+    const templateData = { ...data, ...options };
     const builder = ActionBuilder.forGenerator('component', data.name, this.pathResolver, { isBlock: options.withForm })
-      .withData(data)
+      .withData(templateData)
       .addMainFile();
 
     if (!options.skipTypes) builder.addTypes();
     if (!options.skipTests) builder.addTests();
-    if (options.withForm) builder.addCustomFile(`${data.name}Form.vue`, 'component-form.vue.hbs');
+
+    if (options.withForm) {
+      builder.addCustomFile('defaults.ts', 'defaults.ts.hbs');
+      builder.addCustomFile('icon.svg', 'icon.svg.hbs');
+
+      if (options.complexForm) {
+        this.addComplexFormFiles(builder, data.name, options.skipTests);
+      } else {
+        builder.addCustomFile(`${data.name}Form.vue`, 'component-form.vue.hbs');
+      }
+    }
+
     if (options.withView) builder.addCustomFile('View.vue', 'component-view.vue.hbs');
     if (options.withToolbar) builder.addCustomFile(`${data.name}ToolbarTrigger.vue`, 'component-toolbar.vue.hbs');
 
     return builder.build();
+  }
+
+  /**
+   * Scaffolds the `--complex-form` shape (orchestrator + one generic `forms/` sub-form + one
+   * generic `partials/` fragment), matching the real `UtilityBar` block's structure, instead of a
+   * single `Form.vue`.
+   */
+  private addComplexFormFiles(builder: ActionBuilder, name: string, skipTests: boolean): void {
+    const basePath = builder.resolvedBasePath;
+
+    builder.addCustomFile(`${name}Form.vue`, 'component-form-orchestrator.vue.hbs');
+    builder.addFileToPath(`${basePath}/forms/${name}SettingsForm.vue`, 'forms/component-subform.vue.hbs');
+    builder.addFileToPath(`${basePath}/partials/${name}SectionEditor.vue`, 'partials/component-partial.vue.hbs');
+
+    if (!skipTests) {
+      builder.addFileToPath(
+        `${basePath}/forms/__tests__/${name}SettingsForm.spec.ts`,
+        'forms/component-subform.spec.ts.hbs',
+      );
+      builder.addFileToPath(
+        `${basePath}/partials/__tests__/${name}SectionEditor.spec.ts`,
+        'partials/component-partial.spec.ts.hbs',
+      );
+    }
   }
 
   validateInput(data: PromptAnswers): string | true {

--- a/packages/shop-cli/src/generators/component/component.ts
+++ b/packages/shop-cli/src/generators/component/component.ts
@@ -13,16 +13,20 @@ const BLOCK_DEFAULT_ACCESS_CONTROL = ['content'];
 
 /**
  * Component Generator using BaseGenerator pattern
+ *
+ * Exported (not just the default factory function) so `BlockGenerator` (`block.ts`) can extend it
+ * and reuse `createActions()`/template wiring unchanged, overriding only `getPrompts()` and
+ * `resolveOptions()` to always resolve as a block.
  */
-class ComponentGenerator extends BaseGenerator {
-  readonly name = 'component';
-  readonly description = 'Generate a Vue component with TypeScript support';
+export class ComponentGenerator extends BaseGenerator {
+  readonly name: string = 'component';
+  readonly description: string = 'Generate a Vue component with TypeScript support';
 
   getPrompts(): GeneratorPrompt[] {
     return componentPrompts as GeneratorPrompt[];
   }
 
-  private resolveOptions(data: PromptAnswers): {
+  protected resolveOptions(data: PromptAnswers): {
     skipTests: boolean;
     skipTypes: boolean;
     withForm: boolean;

--- a/packages/shop-cli/src/generators/component/component.ts
+++ b/packages/shop-cli/src/generators/component/component.ts
@@ -20,19 +20,27 @@ class ComponentGenerator extends BaseGenerator {
     return componentPrompts as GeneratorPrompt[];
   }
 
-  private resolveOptions(data: PromptAnswers) {
+  private resolveOptions(data: PromptAnswers): {
+    skipTests: boolean;
+    skipTypes: boolean;
+    withForm: boolean;
+    withView: boolean;
+    withToolbar: boolean;
+  } {
     return {
-      skipTests: data.skipTests ?? process.env.PLENTYSHOP_SKIP_TESTS === 'true',
-      skipTypes: data.skipTypes ?? process.env.PLENTYSHOP_SKIP_TYPES === 'true',
-      withForm: data.withForm ?? process.env.PLENTYSHOP_WITH_FORM === 'true',
-      withView: data.withView ?? process.env.PLENTYSHOP_WITH_VIEW === 'true',
-      withToolbar: data.withToolbar ?? process.env.PLENTYSHOP_WITH_TOOLBAR === 'true',
+      skipTests: Boolean(data.skipTests ?? process.env.PLENTYSHOP_SKIP_TESTS === 'true'),
+      skipTypes: Boolean(data.skipTypes ?? process.env.PLENTYSHOP_SKIP_TYPES === 'true'),
+      withForm: Boolean(data.withForm ?? process.env.PLENTYSHOP_WITH_FORM === 'true'),
+      withView: Boolean(data.withView ?? process.env.PLENTYSHOP_WITH_VIEW === 'true'),
+      withToolbar: Boolean(data.withToolbar ?? process.env.PLENTYSHOP_WITH_TOOLBAR === 'true'),
     };
   }
 
   createActions(data: PromptAnswers): GeneratorAction[] {
     const options = this.resolveOptions(data);
-    const builder = ActionBuilder.forGenerator('component', data.name, this.pathResolver).withData(data).addMainFile();
+    const builder = ActionBuilder.forGenerator('component', data.name, this.pathResolver, { isBlock: options.withForm })
+      .withData(data)
+      .addMainFile();
 
     if (!options.skipTypes) builder.addTypes();
     if (!options.skipTests) builder.addTests();

--- a/packages/shop-cli/src/generators/index.ts
+++ b/packages/shop-cli/src/generators/index.ts
@@ -5,6 +5,7 @@
 import type { NodePlopAPI } from 'plop';
 import type { PathResolver } from '../core';
 import componentGenerator from './component';
+import blockGenerator from './component/block';
 import composableGenerator from './composable';
 
 export default function (plop: NodePlopAPI, pathResolver: PathResolver): void {
@@ -12,6 +13,9 @@ export default function (plop: NodePlopAPI, pathResolver: PathResolver): void {
 
   componentGenerator(plop, pathResolver);
   console.log('🎉 Component generator loaded successfully!');
+
+  blockGenerator(plop, pathResolver);
+  console.log('🧱 Block generator loaded successfully!');
 
   composableGenerator(plop, pathResolver);
   console.log('⚡ Composables generator loaded successfully!');

--- a/packages/shop-cli/src/helpers/plugins/UtilityPlugin.ts
+++ b/packages/shop-cli/src/helpers/plugins/UtilityPlugin.ts
@@ -13,7 +13,7 @@ import { BaseHelperPlugin } from '../../core';
 export class UtilityPlugin extends BaseHelperPlugin {
   readonly name = 'utility';
   readonly description =
-    'General utility helpers (testId, currentDate, currentYear, concat, filePath, importPath, ifEquals, ifNotEmpty)';
+    'General utility helpers (testId, currentDate, currentYear, concat, filePath, importPath, ifEquals, ifNotEmpty, raw)';
   readonly version = '1.0.0';
   readonly helpers = [
     'testId',
@@ -24,12 +24,14 @@ export class UtilityPlugin extends BaseHelperPlugin {
     'importPath',
     'ifEquals',
     'ifNotEmpty',
+    'raw',
   ];
 
   register(plop: NodePlopAPI): void {
     this.registerUtilityHelpers(plop);
     this.registerPathHelpers(plop);
     this.registerConditionalHelpers(plop);
+    this.registerRawHelper(plop);
   }
 
   private registerUtilityHelpers(plop: NodePlopAPI): void {
@@ -85,6 +87,23 @@ export class UtilityPlugin extends BaseHelperPlugin {
         return opts.fn(value);
       }
       return opts.inverse(value);
+    });
+  }
+
+  /**
+   * Registers `raw` as a block helper so `{{{{raw}}}}...{{{{/raw}}}}` emits its contents literally
+   * (e.g. Vue's own `{{ }}` interpolation syntax inside a `.hbs` template). Handlebars' 4-brace raw
+   * block syntax only changes how the parser tokenizes the block — it still calls a block helper
+   * named `raw`, and without one registered it falls through to `blockHelperMissing` (which treats
+   * the bare word "raw" as an unresolved, falsy value and renders nothing).
+   */
+  private registerRawHelper(plop: NodePlopAPI): void {
+    this.safeRegister(plop, 'raw', (...args: unknown[]) => {
+      // {{{{raw}}}}...{{{{/raw}}}} takes no explicit params, so the options hash is the only arg.
+      // Its body is a literal ContentStatement (never evaluated as an expression), so the render
+      // context passed to fn() doesn't affect the output.
+      const options = args[args.length - 1] as { fn: (context: unknown) => string };
+      return options.fn({});
     });
   }
 }

--- a/packages/shop-cli/src/utils/dry-run.ts
+++ b/packages/shop-cli/src/utils/dry-run.ts
@@ -1,8 +1,8 @@
-import { relative, dirname } from 'path';
-import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import { relative, dirname, resolve } from 'path';
+import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
 import type { NodePlopAPI } from 'plop';
 import type { GeneratorAnswers } from '../types/confirmation';
-import { pathResolver } from '../core';
+import { pathResolver } from '../core/path/PathResolver';
 import type { Operation } from '../types/dry-run';
 
 /**
@@ -134,43 +134,39 @@ export class DryRunManager {
 export const dryRunManager = new DryRunManager();
 
 interface PlopActionConfig {
-  path: string;
+  path?: string;
   template?: string;
   templateFile?: string;
   [key: string]: unknown;
 }
 
 /**
- * Plop action that respects dry-run mode
+ * Plop action that respects dry-run mode.
+ *
+ * Only registered under a distinct action type (not `'add'`) and only used when dry-run mode is
+ * active — real (non-dry-run) file writes always go through plop's own built-in `add` action, so
+ * this never affects normal generation. Path/content resolution mirrors node-plop's own
+ * `_common-action-utils.js` (`getDestBasePath`/`getPlopfilePath`) so the preview matches exactly
+ * what the real `add` action would do.
  */
 export function createDryRunAction(type: string) {
   return function (answers: GeneratorAnswers, config: PlopActionConfig, plop: NodePlopAPI) {
-    const path = plop.renderString(config.path, answers);
-    const template = config.template || config.templateFile;
+    const destPath = resolve(plop.getDestBasePath(), plop.renderString(config.path ?? '', answers));
+
     let content = '';
-
-    if (template) {
-      if (config.templateFile) {
-        content = plop.renderString(plop.getHelper('fileContents')(config.templateFile), answers);
-      } else {
-        content = plop.renderString(template, answers);
-      }
+    if (config.templateFile) {
+      const absTemplatePath = resolve(plop.getPlopfilePath(), config.templateFile);
+      const rawTemplate = readFileSync(absTemplatePath, 'utf8');
+      content = plop.renderString(rawTemplate, answers);
+    } else if (config.template) {
+      content = plop.renderString(config.template, answers);
     }
 
-    if (dryRunManager.isDryRun) {
-      dryRunManager.logOperation(type, path, content);
-      return `Planned: ${type} ${path}`;
-    }
-
-    if (type === 'add') {
-      if (existsSync(path)) {
-        throw new Error(`File already exists: ${path}`);
-      }
-      mkdirSync(dirname(path), { recursive: true });
-      writeFileSync(path, content, 'utf8');
-      return `Created: ${path}`;
-    }
-
-    return `Unknown action type: ${type}`;
+    // DryRunManager's summary/conflict logic (getSummary/hasConflicts) recognizes the semantic
+    // operation kinds 'create'/'update', not plop's action-type names ('add', 'modify', ...).
+    const summaryType = type === 'add' ? 'create' : type;
+    dryRunManager.logOperation(summaryType, destPath, content);
+    const conflictNote = existsSync(destPath) ? ' (already exists — would conflict)' : '';
+    return `Planned: ${type} ${destPath}${conflictNote}`;
   };
 }

--- a/packages/shop-cli/templates/component/component-form-orchestrator.vue.hbs
+++ b/packages/shop-cli/templates/component/component-form-orchestrator.vue.hbs
@@ -1,0 +1,16 @@
+<template>
+  <div data-testid="{{kebabCase name}}-form" class="sticky h-[80vh] overflow-y-auto">
+    <Blocks{{pascalCase name}}Forms{{pascalCase name}}SettingsForm :uuid="resolvedUuid" />
+    <Blocks{{pascalCase name}}Partials{{pascalCase name}}SectionEditor :uuid="resolvedUuid" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { {{pascalCase name}}FormProps } from './types';
+
+const props = defineProps<{{pascalCase name}}FormProps>();
+
+const { blockUuid } = useSiteConfiguration();
+
+const resolvedUuid = computed(() => props.uuid || blockUuid.value);
+</script>

--- a/packages/shop-cli/templates/component/component-toolbar.vue.hbs
+++ b/packages/shop-cli/templates/component/component-toolbar.vue.hbs
@@ -12,14 +12,17 @@
       :aria-label="getEditorTranslation('aria-label')"
       data-testid="{{kebabCase name}}-toolbar-trigger"
     >
-      <SfIconSettings v-if="active" class="text-white" />
-      <SfIconSettings v-else class="text-black" />
+      <NuxtImg v-if="active" width="24" height="24px" :src="gearWhite" />
+      <NuxtImg v-else width="24" height="24px" :src="gearBlack" />
     </button>
   </SfTooltip>
 </template>
 
 <script setup lang="ts">
-import { SfTooltip, SfIconSettings } from '@storefront-ui/vue';
+import { SfTooltip } from '@storefront-ui/vue';
+
+import gearWhite from '~/assets/icons/paths/gear-white.svg';
+import gearBlack from '~/assets/icons/paths/gear-black.svg';
 
 defineProps({
   active: Boolean,

--- a/packages/shop-cli/templates/component/component-view.vue.hbs
+++ b/packages/shop-cli/templates/component/component-view.vue.hbs
@@ -1,11 +1,11 @@
 <template>
   <SiteConfigurationView>
-    <template #setting-title>{{curly}} getEditorTranslation('title') {{curly}}</template>
+    <template #setting-title>{{{{raw}}}}{{ getEditorTranslation('title') }}{{{{/raw}}}}</template>
 
     <template #setting-description>
       <div class="flex flex-col px-4 text-sm">
         <p class="pb-2">
-          <span class="align-middle font-bold">{{curly}} getEditorTranslation('description') {{curly}}</span>
+          <span class="align-middle font-bold">{{{{raw}}}}{{ getEditorTranslation('description') }}{{{{/raw}}}}</span>
         </p>
       </div>
     </template>

--- a/packages/shop-cli/templates/component/component.spec.ts.hbs
+++ b/packages/shop-cli/templates/component/component.spec.ts.hbs
@@ -7,9 +7,9 @@ describe('{{pascalCase name}}', () => {
 {{#if withForm}}
   const defaultProps: {{pascalCase name}}Props = {
     name: '{{pascalCase name}}',
-    type: 'content',
+    type: '{{#if structure}}structure{{else}}content{{/if}}',
     meta: { uuid: 'test-uuid' },
-    content: {},
+    content: {{#if structure}}[]{{else}}{}{{/if}},
   };
 {{else}}
   const defaultProps: {{pascalCase name}}Props = {

--- a/packages/shop-cli/templates/component/component.spec.ts.hbs
+++ b/packages/shop-cli/templates/component/component.spec.ts.hbs
@@ -9,6 +9,7 @@ describe('{{pascalCase name}}', () => {
     name: '{{pascalCase name}}',
     type: 'content',
     meta: { uuid: 'test-uuid' },
+    content: {},
   };
 {{else}}
   const defaultProps: {{pascalCase name}}Props = {

--- a/packages/shop-cli/templates/component/component.spec.ts.hbs
+++ b/packages/shop-cli/templates/component/component.spec.ts.hbs
@@ -4,9 +4,17 @@ import {{pascalCase name}} from '../{{pascalCase name}}.vue';
 import type { {{pascalCase name}}Props } from '../types';
 
 describe('{{pascalCase name}}', () => {
+{{#if withForm}}
+  const defaultProps: {{pascalCase name}}Props = {
+    name: '{{pascalCase name}}',
+    type: 'content',
+    meta: { uuid: 'test-uuid' },
+  };
+{{else}}
   const defaultProps: {{pascalCase name}}Props = {
     // Add default props for testing
   };
+{{/if}}
 
   it('renders correctly', () => {
     const wrapper = mount({{pascalCase name}}, {

--- a/packages/shop-cli/templates/component/defaults.ts.hbs
+++ b/packages/shop-cli/templates/component/defaults.ts.hbs
@@ -1,0 +1,39 @@
+import { v4 as uuid } from 'uuid';
+import type { Block } from '@plentymarkets/shop-api';
+
+// `image` has no live consumer in the CMS editor — the picker uses icon.svg instead (see
+// getBlockIconSvg()). Kept empty only because BlockTemplateVariation.image is still a required
+// field; see docs/_backlog/editor-blocks/01-remove-dead-blockslist-drawer-view.md.
+const BLOCK_IMAGE = '';
+
+const create{{pascalCase name}} = (): Block => ({
+  name: '{{pascalCase name}}',
+  type: 'content',
+  meta: { uuid: uuid() },
+  configuration: {
+    visible: true,
+    layout: {},
+  },
+  content: null,
+});
+
+export const getBlocksList = (): BlocksList => ({
+  {{camelCase name}}: {
+    category: '{{category}}',
+    accessControl: [{{#each accessControl}}'{{this}}'{{#unless @last}}, {{/unless}}{{/each}}],
+    title: '{{pascalCase name}}',
+    blockName: '{{pascalCase name}}',
+    variations: [
+      {
+        title: '{{pascalCase name}}',
+        image: BLOCK_IMAGE,
+        template: {
+          en: create{{pascalCase name}}(),
+          de: create{{pascalCase name}}(),
+        },
+      },
+    ],
+  },
+});
+
+export const createDefault = (): Block => create{{pascalCase name}}();

--- a/packages/shop-cli/templates/component/defaults.ts.hbs
+++ b/packages/shop-cli/templates/component/defaults.ts.hbs
@@ -13,7 +13,8 @@ const create{{pascalCase name}} = (): Block => ({
     visible: true,
     layout: {},
   },
-  content: null,
+  // Replace with this block's real default settings (see {{pascalCase name}}Props in ./types).
+  content: {},
 });
 
 export const getBlocksList = (): BlocksList => ({

--- a/packages/shop-cli/templates/component/defaults.ts.hbs
+++ b/packages/shop-cli/templates/component/defaults.ts.hbs
@@ -7,14 +7,20 @@ const BLOCK_IMAGE = '';
 
 const create{{pascalCase name}} = (): Block => ({
   name: '{{pascalCase name}}',
-  type: 'content',
+  type: '{{#if structure}}structure{{else}}content{{/if}}',
   meta: { uuid: uuid() },
   configuration: {
     visible: true,
     layout: {},
   },
+{{#if structure}}
+  // Seed with this block's real child Block instance(s) (see {{pascalCase name}}Props in ./types)
+  // — an empty array renders no children in the CMS editor until the user adds some.
+  content: [],
+{{else}}
   // Replace with this block's real default settings (see {{pascalCase name}}Props in ./types).
   content: {},
+{{/if}}
 });
 
 export const getBlocksList = (): BlocksList => ({

--- a/packages/shop-cli/templates/component/defaults.ts.hbs
+++ b/packages/shop-cli/templates/component/defaults.ts.hbs
@@ -1,9 +1,8 @@
 import { v4 as uuid } from 'uuid';
 import type { Block } from '@plentymarkets/shop-api';
 
-// `image` has no live consumer in the CMS editor — the picker uses icon.svg instead (see
-// getBlockIconSvg()). Kept empty only because BlockTemplateVariation.image is still a required
-// field; see docs/_backlog/editor-blocks/01-remove-dead-blockslist-drawer-view.md.
+// `image` has no live consumer in the CMS editor — the picker uses icon.svg instead. Kept as an
+// empty string only because BlockTemplateVariation.image is still a required field.
 const BLOCK_IMAGE = '';
 
 const create{{pascalCase name}} = (): Block => ({

--- a/packages/shop-cli/templates/component/forms/component-subform.spec.ts.hbs
+++ b/packages/shop-cli/templates/component/forms/component-subform.spec.ts.hbs
@@ -1,6 +1,21 @@
 import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import {{pascalCase name}}SettingsForm from '../{{pascalCase name}}SettingsForm.vue';
+
+const { getEditorTranslationMock } = vi.hoisted(() => ({
+  getEditorTranslationMock: vi.fn((key: string) => key),
+}));
+
+mockNuxtImport('getEditorTranslation', () => getEditorTranslationMock);
+
+const allBlocks = ref([]);
+const blockUuid = ref('test-uuid');
+const findOrDeleteBlockByUuid = vi.fn();
+
+mockNuxtImport('useBlocks', () => () => ({ allBlocks }));
+mockNuxtImport('useSiteConfiguration', () => () => ({ blockUuid }));
+mockNuxtImport('useBlockManager', () => () => ({ findOrDeleteBlockByUuid }));
 
 describe('{{pascalCase name}}SettingsForm', () => {
   it('should render the example setting control', () => {

--- a/packages/shop-cli/templates/component/forms/component-subform.spec.ts.hbs
+++ b/packages/shop-cli/templates/component/forms/component-subform.spec.ts.hbs
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import {{pascalCase name}}SettingsForm from '../{{pascalCase name}}SettingsForm.vue';
+
+describe('{{pascalCase name}}SettingsForm', () => {
+  it('should render the example setting control', () => {
+    const wrapper = mount({{pascalCase name}}SettingsForm, {
+      props: {},
+    });
+
+    expect(wrapper.find('[data-testid="{{kebabCase name}}-example-setting"]').exists()).toBe(true);
+  });
+});

--- a/packages/shop-cli/templates/component/forms/component-subform.vue.hbs
+++ b/packages/shop-cli/templates/component/forms/component-subform.vue.hbs
@@ -1,17 +1,15 @@
 <template>
-  <div data-testid="{{kebabCase name}}-form" class="sticky h-[80vh] overflow-y-auto">
-    <EditorFormPanel :title="getEditorTranslation('settings-label')">
-      <div class="py-2 flex items-center justify-between">
-        <UiFormLabel>{{{{raw}}}}{{ getEditorTranslation('example-setting-label') }}{{{{/raw}}}}</UiFormLabel>
-        <SfSwitch v-model="exampleSetting" data-testid="{{kebabCase name}}-example-setting" />
-      </div>
-    </EditorFormPanel>
-  </div>
+  <EditorFormPanel :title="getEditorTranslation('settings-label')">
+    <div class="py-2 flex items-center justify-between">
+      <UiFormLabel>{{{{raw}}}}{{ getEditorTranslation('example-setting-label') }}{{{{/raw}}}}</UiFormLabel>
+      <SfSwitch v-model="exampleSetting" data-testid="{{kebabCase name}}-example-setting" />
+    </div>
+  </EditorFormPanel>
 </template>
 
 <script setup lang="ts">
 import { SfSwitch } from '@storefront-ui/vue';
-import type { {{pascalCase name}}Props, {{pascalCase name}}FormProps } from './types';
+import type { {{pascalCase name}}Props, {{pascalCase name}}FormProps } from '../types';
 
 const props = defineProps<{{pascalCase name}}FormProps>();
 
@@ -29,7 +27,7 @@ const {{camelCase name}}Configuration = computed(() => {{camelCase name}}Structu
 
 const layout = computed(() => {{camelCase name}}Configuration.value.layout);
 
-// Example field — replace with this block's real settings, following the same get/set pattern.
+// Example field — replace with this section's real settings, following the same get/set pattern.
 const exampleSetting = computed<boolean>({
   get: () => layout.value?.exampleSetting ?? false,
   set: (value: boolean) => (layout.value!.exampleSetting = value),

--- a/packages/shop-cli/templates/component/icon.svg.hbs
+++ b/packages/shop-cli/templates/component/icon.svg.hbs
@@ -1,0 +1,5 @@
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect x="15" y="15" width="70" height="70" rx="6" stroke="black" stroke-width="4"/>
+    <rect x="28" y="35" width="44" height="8" rx="2" fill="black"/>
+    <rect x="28" y="55" width="30" height="8" rx="2" fill="black"/>
+</svg>

--- a/packages/shop-cli/templates/component/partials/component-partial.spec.ts.hbs
+++ b/packages/shop-cli/templates/component/partials/component-partial.spec.ts.hbs
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import {{pascalCase name}}SectionEditor from '../{{pascalCase name}}SectionEditor.vue';
+
+describe('{{pascalCase name}}SectionEditor', () => {
+  it('should render', () => {
+    const wrapper = mount({{pascalCase name}}SectionEditor, {
+      props: {},
+    });
+
+    expect(wrapper.exists()).toBe(true);
+  });
+});

--- a/packages/shop-cli/templates/component/partials/component-partial.spec.ts.hbs
+++ b/packages/shop-cli/templates/component/partials/component-partial.spec.ts.hbs
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import {{pascalCase name}}SectionEditor from '../{{pascalCase name}}SectionEditor.vue';
+
+const { getEditorTranslationMock } = vi.hoisted(() => ({
+  getEditorTranslationMock: vi.fn((key: string) => key),
+}));
+
+mockNuxtImport('getEditorTranslation', () => getEditorTranslationMock);
 
 describe('{{pascalCase name}}SectionEditor', () => {
   it('should render', () => {

--- a/packages/shop-cli/templates/component/partials/component-partial.vue.hbs
+++ b/packages/shop-cli/templates/component/partials/component-partial.vue.hbs
@@ -1,0 +1,26 @@
+<template>
+  <EditorFormPanel :title="getEditorTranslation('section-editor-label')">
+    <p class="px-4 py-2 text-sm text-neutral-500">
+      {{{{raw}}}}{{ getEditorTranslation('section-editor-placeholder') }}{{{{/raw}}}}
+    </p>
+  </EditorFormPanel>
+</template>
+
+<script setup lang="ts">
+import type { {{pascalCase name}}FormProps } from '../types';
+
+defineProps<{{pascalCase name}}FormProps>();
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "section-editor-label": "Section",
+    "section-editor-placeholder": "Add section-specific fields here."
+  },
+  "de": {
+    "section-editor-label": "Bereich",
+    "section-editor-placeholder": "Fügen Sie hier bereichsspezifische Felder hinzu."
+  }
+}
+</i18n>

--- a/packages/shop-cli/templates/component/types.ts.hbs
+++ b/packages/shop-cli/templates/component/types.ts.hbs
@@ -1,6 +1,4 @@
 {{#if withForm}}
-import type { Block } from '@plentymarkets/shop-api';
-
 export type {{pascalCase name}}StructureConfiguration = {
   visible?: boolean;
   layout?: {
@@ -15,7 +13,11 @@ export type {{pascalCase name}}Props = {
     uuid: string;
   };
   configuration?: {{pascalCase name}}StructureConfiguration;
-  content?: Block[];
+  // This scaffold generates a content-type block — content is a settings object you define, same
+  // as e.g. Image's. Building a structure/container block instead (children the CMS user arranges,
+  // like MultiGrid/Carousel under components/blocks/structure/)? Use a real array type there
+  // instead, and set `type` below to `'structure'`.
+  content: Record<string, unknown>;
 };
 
 export type {{pascalCase name}}FormProps = {

--- a/packages/shop-cli/templates/component/types.ts.hbs
+++ b/packages/shop-cli/templates/component/types.ts.hbs
@@ -1,3 +1,7 @@
+{{#if structure}}
+import type { Block } from '@plentymarkets/shop-api';
+
+{{/if}}
 {{#if withForm}}
 export type {{pascalCase name}}StructureConfiguration = {
   visible?: boolean;
@@ -13,11 +17,15 @@ export type {{pascalCase name}}Props = {
     uuid: string;
   };
   configuration?: {{pascalCase name}}StructureConfiguration;
-  // This scaffold generates a content-type block — content is a settings object you define, same
-  // as e.g. Image's. Building a structure/container block instead (children the CMS user arranges,
-  // like MultiGrid/Carousel under components/blocks/structure/)? Use a real array type there
-  // instead, and set `type` below to `'structure'`.
+{{#if structure}}
+  // Structure/container block — content holds this block's real children, populated by the CMS
+  // user (see MultiGrid/Carousel under components/blocks/structure/ for real examples). Narrow
+  // `Block` to a more specific child type here if this block only ever holds one kind of child.
+  content: Block[];
+{{else}}
+  // Content block — content is a settings object you define, same as e.g. Image's.
   content: Record<string, unknown>;
+{{/if}}
 };
 
 export type {{pascalCase name}}FormProps = {

--- a/packages/shop-cli/templates/component/types.ts.hbs
+++ b/packages/shop-cli/templates/component/types.ts.hbs
@@ -1,2 +1,27 @@
+{{#if withForm}}
+import type { Block } from '@plentymarkets/shop-api';
+
+export type {{pascalCase name}}StructureConfiguration = {
+  visible?: boolean;
+  layout?: {
+    exampleSetting?: boolean;
+  };
+};
+
+export type {{pascalCase name}}Props = {
+  name: string;
+  type: string;
+  meta: {
+    uuid: string;
+  };
+  configuration?: {{pascalCase name}}StructureConfiguration;
+  content?: Block[];
+};
+
+export type {{pascalCase name}}FormProps = {
+  uuid?: string;
+};
+{{else}}
 {{> jsdoc description=(concat "Props for " (pascalCase name) " component")}}
 {{> typescript-interface name=(concat (pascalCase name) "Props") properties=props}}
+{{/if}}


### PR DESCRIPTION
## Issue:

When generating components via the shop CLI, there is no option to generate everything needed for a block component.

## Describe your changes

- Adds a dry-run mode
- Adds block support to shop cli as its own generator
- Generates all standard files
- Distinguishes between content blocks and structure blocks
- Fixes the way templates handle interpolation
- Removes the superfluous path resolution CLI flag to decrease complexity
- Updates relevant docs and skills

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
