### PR TITLE
fix: cross price display only if its higher then the normal price

### DIFF
--- a/apps/web/app/components/Price/Price.vue
+++ b/apps/web/app/components/Price/Price.vue
@@ -8,7 +8,10 @@
       <span>{{ format(props.price) }}</span>
       <span v-if="props.displayVatHint">{{ t('common.labels.asterisk') }}</span>
     </span>
-    <span v-if="props.crossedPrice && differentPrices" class="text-base font-normal text-neutral-500 line-through">
+    <span
+      v-if="props.crossedPrice && differentPrices && props.crossedPrice > props.price"
+      class="text-base font-normal text-neutral-500 line-through"
+    >
       {{ format(props.crossedPrice) }}
     </span>
   </div>

--- a/apps/web/app/components/Price/__tests__/Price.spec.ts
+++ b/apps/web/app/components/Price/__tests__/Price.spec.ts
@@ -77,6 +77,18 @@ describe('<Price />', () => {
     expect(occurrences).toBe(1);
   });
 
+  it('should not render the crossed price when it is lower than the price', () => {
+    const wrapper = mount(Price, {
+      props: {
+        price: 20,
+        crossedPrice: 10,
+        displayVatHint: false,
+      },
+    });
+
+    expect(wrapper.text()).not.toContain('10');
+  });
+
   it('should use a custom test id when provided', () => {
     const wrapper = mount(Price, {
       props: {

--- a/apps/web/app/components/ui/ProductCard/ProductCard.vue
+++ b/apps/web/app/components/ui/ProductCard/ProductCard.vue
@@ -137,7 +137,7 @@
               <span>{{ t('common.labels.asterisk') }}</span>
             </span>
             <span
-              v-if="crossedPrice && differentPrices(price, crossedPrice)"
+              v-if="crossedPrice && differentPrices(price, crossedPrice) && crossedPrice > price"
               class="typography-text-sm text-neutral-500 line-through @md:ml-3 @md:pb-2"
             >
               {{ format(crossedPrice) }}

--- a/apps/web/app/components/ui/ProductCard/__tests__/ProductCard.spec.ts
+++ b/apps/web/app/components/ui/ProductCard/__tests__/ProductCard.spec.ts
@@ -3,12 +3,17 @@ import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { UiProductCard } from '#components';
 import { ProductMock } from '../../../../../__tests__/__mocks__/product.mock';
 
-const { useLazyProductImageMock } = vi.hoisted(() => ({
+const { useLazyProductImageMock, useProductPriceMock } = vi.hoisted(() => ({
   useLazyProductImageMock: vi.fn(),
+  useProductPriceMock: vi.fn(),
 }));
 
 mockNuxtImport('useLazyProductImage', () => {
   return useLazyProductImageMock;
+});
+
+mockNuxtImport('useProductPrice', () => {
+  return useProductPriceMock;
 });
 
 describe('<ProductCard />', () => {
@@ -24,6 +29,12 @@ describe('<ProductCard />', () => {
       onMainImageError: vi.fn(),
       onHoverImageLoad: vi.fn(),
       onHoverImageError: vi.fn(),
+    });
+
+    useProductPriceMock.mockReset();
+    useProductPriceMock.mockReturnValue({
+      price: ref(10),
+      crossedPrice: ref(null),
     });
   });
 
@@ -58,5 +69,35 @@ describe('<ProductCard />', () => {
     });
 
     expect(wrapper.find('[data-testid="image-slot"]').exists()).toBe(false);
+  });
+
+  it('should render the crossed price when it is higher than the price', () => {
+    useProductPriceMock.mockReturnValue({
+      price: ref(10),
+      crossedPrice: ref(20),
+    });
+
+    const wrapper = mount(UiProductCard, {
+      props: {
+        product: ProductMock,
+      },
+    });
+
+    expect(wrapper.text()).toContain('20');
+  });
+
+  it('should not render the crossed price when it is lower than the price', () => {
+    useProductPriceMock.mockReturnValue({
+      price: ref(20),
+      crossedPrice: ref(10),
+    });
+
+    const wrapper = mount(UiProductCard, {
+      props: {
+        product: ProductMock,
+      },
+    });
+
+    expect(wrapper.text()).not.toContain('10');
   });
 });

--- a/apps/web/app/components/ui/Search/SearchSuggestionProduct.vue
+++ b/apps/web/app/components/ui/Search/SearchSuggestionProduct.vue
@@ -18,7 +18,10 @@
         {{ item.label }}
       </div>
       <div class="flex items-baseline gap-2 tabular-nums">
-        <span v-if="crossedPrice && hasDifferentPrices" class="text-xs text-neutral-400 line-through">
+        <span
+          v-if="crossedPrice && hasDifferentPrices && crossedPrice > itemSearchAutocompleteGetters.getPrice(item)"
+          class="text-xs text-neutral-400 line-through"
+        >
           {{ format(crossedPrice) }}
         </span>
         <span class="text-sm font-semibold text-neutral-900">


### PR DESCRIPTION
## Issue:

Closes: [AB#203301](https://dev.azure.com/plentymarkets/0af57df9-8662-4901-bb97-8e88b07ff0c9/_workitems/edit/203301)

## Describe your changes

- [What changed]
- [Notable implementation decisions]
- [Known limitations]

## Definition of Done

**Review the following checklist and tick off completed tasks before requesting a review.**

### Environment

**Mode**: Production (`build` & `start`)

**Feature flags**:

- [Which flags have to be enabled for this change]

### Functionality

- [ ] Implemented all acceptance criteria from the issue
- [ ] Encoded requirements in executable specifications (unit and/or e2e tests)
- [ ] Ran e2e tests relevant to my changes locally
- [ ] Verified functionality under the following scenarios:
  - Initial load (mobile & desktop)
  - After navigation (mobile & desktop)
  - After language switch (mobile & desktop)
- [ ] Verified error handling

### Compliance

- [ ] Checked accessibility (mobile & desktop)

### Documentation

- [ ] Added TSDoc annotations to TypeScript files

### Screenshots

_Add screenshots to illustrate visual changes._
_Take care not to include sensitive information._
